### PR TITLE
Fix string/integer conversions in migrations.

### DIFF
--- a/db/migrate/20130515054017_change_order_member_id_to_integer.rb
+++ b/db/migrate/20130515054017_change_order_member_id_to_integer.rb
@@ -1,5 +1,11 @@
 class ChangeOrderMemberIdToInteger < ActiveRecord::Migration
-  def change
-    change_column :orders, :member_id, :integer
+  def up
+    remove_column :orders, :member_id
+    add_column :orders, :member_id, :integer
+  end
+
+  def down
+    remove_column :orders, :member_id
+    add_column :orders, :member_id, :string
   end
 end

--- a/db/migrate/20130601011725_change_flickr_photo_id_to_string.rb
+++ b/db/migrate/20130601011725_change_flickr_photo_id_to_string.rb
@@ -1,8 +1,13 @@
 class ChangeFlickrPhotoIdToString < ActiveRecord::Migration
   def up
-    change_column :photos, :flickr_photo_id, :string
+    remove_column :photos, :flickr_photo_id
+    add_column :photos, :flickr_photo_id, :string
   end
   def down
+    # Postgres doesn't allow you to cast strings to integers
+    # Hence there's no way of rolling back this migration without losing
+    # information.
+    remove_column :photos, :flickr_photo_id
     change_column :photos, :flickr_photo_id, :integer
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -147,10 +147,10 @@ ActiveRecord::Schema.define(:version => 20130601011725) do
   end
 
   create_table "orders", :force => true do |t|
-    t.integer  "member_id",               :limit => 255, :null => false
-    t.datetime "created_at",                             :null => false
-    t.datetime "updated_at",                             :null => false
+    t.datetime "created_at",              :null => false
+    t.datetime "updated_at",              :null => false
     t.datetime "completed_at"
+    t.integer  "member_id"
     t.string   "paypal_express_token"
     t.string   "paypal_express_payer_id"
   end
@@ -162,7 +162,6 @@ ActiveRecord::Schema.define(:version => 20130601011725) do
 
   create_table "photos", :force => true do |t|
     t.integer  "owner_id",        :null => false
-    t.string   "flickr_photo_id", :null => false
     t.string   "thumbnail_url",   :null => false
     t.string   "fullsize_url",    :null => false
     t.datetime "created_at",      :null => false
@@ -171,6 +170,7 @@ ActiveRecord::Schema.define(:version => 20130601011725) do
     t.string   "license_name",    :null => false
     t.string   "license_url"
     t.string   "link_url",        :null => false
+    t.string   "flickr_photo_id"
   end
 
   create_table "photos_plantings", :id => false, :force => true do |t|


### PR DESCRIPTION
This is for postgres compatibility.
