### PR TITLE
You can now reconfirm using email or username.

### DIFF
--- a/app/views/devise/confirmations/new.html.haml
+++ b/app/views/devise/confirmations/new.html.haml
@@ -3,12 +3,10 @@
 = form_for(resource, :as => resource_name, :url => confirmation_path(resource_name), :html => { :method => :post }) do |f|
   = devise_error_messages!
 
-  %div
-    = f.label :email
-    %br
-    = f.email_field :email
+  %p Enter either your username or your email address to resend the confirmation email.
 
-  %div
-    = f.submit "Resend confirmation instructions"
+  = f.label :login
+  = f.text_field :login
+  = f.submit "Resend confirmation instructions"
 
 = render "devise/shared/links"

--- a/app/views/devise/shared/_links.haml
+++ b/app/views/devise/shared/_links.haml
@@ -1,11 +1,3 @@
-- if controller_name != 'sessions'
-  = link_to "Sign in", new_session_path(resource_name)
-  %br
-
-- if devise_mapping.registerable? && controller_name != 'registrations'
-  = link_to "Sign up", new_registration_path(resource_name)
-  %br
-
 - if devise_mapping.recoverable? && controller_name != 'passwords'
   = link_to "Forgot your password?", new_password_path(resource_name)
   %br

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -6,7 +6,7 @@
           You are signed in as
           = current_user.email + "."
         %li
-          = link_to("Log out", destroy_user_session_path)
+          = link_to("Log out", destroy_user_session_path, :method => :delete)
     - else
       %ul.link-list
         %li

--- a/spec/views/devise/confirmations/new_spec.rb
+++ b/spec/views/devise/confirmations/new_spec.rb
@@ -8,7 +8,7 @@ describe 'devise/confirmations/new.html.haml', :type => "view" do
     render
   end
 
-  it 'should contain an Email field' do
-    rendered.should contain "Email"
+  it 'should contain a login field' do
+    rendered.should contain "Username or email"
   end
 end

--- a/spec/views/devise/registrations/new_spec.rb
+++ b/spec/views/devise/registrations/new_spec.rb
@@ -12,7 +12,6 @@ describe 'devise/registrations/new.html.haml', :type => "view" do
     end
 
     it 'should have some fields' do
-        rendered.should contain 'Sign up'
         rendered.should contain 'Email'
     end
   end

--- a/spec/views/devise/sessions/new_spec.rb
+++ b/spec/views/devise/sessions/new_spec.rb
@@ -14,7 +14,6 @@ describe 'devise/sessions/new.html.haml', :type => "view" do
     it 'should have some fields' do
         rendered.should contain 'Remember me'
         rendered.should contain 'Password'
-        rendered.should contain 'Sign in'
     end
   end
 end

--- a/spec/views/devise/shared/_links_spec.rb
+++ b/spec/views/devise/shared/_links_spec.rb
@@ -16,7 +16,6 @@ describe 'devise/shared/_links.haml', :type => "view" do
     @view.stub(:devise_mapping =>
                devise_mapping(false, false, false, false, false))
     render
-    rendered.should contain "Sign in"
   end
 
   it "shouldn't have a sign-in link if in sessions" do
@@ -25,6 +24,5 @@ describe 'devise/shared/_links.haml', :type => "view" do
     @view.stub(:devise_mapping =>
                devise_mapping(false, false, false, false, false))
     render
-    rendered.should_not contain "Sign in"
   end
 end


### PR DESCRIPTION
Also, cleaned up the standard devise links that show up everywhere, removing signup/signin as they duplicate what's in our header.
