### PR TITLE
Make "rake" depend on "rake db:test:prepare".

### DIFF
--- a/lib/tasks/testing.rake
+++ b/lib/tasks/testing.rake
@@ -2,7 +2,7 @@ require 'rake'
 begin
   require 'rspec/core/rake_task'
   task(:spec).clear
-  RSpec::Core::RakeTask.new(:spec) do |t|
+  RSpec::Core::RakeTask.new(:spec => 'db:test:prepare') do |t|
     t.verbose = false
   end
 rescue LoadError


### PR DESCRIPTION
"Help! Why are all my tests failing? Oh, right, because I need to run a migration and/or prepare a test database. _Again_. If only we had some sort of system for managing dependencies, like, er, Rake."

https://www.pivotaltracker.com/story/show/55709360
