### PR TITLE
Make centering specific to footer

### DIFF
--- a/app/assets/stylesheets/bootstrap_and_overrides.css.less
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css.less
@@ -204,7 +204,8 @@ li.crop-hierarchy {
 }
 
 // navbar centering
-.navbar .nav {
+footer .navbar .nav {
+  float: none;
   display: inline-block;
   *display: inline;
   /* ie7 fix */


### PR DESCRIPTION
This seems to be the magic needed to make @ameliagreenhall's changes fully work.  Making this centreing be specific to the footer prevents brokenness in the header nav's "brand" link.
