### PR TITLE
security fix: check ENV for rails secret token

### DIFF
--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -4,4 +4,4 @@
 # If you change this key, all old signed cookies will become invalid!
 # Make sure the secret is at least 30 characters and all random,
 # no regular words or you'll be exposed to dictionary attacks.
-Growstuff::Application.config.secret_token = '6b61c7a7c5f5684945c445d80ea3df725ee2bb3101a3a57a4bec349657e092a562aa714cb4706c038d7fb1bdbd497c4b103aa1247f3bdf79044e03363ea8ee50'
+Growstuff::Application.config.secret_token = ENV['RAILS_SECRET_TOKEN'] || "this is not a real secret token but it's here to make life easier for developers"


### PR DESCRIPTION
As per: http://biggestfool.tumblr.com/post/24049554541/reminder-secret-token-rb-is-named-so-for-a-reason

Having this secret token in github can make it possible for people to steal our session cookies.  This makes it look for an environment variable instead (but falls back to a fake secret token if you don't have one, as in most dev environments.)

I have set the environment variables on the staging and production heroku apps.
