### PR TITLE
Fix some email formatting issues

### DIFF
--- a/app/views/devise/mailer/confirmation_instructions.html.haml
+++ b/app/views/devise/mailer/confirmation_instructions.html.haml
@@ -5,8 +5,7 @@
   Your account on #{site_name} has been created.  You just need to confirm
   your email address through the link below:
 
-%p
-  = link_to 'Confirm my account', confirmation_url(@resource, :confirmation_token => @resource.confirmation_token)
+%p= link_to 'Confirm my account', confirmation_url(@resource, :confirmation_token => @resource.confirmation_token)
 
 %p
   Once you're confirmed, you can sign in with your login name
@@ -17,22 +16,23 @@
 %p
   We're excited to have you as a member, and hope you'll enjoy
   what #{site_name} has to offer. Take a look around the site,
-  =link_to 'plant some things', url_for(:controller => '/crops', :only_path => false)
-  , and feel free to drop in on the
-  =link_to 'forums', url_for(:controller => '/forums', :only_path => false)
+  = succeed "," do
+    = link_to('plant some things', url_for(:controller => '/crops', :only_path => false))
+  and feel free to drop in on the
+  = link_to 'forums', url_for(:controller => '/forums', :only_path => false)
   if you have any questions or feedback.
 
 %p
   We'd also appreciate it if you'd read our
-  =link_to 'Community Guidelines', url_for(:controller => '/policy', :action => 'community', :only_path => false)
-  , and make sure you follow them. We want #{site_name} to be a
+  = succeed "," do
+    = link_to 'Community Guidelines', url_for(:controller => '/policy', :action => 'community', :only_path => false)
+  and make sure you follow them. We want #{site_name} to be a
   friendly, welcoming environment for everyone, and we hope you'll
   help us keep it that way.
 
-%p
-  Looking forward to seeing you!
+%p Looking forward to seeing you!
 
 %p
   The #{site_name} team.
   %br/
-  =link_to root_url, root_url
+  = link_to root_url, root_url

--- a/app/views/devise/mailer/reset_password_instructions.html.haml
+++ b/app/views/devise/mailer/reset_password_instructions.html.haml
@@ -1,19 +1,21 @@
 - site_name = Growstuff::Application.config.site_name
 %p Hello #{@resource.login_name},
 
-%p Someone has requested a link to reset your password on #{site_name}.
-We presume this was you, in which case you can do so through this link:
+%p
+  Someone has requested a link to reset your password on #{site_name}.
+  We presume this was you, in which case you can do so through this link:
+
+%p= link_to 'Change my password', edit_password_url(@resource, :reset_password_token => @resource.reset_password_token)
 
 %p
-  = link_to 'Change my password', edit_password_url(@resource, :reset_password_token => @resource.reset_password_token)
-
-%p If it wasn't you, then someone's made a typo or has been messing
-around.  In this case, you can safely ignore this email, and your
-password will not be changed.
+  If it wasn't you, then someone's made a typo or has been messing
+  around.  In this case, you can safely ignore this email, and your
+  password will not be changed.
 
 %p See you soon,
 
-%p The #{site_name} team.
-%br/
-=link_to root_url, root_url
+%p
+  The #{site_name} team.
+  %br/
+  =link_to root_url, root_url
 

--- a/app/views/devise/mailer/unlock_instructions.html.haml
+++ b/app/views/devise/mailer/unlock_instructions.html.haml
@@ -10,11 +10,14 @@
 
 %p= link_to 'Unlock my account', unlock_url(@resource, :unlock_token => @resource.unlock_token)
 
-%p If you have actually forgotten your password, you can
-= link_to 'reset your password', new_password_url(@resource)
-after you've unlocked your account.
+%p
+  If you have actually forgotten your password, you can
+  = link_to 'reset your password', new_password_url(@resource)
+  after you've unlocked your account.
 
 %p See you soon,
-%p The #{site_name} team.
-%br/
-=link_to root_url, root_url
+
+%p
+  The #{site_name} team.
+  %br/
+  =link_to root_url, root_url


### PR DESCRIPTION
When I first signed up, the email looked like this:

![Before](https://f.cloud.github.com/assets/14028/378877/caa7b01e-a56c-11e2-9994-02efbac06dfa.png)

The circles highlight the bits which caught me eye. I've fixed bits, and made the templates a little more consistent and corrected some syntactic mistakes. Here's the confirmation email now:

![After](https://f.cloud.github.com/assets/14028/378883/f9bf8c0a-a56c-11e2-8565-7e0bc6571974.png)
