### PR TITLE
Fixes problem with devise caused by RSS changes

### DIFF
--- a/app/views/layouts/_meta.html.haml
+++ b/app/views/layouts/_meta.html.haml
@@ -4,9 +4,9 @@
   <link href='http://fonts.googleapis.com/css?family=Sevillana' rel='stylesheet' type='text/css'>
 
   - if (content_for?(:member_rss_username) && content_for(:member_rss_slug))
-    = auto_discovery_link_tag(:rss, { :controller => "members", :action => 'show', :format => "rss", :id => yield(:member_rss_slug) }, { :title => "Growstuff - #{yield(:member_rss_username)}'s updates" })
-  = auto_discovery_link_tag(:rss, { :controller => "updates", :format => "rss" }, { :title => "Growstuff - Recent updates from all members" })
-  = auto_discovery_link_tag(:rss, { :controller => "crops", :format => "rss" }, { :title => "Growstuff - Recently added crops" })
+    = auto_discovery_link_tag(:rss, { :controller => "/members", :action => 'show', :format => "rss", :id => yield(:member_rss_slug) }, { :title => "Growstuff - #{yield(:member_rss_username)}'s updates" })
+  = auto_discovery_link_tag(:rss, { :controller => "/updates", :format => "rss" }, { :title => "Growstuff - Recent updates from all members" })
+  = auto_discovery_link_tag(:rss, { :controller => "/crops", :format => "rss" }, { :title => "Growstuff - Recently added crops" })
 
   %title
     = content_for?(:title) ? yield(:title) + " - Growstuff" : "Growstuff"


### PR DESCRIPTION
The auto discovery links in the head of the HTML were causing
trouble when rails tried to render the devise pages.  It kept
saying it couldn't find a route for /devise/updates.  This seems
to have fixed it.
