### PR TITLE
Fix size of boxes on /members; truncate long names

### DIFF
--- a/app/helpers/members_helper.rb
+++ b/app/helpers/members_helper.rb
@@ -1,0 +1,9 @@
+module MembersHelper
+  def shorten(str, max_length)
+    if str.length > max_length
+      return str.slice(0, max_length - 3) + "..."
+    else
+      return str
+    end
+  end
+end

--- a/app/views/members/index.html.haml
+++ b/app/views/members/index.html.haml
@@ -3,7 +3,7 @@
 %ul.thumbnails
   - @members.each do |m|
     %li.span2
-      .thumbnail
+      .thumbnail(style="height: 190px")
         = image_tag('http://placehold.it/150x150', :alt => '', :class => 'img-rounded')
-        %h3= link_to m.username, member_path(m)
+        = link_to shorten(m.username, 30), member_path(m)
 

--- a/spec/views/members/index.html.haml_spec.rb
+++ b/spec/views/members/index.html.haml_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe "members/index" do
+  before(:each) do
+    assign(:members, [
+      User.create!(
+        :username => "Marmaduke Blundell-Hollinshead-Blundell-Tolemache-Plantagenet-Whistlebinkie, 3rd Duke of Marmoset",
+        :password => "ilikehorses",
+        :email => "binky@example.com",
+        :tos_agreement => true
+      ),
+      User.create!(
+        :username => "bob",
+        :password => "password",
+        :email => "bob@example.com",
+        :tos_agreement => true
+      )
+    ])
+    render
+  end
+
+  it "truncates long names" do
+    rendered.should contain "marmaduke blundell-hollinsh..."
+  end
+
+  it "does not truncate short names" do
+    rendered.should contain "bob"
+    rendered.should_not contain "bob..."
+  end
+end


### PR DESCRIPTION
Fixes bug 40526783, "Long user names overflow their textboxes"
