### PR TITLE
Minor tweaks to seed trading:

### DIFF
--- a/app/models/seed.rb
+++ b/app/models/seed.rb
@@ -12,6 +12,8 @@ class Seed < ActiveRecord::Base
     :numericality => { :only_integer => true },
     :allow_nil => true
 
+  scope :tradable, where("tradable_to != 'nowhere'")
+
   TRADABLE_TO_VALUES = %w(nowhere locally nationally internationally)
   validates :tradable_to, :inclusion => { :in => TRADABLE_TO_VALUES,
         :message => "You may only trade seed nowhere, locally, nationally, or internationally" },

--- a/app/views/crops/show.html.haml
+++ b/app/views/crops/show.html.haml
@@ -41,8 +41,6 @@
 
       - if can? :create, Seed
         = link_to 'Add seeds to stash', new_seed_path(:params => { :crop_id => @crop.id }), :class => 'btn btn-primary'
-      - else
-        = render :partial => 'shared/signin_signup', :locals => { :to => 'add seeds for this crop to your stash' }
 
     - if @crop.plantings_count > 0
       - @crop.plantings.each do |p|
@@ -61,7 +59,7 @@
         - if can? :destroy, @crop
           = link_to 'Delete crop', @crop, method: :delete, data: { confirm: 'Are you sure?' }, :class => 'btn btn-mini'
 
-    %h4 Scientific names:
+    %h4 Scientific names
     %ul
       - @crop.scientific_names.each do |sn|
         %li
@@ -73,12 +71,26 @@
     %p
     - if can? :edit, @crop
       = link_to 'Add', new_scientific_name_path( :crop_id => @crop.id ), { :class => 'btn btn-mini' }
-    %h4 More information:
+    %h4 More information
     %ul
       %li= link_to 'Wikipedia (English)', @crop.en_wikipedia_url
 
-    - unless @crop.seeds.empty?
-      %h4 Seeds available for trade:
+    %h4 Find seeds
+    - if @crop.seeds.empty?
+      %p
+        There are no seeds available to trade.
+    - else
       %ul
-        - @crop.seeds.each do |seed|
-          %li= link_to "#{seed.owner} in #{seed.owner.location} will trade #{seed.tradable_to}", seed_path(seed)
+        - @crop.seeds.tradable.each do |seed|
+          %li
+            = link_to seed.owner, seed.owner
+            - if seed.owner.location
+              in #{seed.owner.location}
+            - else
+              (location unknown)
+            will trade #{seed.tradable_to}.
+            = link_to "View details.", seed_path(seed)
+    - if current_member
+      = link_to "List your seeds to trade.", new_seed_path()
+    - else
+      = render :partial => 'shared/signin_signup', :locals => { :to => 'list your seeds to trade' }

--- a/app/views/seeds/show.html.haml
+++ b/app/views/seeds/show.html.haml
@@ -14,7 +14,7 @@
       %b Plant before:
       = @seed.plant_before.to_s
     %p
-      %b Will trade to:
+      %b Will trade:
       = @seed.tradable_to
       - if @seed.owner.location.blank?
         (from unspecified location)

--- a/spec/models/seed_spec.rb
+++ b/spec/models/seed_spec.rb
@@ -78,5 +78,13 @@ describe Seed do
     it 'recognises an untradable seed' do
       FactoryGirl.create(:untradable_seed).tradable?.should == false
     end
+
+    it 'scopes correctly' do
+      @tradable = FactoryGirl.create(:tradable_seed)
+      @untradable = FactoryGirl.create(:untradable_seed)
+      Seed.tradable.should include @tradable
+      Seed.tradable.should_not include @untradable
+
+    end
   end
 end

--- a/spec/views/crops/show.html.haml_spec.rb
+++ b/spec/views/crops/show.html.haml_spec.rb
@@ -20,22 +20,44 @@ describe "crops/show" do
     rendered.should contain "Zea mays"
   end
 
-  it "shows a list of people with seeds to trade when seeds are available for trade" do
-    @owner = FactoryGirl.create(:london_member)
-    @owner2 = FactoryGirl.create(:london_member)
-    @seed1 = FactoryGirl.build(:tradable_seed, :owner => @owner)
-    @seed2 = FactoryGirl.build(:tradable_seed, :owner => @owner2)
-    @crop.seeds = [@seed1, @seed2]
-    render
-    rendered.should contain "Seeds available for trade:"
-    @crop.seeds.each do |seed|
-      assert_select "a[href=#{seed_path(seed)}]"
+  context "seeds available for trade" do
+    before(:each) do
+      @owner1 = FactoryGirl.create(:london_member)
+      @owner2 = FactoryGirl.create(:member) # no location
+      @seed1 = FactoryGirl.create(:tradable_seed, :owner => @owner1, :crop => @crop)
+      @seed2 = FactoryGirl.create(:tradable_seed, :owner => @owner2, :crop => @crop)
+      render
+    end
+
+    it "shows a heading" do
+      rendered.should contain "Find seeds"
+    end
+
+    it "shows a list of people with seeds to trade" do
+      @crop.seeds.each do |seed|
+        assert_select "a[href=#{seed_path(seed)}]"
+      end
+    end
+
+    it "shows location if available" do
+      rendered.should contain "#{@owner1} in #{@owner1.location} will trade #{@seed1.tradable_to}"
+    end
+
+    it "shows grammatical text if seed trader has no location" do
+      rendered.should contain "#{@owner2} (location unknown) will trade #{@seed2.tradable_to}"
     end
   end
 
-  it "does not show a list of people with seeds to trade if there are none" do
-    render
-    rendered.should_not contain "Seeds available for trade:"
+  context "no seeds available for trade" do
+    it "shows a heading" do
+      render
+      rendered.should contain "Find seeds"
+    end
+
+    it "suggests you trade seeds" do
+      render
+      rendered.should contain "There are no seeds available to trade."
+    end
   end
 
   context "has plantings" do
@@ -127,7 +149,6 @@ describe "crops/show" do
   it 'tells you to sign in/sign up' do
     render
     rendered.should contain 'Sign in or sign up to plant'
-    rendered.should contain 'Sign in or sign up to add seed'
   end
 
   context 'logged in' do

--- a/spec/views/seeds/show.html.haml_spec.rb
+++ b/spec/views/seeds/show.html.haml_spec.rb
@@ -25,7 +25,7 @@ describe "seeds/show" do
 
     it "shows tradable attributes" do
       render
-      rendered.should contain "Will trade to: locally"
+      rendered.should contain "Will trade: locally"
     end
 
     it "shows location of seed owner" do


### PR DESCRIPTION
- changed "Will trade to" to "Will trade" on seeds/show page
- on crop page, only list tradable seeds (not "nowhere" ones) -- did
  this by adding a tradable scope to Crop
- on crop page, say "(location unknown)" where necessary
- change heading on crop page to "Find seeds"
- show "Find seeds" heading regardless of whether any are available, and
  say there are none if there aren't any, along with a link to add some
- moved "sign in or sign up to add seeds" to under the Find seeds area
