### PR TITLE
Tweak formatting of images with popovers (used mostly on homepage)

### DIFF
--- a/app/assets/stylesheets/overrides.css.less
+++ b/app/assets/stylesheets/overrides.css.less
@@ -176,6 +176,11 @@ footer .navbar .nav {
   border-radius: 0;
 }
 
+.crop-image, .member-image {
+  width: 100%;
+  height: 100%;
+}
+
 // Overrides applying only to mobile view. This must be at the end of the overrides file.
 
 @media only screen and (max-width: 767px) {

--- a/app/views/crops/_image_with_popover.html.haml
+++ b/app/views/crops/_image_with_popover.html.haml
@@ -2,11 +2,12 @@
   = link_to |
     image_tag( |
       crop.default_photo ?  crop.default_photo.thumbnail_url : 'placeholder_150.png', |
-      :alt => crop.name |
+      :alt => crop.name, |
+      :class => 'image-responsive crop-image' |
     ), |
     crop, |
     :rel => "popover", |
     'data-trigger' => 'hover', |
     'data-title' => crop.name, |
     'data-content' => "#{ render :partial => 'crops/popover', :locals => { :crop => crop } }", |
-    'data-html' => true
+    'data-html' => true |

--- a/app/views/members/_image_with_popover.html.haml
+++ b/app/views/members/_image_with_popover.html.haml
@@ -5,7 +5,7 @@
           :size => defined?(size) ?  size : 150, |
           :default => :identicon }), |
         :alt => member.login_name, |
-        :class => 'img-responsive' |
+        :class => 'img-responsive member-image' |
   ), |
   member, |
   :rel => "popover", |

--- a/app/views/plantings/_image_with_popover.html.haml
+++ b/app/views/plantings/_image_with_popover.html.haml
@@ -2,7 +2,8 @@
   = link_to |
     image_tag( |
       planting.photos.present? ? planting.photos.first.thumbnail_url : 'placeholder_150.png', |
-      :alt => planting.to_s |
+      :alt => planting.to_s, |
+      :class => 'image-responsive crop-image' |
     ), |
     planting, |
     :rel => "popover", |


### PR DESCRIPTION
Some problems with bootstrap3 formatting on the homepage. This seems to help on my dev box.
