### PR TITLE
added crop hierarchy basics

### DIFF
--- a/app/models/crop.rb
+++ b/app/models/crop.rb
@@ -1,9 +1,14 @@
 class Crop < ActiveRecord::Base
   extend FriendlyId
   friendly_id :system_name, use: :slugged
-  attr_accessible :en_wikipedia_url, :system_name
+  attr_accessible :en_wikipedia_url, :system_name, :parent_id
+
   has_many :scientific_names
   has_many :plantings
+
+  belongs_to :parent, :class_name => 'Crop'
+  has_many :varieties, :class_name => 'Crop', :foreign_key => 'parent_id'
+
   default_scope order("lower(system_name) asc")
 
   validates :en_wikipedia_url,

--- a/app/views/crops/_form.html.haml
+++ b/app/views/crops/_form.html.haml
@@ -22,5 +22,10 @@
     .controls
       = f.text_field :en_wikipedia_url
       %span.help-inline Link to this crop's page on the English language Wikipedia.
+  .control-group
+    = f.label :parent_id, 'Parent crop', :class => 'control-label'
+    .controls
+      = collection_select(:crop, :parent_id, Crop.all, :id, :system_name, {:include_blank => true})
+      %span.help-inline Optional. For setting up crop hierarchies for varieties etc.
   .form-actions
     = f.submit 'Save', :class => 'btn btn-primary'

--- a/app/views/crops/show.html.haml
+++ b/app/views/crops/show.html.haml
@@ -2,6 +2,19 @@
 
 .row
   .span9
+    - if @crop.parent
+      %p
+        = @crop.system_name 
+        is a variety of
+        = succeed "." do
+          = link_to @crop.parent, @crop.parent
+    - if @crop.varieties.count > 0
+      %p
+        Varieties of
+        = succeed ":" do
+          = @crop.system_name
+        != @crop.varieties.map{ |c| link_to c, c }.join(", ")
+
     - if @crop.plantings_count > 0
       %p
         Planted

--- a/db/migrate/20130514124515_add_parent_to_crop.rb
+++ b/db/migrate/20130514124515_add_parent_to_crop.rb
@@ -1,0 +1,5 @@
+class AddParentToCrop < ActiveRecord::Migration
+  def change
+    add_column :crops, :parent_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130418102558) do
+ActiveRecord::Schema.define(:version => 20130514124515) do
 
   create_table "authentications", :force => true do |t|
     t.integer  "member_id",  :null => false
@@ -40,6 +40,7 @@ ActiveRecord::Schema.define(:version => 20130418102558) do
     t.datetime "created_at",       :null => false
     t.datetime "updated_at",       :null => false
     t.string   "slug"
+    t.integer  "parent_id"
   end
 
   add_index "crops", ["slug"], :name => "index_crops_on_slug", :unique => true
@@ -120,12 +121,37 @@ ActiveRecord::Schema.define(:version => 20130418102558) do
     t.datetime "updated_at",                      :null => false
   end
 
+  create_table "orders", :force => true do |t|
+    t.string   "member_id",    :null => false
+    t.datetime "created_at",   :null => false
+    t.datetime "updated_at",   :null => false
+    t.datetime "completed_at"
+  end
+
+  create_table "orders_products", :id => false, :force => true do |t|
+    t.integer "order_id"
+    t.integer "product_id"
+  end
+
   create_table "payments", :force => true do |t|
     t.integer  "payer_id"
     t.string   "payment_type"
     t.decimal  "amount"
     t.datetime "created_at",   :null => false
     t.datetime "updated_at",   :null => false
+  end
+
+  create_table "photos", :force => true do |t|
+    t.integer  "owner_id",        :null => false
+    t.integer  "flickr_photo_id", :null => false
+    t.string   "thumbnail_url",   :null => false
+    t.string   "fullsize_url",    :null => false
+    t.datetime "created_at",      :null => false
+    t.datetime "updated_at",      :null => false
+    t.string   "title",           :null => false
+    t.string   "license_name",    :null => false
+    t.string   "license_url"
+    t.string   "link_url",        :null => false
   end
 
   create_table "plantings", :force => true do |t|
@@ -154,6 +180,14 @@ ActiveRecord::Schema.define(:version => 20130418102558) do
 
   add_index "posts", ["created_at", "author_id"], :name => "index_updates_on_created_at_and_user_id"
   add_index "posts", ["slug"], :name => "index_updates_on_slug", :unique => true
+
+  create_table "products", :force => true do |t|
+    t.string   "name",        :null => false
+    t.string   "description", :null => false
+    t.decimal  "min_price",   :null => false
+    t.datetime "created_at",  :null => false
+    t.datetime "updated_at",  :null => false
+  end
 
   create_table "roles", :force => true do |t|
     t.string   "name",        :null => false

--- a/spec/factories/crop.rb
+++ b/spec/factories/crop.rb
@@ -30,6 +30,16 @@ FactoryGirl.define do
       system_name "Pear"
     end
 
+    # for testing varieties
+    factory :roma do
+      system_name "Roma tomato"
+    end
+
+    factory :popcorn do
+      system_name "popcorn"
+    end
+
+
     # This should have a name that is alphabetically earlier than :uppercase
     # crop to ensure that the ordering tests work.
     factory :lowercasecrop do

--- a/spec/models/crop_spec.rb
+++ b/spec/models/crop_spec.rb
@@ -60,4 +60,13 @@ describe Crop do
     @crop = FactoryGirl.build(:tomato, :en_wikipedia_url => 'http://en.wikipedia.org/wiki/SomePage')
     @crop.should be_valid
   end
+
+  context 'varieties' do
+    it 'has a crop hierarchy' do
+      @tomato = FactoryGirl.create(:tomato)
+      @roma = FactoryGirl.create(:roma, :parent_id => @tomato.id)
+      @roma.parent.should eq @tomato
+      @tomato.varieties.should eq [@roma]
+    end
+  end
 end

--- a/spec/views/crops/new.html.haml_spec.rb
+++ b/spec/views/crops/new.html.haml_spec.rb
@@ -14,6 +14,7 @@ describe "crops/new" do
     assert_select "form", :action => crops_path, :method => "post" do
       assert_select "input#crop_system_name", :name => "crop[system_name]"
       assert_select "input#crop_en_wikipedia_url", :name => "crop[en_wikipedia_url]"
+      assert_select "select#crop_parent_id", :name => "crop[parent_id]"
     end
   end
 

--- a/spec/views/crops/show.html.haml_spec.rb
+++ b/spec/views/crops/show.html.haml_spec.rb
@@ -44,6 +44,25 @@ describe "crops/show" do
     rendered.should contain "Springfield Community Garden"
   end
 
+  context 'varieties' do
+    before(:each) do
+      @popcorn = FactoryGirl.create(:popcorn, :parent_id => @crop.id)
+      @ubercrop = FactoryGirl.create(:crop, :system_name => 'ubercrop')
+      @crop.parent_id = @ubercrop.id
+      @crop.save
+      render
+    end
+
+    it 'shows popcorn as a child variety' do
+      rendered.should contain @popcorn.system_name
+    end
+
+    it 'shows parent crop' do
+      rendered.should contain @ubercrop.system_name
+    end
+
+  end
+
   context "logged in and crop wrangler" do
 
     before(:each) do


### PR DESCRIPTION
Crop wranglers can now specify a parent crop, and varieties show up on the individual crop pages (i.e. "This is a variety of..." etc).  This story spawned several others which we will hopefully get to later.
