### PR TITLE
Fix the remaining mobile menu issues

### DIFF
--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -6,7 +6,7 @@
         %span.icon-bar
         %span.icon-bar
       %a.brand(href=root_path) Growstuff (development site)
-      .container.nav-collapse
+      .container.nav-collapse.collapse
         %ul.nav
           %li= link_to "Crops", crops_path
           %li= link_to "Members", members_path


### PR DESCRIPTION
add .collapse class to the header menu to fix the remaining mobile menu issues. See https://www.pivotaltracker.com/story/show/44352329
