### PR TITLE
Reverted uniqueness limits for photo/planting association

### DIFF
--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -2,7 +2,7 @@ class Photo < ActiveRecord::Base
   attr_accessible :flickr_photo_id, :owner_id, :title, :license_name,
     :license_url, :thumbnail_url, :fullsize_url, :link_url
   belongs_to :owner, :class_name => 'Member'
-  has_and_belongs_to_many :plantings, :uniq => true
+  has_and_belongs_to_many :plantings
 
   default_scope order("created_at desc")
 

--- a/app/models/planting.rb
+++ b/app/models/planting.rb
@@ -7,7 +7,7 @@ class Planting < ActiveRecord::Base
 
   belongs_to :garden
   belongs_to :crop
-  has_and_belongs_to_many :photos, :uniq => true
+  has_and_belongs_to_many :photos
 
   default_scope order("created_at desc")
 

--- a/spec/models/planting_spec.rb
+++ b/spec/models/planting_spec.rb
@@ -93,14 +93,6 @@ describe Planting do
       @planting.photos << @photo
       @planting.photos.first.should eq @photo
     end
-
-    it "doesn't return duplicate photos" do
-      @planting = FactoryGirl.create(:planting)
-      @photo = FactoryGirl.create(:photo)
-      @planting.photos << @photo
-      @planting.photos << @photo
-      @planting.photos.count.should eq 1
-    end
   end
 
 end


### PR DESCRIPTION
It seems this interacts badly with the default_scope on postgres (but
    not on sqlite3).  Error message from the logs:

2013-06-01T02:21:05.312099+00:00 app[web.1]: ActiveRecord::StatementInvalid (PG::Error: ERROR:  for SELECT DISTINCT, ORDER BY expressions must appear in select list
2013-06-01T02:21:05.312099+00:00 app[web.1]: LINE 1: ...photo_id" = 2 AND "plantings"."id" = 181 ORDER BY created_at...
2013-06-01T02:21:05.312099+00:00 app[web.1]:   app/controllers/photos_controller.rb:59:in `create'
2013-06-01T02:21:05.312099+00:00 app[web.1]:                                                              ^
2013-06-01T02:21:05.312099+00:00 app[web.1]: : SELECT  DISTINCT 1 AS one FROM "plantings" INNER JOIN "photos_plantings" ON "plantings"."id" = "photos_plantings"."planting_id" WHERE "photos_plantings"."photo_id" = 2 AND "plantings"."id" = 181 ORDER BY created_at desc LIMIT 1):

For now, we'll just have to rely on the controller (which adds the
association) to keep things unique.
