### PR TITLE
Fix for bug when redirecting after password reset

### DIFF
--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -1,0 +1,7 @@
+class PasswordsController < Devise::PasswordsController
+
+protected
+  def after_resetting_password_path_for(resource)
+    root_path
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Growstuff::Application.routes.draw do
   resources :plant_parts
 
 
-  devise_for :members, :controllers => { :registrations => "registrations" }
+  devise_for :members, :controllers => { :registrations => "registrations", :passwords => "passwords" }
   resources :members
 
   resources :photos


### PR DESCRIPTION
Explicitly set after_resetting_password_path_for to direct to root_path instead of erroneously to /members/password. Might be a good idea to write a feature spec for this behavior.
