### PR TITLE
fixed(?) firefox bug with email address in location field

### DIFF
--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -13,6 +13,11 @@
 
   .control-group
     .controls
+      = f.check_box :show_email
+      Show email publicly on your profile page
+
+  .control-group
+    .controls
       = f.check_box :send_notification_email
       Receive emailed copies of Inbox notifications.
 
@@ -32,12 +37,8 @@
     =f.label :location, 'Your location', :class => 'control-label'
     .controls
       =f.text_field :location
-      %span.help-inline Be as detailed or vague as you like.
+      %span.help-inline This will be displayed on a map. You can be as detailed or vague as you like.
 
-  .control-group
-    .controls
-      = f.check_box :show_email
-      Show email publicly on your profile page
 
   %h2 Linked accounts
 


### PR DESCRIPTION
I _think_ this should fix this bug: https://www.pivotaltracker.com/story/show/47196635

My theory is that it was the proximity of the "show email on profile" checkbox that was making Firefox guess that the location field was in fact an email field.
