### PR TITLE
Smallsearch

### DIFF
--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -65,5 +65,5 @@
             %li= link_to 'Sign up', new_member_registration_path
 
         = form_tag crops_search_path, :method => :get, :class => 'navbar-search pull-right' do
-          .input-append
+          .input
             = text_field_tag 'search', nil, :class => 'search-query input-medium', :placeholder => 'Search crops'


### PR DESCRIPTION
Smaller search box in the nav bar; as shown in screenshot below. Note that changing from input-prepend to plain input class for the search box removes some of the bottom padding that came with the input-prepend class. 
![screen shot 2014-06-18 at 7 58 52 pm](https://cloud.githubusercontent.com/assets/984213/3323274/b03c428c-f75d-11e3-95f6-5e1f14b0981d.png)
