### PR TITLE
Fix Travis CI status image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Growstuff
 
-[![Build Status](https://travis-ci.org/growstuff/growstuff.png)](https://travis-ci.org/growstuff/growstuff)
+[![Build Status](https://travis-ci.org/Growstuff/growstuff.png)](https://travis-ci.org/Growstuff/growstuff)
 
 Welcome to the Growstuff project.
 


### PR DESCRIPTION
Since Travis CI uses case-sensitive urls for GitHub account and
organization names, this commit adjusts the reference to match the
organization name exactly.
