### PR TITLE
Clear crop hierarchy view cache after uploading crops

### DIFF
--- a/lib/tasks/growstuff.rake
+++ b/lib/tasks/growstuff.rake
@@ -30,6 +30,7 @@ namespace :growstuff do
     CSV.foreach(@file) do |row|
       Crop.create_from_csv(row)
     end
+    Rails.cache.delete('full_crop_hierarchy')
     puts "Finished loading crops"
 
   end


### PR DESCRIPTION
The crop_sweeper only acts in response to things that happen in the
controller.  Since this works directly with the model, we need to clear
the cache fragment manually.
