### PR TITLE
Add 'oz' as a weight unit for harvesting

### DIFF
--- a/app/models/harvest.rb
+++ b/app/models/harvest.rb
@@ -38,7 +38,8 @@ class Harvest < ActiveRecord::Base
 
   WEIGHT_UNITS_VALUES = {
     "kg" => "kg",
-    "lb" => "lb"
+    "lb" => "lb",
+    "oz" => "oz"
   }
   validates :weight_unit, :inclusion => { :in => WEIGHT_UNITS_VALUES.values,
     :message => "%{value} is not a valid unit" },


### PR DESCRIPTION
Updating the harvest WEIGHT_UNITS_VALUES to include kg, lb, and now oz, so Imperial-unit-users don't need to get out the calculator when going from scale to growstuff
