### PR TITLE
Tiny CSS tweak to fix navbar problems

### DIFF
--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -6,7 +6,7 @@
         %span.icon-bar
         %span.icon-bar
       %a.brand(href=root_path) Growstuff (development site)
-      .container.nav-collapse.collapse
+      .nav-collapse.collapse
         %ul.nav
           %li= link_to "Crops", crops_path
           %li= link_to "Members", members_path


### PR DESCRIPTION
When you click "Growstuff" it should take you to the homepage.  This was
broken, and only a few pixels to the left of the G were clickable.  This
seems to fix it.  I hope.
