### PR TITLE
test & task for the ping -> pint change

### DIFF
--- a/lib/tasks/growstuff.rake
+++ b/lib/tasks/growstuff.rake
@@ -246,6 +246,16 @@ namespace :growstuff do
       end
     end
 
+    desc "August 2014: fix ping to pint in database"
+    task :ping_to_pint => :environment do
+      Harvest.find_each do |h|
+        if h.unit == "ping" 
+          h.unit = "pint"
+          h.save
+        end
+      end
+    end
+
   end # end oneoff section
 
 end

--- a/script/deploy-tasks.sh
+++ b/script/deploy-tasks.sh
@@ -12,3 +12,6 @@
 
 echo "2013-07-18 - zero crop plantings_count"
 rake growstuff:oneoff:zero_plantings_count
+
+echo "2014-08-10 - replace ping with pint in db"
+rake growstuff:oneoff:ping_to_pint

--- a/spec/models/harvest_spec.rb
+++ b/spec/models/harvest_spec.rb
@@ -45,8 +45,8 @@ describe Harvest do
   end
 
   context 'units' do
-    Harvest::UNITS_VALUES.values.push(nil, '').each do |s|
-      it "#{s} should be a valid unit" do
+    it 'all valid units should work' do
+      ['individual','bunch','sprig','handful','litre','pint','quart','bucket','basket','bushel', nil, ''].each do |s|
         @harvest = FactoryGirl.build(:harvest, :unit => s)
         @harvest.should be_valid
       end


### PR DESCRIPTION
How's this look?

Here's how I tested:
I undid the ping/pint change. I ran "unicorn" and logged in as test1. I created a harvest of 2 pints of achiote and confirmed via the web interface that it displayed as "2 pings" and in psql that the unit was "ping". Then I ran "scripts/deploy.sh" and checked the web interface and psql again to see that it now showed pint in the db and pints in the UI.  (Then I put back the initial ping/pint change so as not to mess up my tree)

I hope running "scripts/deploy.sh" was correct. I also ran "rake" and saw no new failures with the ping/pint change in place and the spec modified.
