### PR TITLE
added help text/links to planting form

### DIFF
--- a/app/views/plantings/_form.html.haml
+++ b/app/views/plantings/_form.html.haml
@@ -8,11 +8,17 @@
 
   .control-group
     = f.label 'What did you plant?', :class => 'control-label'
-    .controls= collection_select(:planting, :crop_id, Crop.all, :id, :system_name, :selected => @planting.crop_id || @crop.id)
+    .controls
+      = collection_select(:planting, :crop_id, Crop.all, :id, :system_name, :selected => @planting.crop_id || @crop.id)
+      %span.help-inline
+        Can't find what you're looking for?
+        = link_to "Request new crops.", Growstuff::Application.config.new_crops_request_link
   .control-group
     = f.label 'Where did you plant it?', :class => 'control-label'
-    .controls= collection_select(:planting, :garden_id,
-        Garden.where(:owner_id => current_member), :id, :name, :selected => @planting.garden_id || @garden.id)
+    .controls
+      = collection_select(:planting, :garden_id, Garden.where(:owner_id => current_member), :id, :name, :selected => @planting.garden_id || @garden.id)
+      %span.help-inline
+        = link_to "Add a garden.", new_garden_path
   .control-group
     = f.label 'When?', :class => 'control-label'
     .controls= f.text_field :planted_at, :value => @planting.planted_at ? @planting.planted_at.to_s(:ymd) : '', :class => 'add-datepicker'

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -39,6 +39,7 @@ Growstuff::Application.configure do
   config.assets.debug = true
 
   # Growstuff config
+  config.new_crops_request_link = "http://example.com/not-a-real-url"
   config.action_mailer.default_url_options = { :host => 'localhost:3000' }
 
   config.action_mailer.delivery_method = :smtp

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -66,6 +66,7 @@ Growstuff::Application.configure do
   # config.active_record.auto_explain_threshold_in_seconds = 0.5
 
   # Growstuff configuration
+  config.new_crops_request_link = "http://growstuff.org/posts/skud-20130319-requests-for-new-crops"
   config.action_mailer.default_url_options = { :host => 'growstuff.org' }
 
   config.action_mailer.smtp_settings = {

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -66,6 +66,7 @@ Growstuff::Application.configure do
   # config.active_record.auto_explain_threshold_in_seconds = 0.5
 
   # Growstuff configuration
+  config.new_crops_request_link = "http://example.com/not-a-real-url"
   config.action_mailer.default_url_options = { :host => 'dev.growstuff.org' }
 
   config.action_mailer.smtp_settings = {

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -38,6 +38,7 @@ Growstuff::Application.configure do
   config.active_support.deprecation = :stderr
 
   # Growstuff config
+  config.new_crops_request_link = "http://example.com/not-a-real-url"
   config.action_mailer.default_url_options = { :host => 'localhost:3000' }
 
   Growstuff::Application.configure do

--- a/spec/views/plantings/edit.html.haml_spec.rb
+++ b/spec/views/plantings/edit.html.haml_spec.rb
@@ -38,6 +38,11 @@ describe "plantings/edit" do
       end
     end
 
+    it 'includes helpful links for crops and gardens' do
+      assert_select "a[href=#{new_garden_path}]", :text => "Add a garden."
+      assert_select "a[href=#{Growstuff::Application.config.new_crops_request_link}]", :text => "Request new crops."
+    end
+
     it "chooses the right crop" do
       assert_select "select#planting_crop_id",
         :html => /option value="#{@tomato.id}" selected="selected"/

--- a/spec/views/plantings/new.html.haml_spec.rb
+++ b/spec/views/plantings/new.html.haml_spec.rb
@@ -38,6 +38,11 @@ describe "plantings/new" do
       end
     end
 
+    it 'includes helpful links for crops and gardens' do
+      assert_select "a[href=#{new_garden_path}]", :text => "Add a garden."
+      assert_select "a[href=#{Growstuff::Application.config.new_crops_request_link}]", :text => "Request new crops."
+    end
+
     it "selects a crop given in a param" do
       assert_select "select#planting_crop_id",
         :html => /option value="#{@crop2.id}" selected="selected"/


### PR DESCRIPTION
Two 1-point stories in one pull request:

https://www.pivotaltracker.com/story/show/56022062
https://www.pivotaltracker.com/story/show/56022170

At the request of one of our new members, we're adding some explanatory/helpful text and links to the planting form:
# a link to the "request new crops" forum thread next to the crop dropdown (we made this a config variable, as it's meaningless anywhere except production)
# a link to "add a garden" next to the garden dropdown
