### PR TITLE
changed flickr_photo_id to string

### DIFF
--- a/db/migrate/20130601011725_change_flickr_photo_id_to_string.rb
+++ b/db/migrate/20130601011725_change_flickr_photo_id_to_string.rb
@@ -1,0 +1,8 @@
+class ChangeFlickrPhotoIdToString < ActiveRecord::Migration
+  def up
+    change_column :photos, :flickr_photo_id, :string
+  end
+  def down
+    change_column :photos, :flickr_photo_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130531110729) do
+ActiveRecord::Schema.define(:version => 20130601011725) do
 
   create_table "authentications", :force => true do |t|
     t.integer  "member_id",  :null => false
@@ -123,7 +123,7 @@ ActiveRecord::Schema.define(:version => 20130531110729) do
 
   create_table "photos", :force => true do |t|
     t.integer  "owner_id",        :null => false
-    t.integer  "flickr_photo_id", :null => false
+    t.string   "flickr_photo_id", :null => false
     t.string   "thumbnail_url",   :null => false
     t.string   "fullsize_url",    :null => false
     t.datetime "created_at",      :null => false


### PR DESCRIPTION
... because integer worked fine in dev (on sqlite3) but broke on staging
(with postgres). Turns out flickr photo IDs are quite LARGE integers.
But really they could be anything, so string seems safest.
