### PR TITLE
removed marker bounds on hover

### DIFF
--- a/app/assets/javascripts/places.js.erb
+++ b/app/assets/javascripts/places.js.erb
@@ -30,7 +30,7 @@ function showMap(map) {
     attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors under <a href="http://www.openstreetmap.org/copyright">ODbL</a> | Map imagery &copy; <a href="http://cloudmade.com">Cloudmade</a>',
     maxZoom: 18
   }).addTo(map);
-  markers = new L.MarkerClusterGroup();
+  markers = new L.MarkerClusterGroup({showCoverageOnHover: false});
 
   $.getJSON(things_to_map, function(members) {
     $.each(members, function(i, m) {


### PR DESCRIPTION
Small places fix -- removed the blue outline you get when you hover over a marker cluster, as it's inconsistent and confusing.
