### PR TITLE
Updated devise tokens in emails for devise 3.2

### DIFF
--- a/app/views/devise/mailer/confirmation_instructions.html.haml
+++ b/app/views/devise/mailer/confirmation_instructions.html.haml
@@ -5,7 +5,7 @@
   Your account on #{site_name} has been created.  You just need to confirm
   your email address through the link below:
 
-%p= link_to 'Confirm my account', confirmation_url(@resource, :confirmation_token => @resource.confirmation_token)
+%p= link_to 'Confirm my account', confirmation_url(@resource, :confirmation_token => @token)
 
 %p
   Once you're confirmed, you can sign in with your login name

--- a/app/views/devise/mailer/reset_password_instructions.html.haml
+++ b/app/views/devise/mailer/reset_password_instructions.html.haml
@@ -5,7 +5,7 @@
   Someone has requested a link to reset your password on #{site_name}.
   We presume this was you, in which case you can do so through this link:
 
-%p= link_to 'Change my password', edit_password_url(@resource, :reset_password_token => @resource.reset_password_token)
+%p= link_to 'Change my password', edit_password_url(@resource, :reset_password_token => @token)
 
 %p
   If it wasn't you, then someone's made a typo or has been messing

--- a/app/views/devise/mailer/unlock_instructions.html.haml
+++ b/app/views/devise/mailer/unlock_instructions.html.haml
@@ -8,7 +8,7 @@
   forgotten your password.  In either case, use the link below to unlock
   your account:
 
-%p= link_to 'Unlock my account', unlock_url(@resource, :unlock_token => @resource.unlock_token)
+%p= link_to 'Unlock my account', unlock_url(@resource, :unlock_token => @token)
 
 %p
   If you have actually forgotten your password, you can


### PR DESCRIPTION
Devise 3.2 has a breaking change in the way it emails confirmation tokens. This fixes it.
