### PR TITLE
Set up friendly IDs for crops aka slugs (eww!)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ gem 'capistrano-ext'
 
 # user signup/login/etc
 gem 'devise'
+gem 'friendly_id'
 
 # for phusion passenger (i.e. mod_rails) on the server
 gem 'passenger'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,7 @@ GEM
     execjs (1.4.0)
       multi_json (~> 1.0)
     fastthread (1.0.7)
+    friendly_id (4.0.8)
     fssm (0.2.9)
     haml (3.1.7)
     haml-rails (0.3.5)
@@ -195,6 +196,7 @@ DEPENDENCIES
   compass-rails (~> 1.0.3)
   devise
   diff-lcs
+  friendly_id
   haml
   haml-rails
   jquery-rails

--- a/app/models/crop.rb
+++ b/app/models/crop.rb
@@ -1,3 +1,5 @@
 class Crop < ActiveRecord::Base
+  extend FriendlyId
+  friendly_id :system_name, use: :slugged
   attr_accessible :en_wikipedia_url, :system_name
 end

--- a/db/migrate/20121027035231_add_slug_to_crops.rb
+++ b/db/migrate/20121027035231_add_slug_to_crops.rb
@@ -1,0 +1,6 @@
+class AddSlugToCrops < ActiveRecord::Migration
+  def change
+    add_column :crops, :slug, :string
+    add_index :crops, :slug, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,15 +11,17 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20121003190731) do
+ActiveRecord::Schema.define(:version => 20121027035231) do
 
   create_table "crops", :force => true do |t|
     t.string   "system_name",      :null => false
     t.string   "en_wikipedia_url"
     t.datetime "created_at",       :null => false
     t.datetime "updated_at",       :null => false
+    t.string   "slug"
   end
 
+  add_index "crops", ["slug"], :name => "index_crops_on_slug", :unique => true
   add_index "crops", ["system_name"], :name => "index_crops_on_system_name"
 
   create_table "users", :force => true do |t|

--- a/spec/models/crop_spec.rb
+++ b/spec/models/crop_spec.rb
@@ -17,6 +17,7 @@ describe Crop do
       @crop.save
       @crop2 = Crop.find_by_system_name('Tomato')
       @crop2.en_wikipedia_url.should == "http://en.wikipedia.org/wiki/Tomato"
+      @crop2.slug.should == "tomato"
     end
   end
 


### PR DESCRIPTION
NOTE: when deployed, someone (ahem, me) should run this command on the production server, using "rails console":

Crop.find_each(&:save)
exit

This will update all existing crops to have friendly IDs.  This could also have been written as a rake task but since that would involve a lot of mucking around with capistrano, and since it's only a once-off, I have decided to not bother.
