### PR TITLE
Fix to deploy-tasks bash script.

### DIFF
--- a/script/deploy-tasks.sh
+++ b/script/deploy-tasks.sh
@@ -37,7 +37,7 @@ then
   failed=true
 fi
 
-if [ failed ]
+if [ $failed ]
 then
   exit
 fi


### PR DESCRIPTION
Stupid variable/$variable distinction.
