### PR TITLE
Added rails_12factor gem to suppress heroku messages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ group :production, :staging do
   gem 'newrelic_rpm'
   gem 'dalli'
   gem 'memcachier'
+  gem 'rails_12factor' # supresses heroku plugin injection
 end
 
 # Gems used only for assets and not required

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,6 +187,11 @@ GEM
       activesupport (= 3.2.13)
       bundler (~> 1.0)
       railties (= 3.2.13)
+    rails_12factor (0.0.2)
+      rails_serve_static_assets
+      rails_stdout_logging
+    rails_serve_static_assets (0.0.1)
+    rails_stdout_logging (0.0.3)
     railties (3.2.13)
       actionpack (= 3.2.13)
       activesupport (= 3.2.13)
@@ -287,6 +292,7 @@ DEPENDENCIES
   pg
   rack (~> 1.4.5)
   rails (= 3.2.13)
+  rails_12factor
   rake (>= 10.0.0)
   rspec-rails (~> 2.12.1)
   sass-rails (~> 3.2.3)


### PR DESCRIPTION
This gem supposedly suppresses those annoying messages about vendor plugins when you deploy to Heroku.
