### PR TITLE
Upgrade rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,11 @@ gem 'passenger'
 gem 'rake', '>= 10.0.0'
 gem 'cape'
 
+# instead of webrick, use thin, which is recommended for many reasons
+# eg. better on heroku, also doesn't throw spurious asset warnings
+
+gem 'thin'
+
 gem 'diff-lcs'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,7 @@ GEM
     compass-rails (1.0.3)
       compass (>= 0.12.2, < 0.14)
     daemon_controller (1.1.0)
+    daemons (1.1.9)
     devise (2.2.0)
       bcrypt-ruby (~> 3.0)
       orm_adapter (~> 0.1)
@@ -64,6 +65,7 @@ GEM
       warden (~> 1.2.1)
     diff-lcs (1.1.3)
     erubis (2.7.0)
+    eventmachine (1.0.0)
     execjs (1.4.0)
       multi_json (~> 1.0)
     fastthread (1.0.7)
@@ -164,6 +166,10 @@ GEM
     sqlite3 (1.3.6)
     therubyracer (0.10.2)
       libv8 (~> 3.3.10)
+    thin (1.5.0)
+      daemons (>= 1.0.9)
+      eventmachine (>= 0.12.6)
+      rack (>= 1.0.0)
     thor (0.16.0)
     tilt (1.3.3)
     treetop (1.4.12)
@@ -214,6 +220,7 @@ DEPENDENCIES
   spork (~> 0.9.0.rc)
   sqlite3
   therubyracer (~> 0.10.2)
+  thin
   twitter-bootstrap-rails (= 2.1.6)
   uglifier (>= 1.0.3)
   watchr


### PR DESCRIPTION
Now upgrading to 3.2.11 for a much more serious security hole.  This works fine on my laptop -- you need to do "bundle install" and then maybe "bundle update" if it spits out errors, but tests pass and the website works fine without any complaints about @green.
