### PR TITLE
reined in over-enthusiastic rake task

### DIFF
--- a/lib/tasks/growstuff.rake
+++ b/lib/tasks/growstuff.rake
@@ -138,12 +138,16 @@ namespace :growstuff do
       cropbot.account.account_type = AccountType.find_by_name("Staff") # set this just because it's nice
       cropbot.account.save
       Crop.find_each do |crop|
-        crop.creator = cropbot
-        crop.save
+        unless crop.creator
+          crop.creator = cropbot
+          crop.save
+        end
       end
       ScientificName.find_each do |sn|
-        sn.creator = cropbot
-        sn.save
+        unless sn.creator
+          sn.creator = cropbot
+          sn.save
+        end
       end
 
     end

--- a/script/deploy-tasks.sh
+++ b/script/deploy-tasks.sh
@@ -6,8 +6,6 @@
 # when it was added.  This will help us know which ones have been run
 # and can safely be commented out or removed.
 
-echo "2013-08-18 - reset crop planting counts"
-rake growstuff:oneoff:reset_crop_plantings_count
-
-echo "2013-08-21 - set default crop creator"
-rake growstuff:oneoff:set_default_crop_creator
+# Default format is:
+# echo "YYYY-MM-DD - do something or other"
+# rake growstuff:oneoff:something


### PR DESCRIPTION
This prevents existing crops from being attributed to cropbot when they shouldn't be.

PT: https://www.pivotaltracker.com/story/show/55864566
