### PR TITLE
Added posts and comments RSS links

### DIFF
--- a/app/views/comments/index.html.haml
+++ b/app/views/comments/index.html.haml
@@ -13,3 +13,8 @@
 %div.pagination
   = page_entries_info @comments, :model => "comments"
   = will_paginate @comments
+
+%p
+  Subscribe to the #{Growstuff::Application.config.site_name}
+  = succeed "." do
+    = link_to "comments RSS feed", comments_path(:format => 'rss')

--- a/app/views/posts/index.html.haml
+++ b/app/views/posts/index.html.haml
@@ -25,3 +25,16 @@
   %div.pagination
     = page_entries_info @posts, :model => "posts"
     = will_paginate @posts
+
+%p
+  - if @author
+    Subscribe to
+    = succeed "." do
+      = link_to "#{@author}'s posts RSS feed", posts_path(:format => 'rss')
+
+  - else
+    Subscribe to the #{Growstuff::Application.config.site_name}
+    = link_to "posts RSS feed", posts_path(:format => 'rss')
+    or
+    = succeed "." do
+      = link_to "comments RSS feed", comments_path(:format => 'rss')

--- a/spec/views/comments/index.html.haml_spec.rb
+++ b/spec/views/comments/index.html.haml_spec.rb
@@ -21,4 +21,8 @@ describe "comments/index" do
     rendered.should contain 'OMG LOL'
     rendered.should contain 'ROFL'
   end
+
+  it "contains an RSS feed link" do
+    assert_select "a", :href => comments_path(:format => 'rss')
+  end
 end

--- a/spec/views/posts/index.html.haml_spec.rb
+++ b/spec/views/posts/index.html.haml_spec.rb
@@ -27,4 +27,9 @@ describe "posts/index" do
   it "contains two gravatar icons" do
     assert_select "img", :src => /gravatar\.com\/avatar/, :count => 2
   end
+
+  it "contains RSS feed links for posts and comments" do
+    assert_select "a", :href => posts_path(:format => 'rss')
+    assert_select "a", :href => comments_path(:format => 'rss')
+  end
 end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/48988933

Adding RSS links to the posts and comments pages.  This is just a couple of lines so I thought I'd just quickly do it and get it out of the way.  Most other RSS links were done as part of the harvest data dump story.
