### PR TITLE
added analytics tracking code w/ per-env config

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -24,3 +24,5 @@
       \==================================================
     / Placed at the end of the document so the pages load faster
     = javascript_include_tag "application"
+
+    = Growstuff::Application.config.analytics_code

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -50,5 +50,6 @@ Growstuff::Application.configure do
 
   Growstuff::Application.configure do
     config.site_name = "Growstuff (dev)"
+    config.analytics_code = ''
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -80,6 +80,11 @@ Growstuff::Application.configure do
 
   Growstuff::Application.configure do
     config.site_name = "Growstuff"
+    config.analytics_code = <<-eos
+      <script src="//static.getclicky.com/js" type="text/javascript"></script>
+      <script type="text/javascript">try{ clicky.init(100594260); }catch(e){}</script>
+      <noscript><p><img alt="Clicky" width="1" height="1" src="//in.getclicky.com/100594260ns.gif" /></p></noscript>
+    eos
   end
 
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -80,6 +80,7 @@ Growstuff::Application.configure do
 
   Growstuff::Application.configure do
     config.site_name = "Growstuff (staging)"
+    config.analytics_code = ''
   end
 
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -42,6 +42,7 @@ Growstuff::Application.configure do
 
   Growstuff::Application.configure do
     config.site_name = "Growstuff (test)"
+    config.analytics_code = ''
   end
 
 end

--- a/spec/views/layouts/application_spec.rb
+++ b/spec/views/layouts/application_spec.rb
@@ -57,5 +57,11 @@ describe 'layouts/application.html.haml', :type => "view" do
       end
     end
 
+    it 'includes the analytics code' do
+      Growstuff::Application.config.analytics_code = 'ANALYTICS'
+      render
+      rendered.should contain 'ANALYTICS'
+    end
+
   end
 end


### PR DESCRIPTION
I've added a config variable (via config/environments) to specify a snippet of code to include if you want web traffic analytics.  The analytics provider we've chosen for our production site is http://clicky.com, which has good privacy protections for Growstuff's visitors -- in particular, we have set it up so that it drops the last octet of any IP address, so that they aren't storing personally identifying information about our visitors.

Their specific terminology wrt the IP address privacy option is: "Enabling this will replace the last octet of all IP addresses with a "0". If users from the same subnet visit your site at the same time, they will still be counted as separate unique visitors, as long as they have cookies enabled."
