### PR TITLE
Rearranged menus to save space

### DIFF
--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -8,19 +8,25 @@
       %a.brand(href=root_path)= ENV['GROWSTUFF_SITE_NAME']
       .nav-collapse.collapse
         %ul.nav
-          %li= link_to "Crops", crops_path
-          %li= link_to "Seeds", seeds_path
-          %li= link_to "Places", places_path
+          %li.dropdown<
+            %a.dropdown-toggle{'data-toggle' => 'dropdown', :href => crops_path}
+              Crops
+              %b.caret
+            %ul.dropdown-menu
+              %li= link_to "Browse Crops", crops_path
+              %li= link_to "Seeds", seeds_path
+              %li= link_to "Plantings", plantings_path
+              %li= link_to "Harvests", harvests_path
           %li.dropdown<
             %a.dropdown-toggle{'data-toggle' => 'dropdown', :href => members_path}
               Community
               %b.caret
             %ul.dropdown-menu
-              %li= link_to "Members", members_path
+              %li= link_to "Community Map", places_path
+              %li= link_to "Browse Members", members_path
               %li= link_to "Posts", posts_path
               %li= link_to "Forums", forums_path
 
-          %li.divider-vertical
 
           - if member_signed_in?
             %li.dropdown<
@@ -43,12 +49,15 @@
                     = link_to("Inbox (#{current_member.notifications.unread_count})", notifications_path)
                   - else
                     = link_to("Inbox", notifications_path)
+                - if current_member.has_role?(:crop_wrangler) || current_member.has_role?(:admin)
+                  %li{:class => 'divider', :role => 'presentation'}
+                  - if current_member.has_role?(:crop_wrangler)
+                    %li= link_to "Crop Wrangling", wrangle_crops_path
+                  - if current_member.has_role?(:admin)
+                    %li= link_to "Admin", admin_path
+              %li= link_to "Support Growstuff", shop_path
 
-            %li= link_to "Shop", shop_path
-            - if current_member.has_role?(:crop_wrangler)
-              %li= link_to "Crop Wrangling", wrangle_crops_path
-            - if current_member.has_role?(:admin)
-              %li= link_to "Admin", admin_path
+
             %li= link_to "Sign out", destroy_member_session_path, :method => :delete
 
           - else

--- a/spec/views/layouts/_header_spec.rb
+++ b/spec/views/layouts/_header_spec.rb
@@ -25,7 +25,7 @@ describe 'layouts/_header.html.haml', :type => "view" do
     end
 
     it 'has a Places link' do
-      rendered.should contain "Places"
+      rendered.should contain "Community Map"
     end
 
     it 'has a Community section' do
@@ -33,7 +33,7 @@ describe 'layouts/_header.html.haml', :type => "view" do
     end
 
     it 'links to members' do
-      assert_select("a[href=#{members_path}]", 'Members')
+      assert_select("a[href=#{members_path}]", 'Browse Members')
     end
 
     it 'links to posts' do


### PR DESCRIPTION
PT: https://www.pivotaltracker.com/story/show/73178942

The navbar menus were getting really unwieldy if you are an admin/crop wrangler.  This rearranges them considerably, including some general improvement to the layout, moving most of the stuff under one of two main menus: crops and community.

Admin and Crop Wrangler links now appear under "Your Stuff" if you have them.

"Shop" link is now "Support Growstuff" and only shows up to signed in members.
