### PR TITLE
Plantings index should display finished at date instead of planted at under the finished column

### DIFF
--- a/app/views/plantings/index.html.haml
+++ b/app/views/plantings/index.html.haml
@@ -43,7 +43,7 @@
         %td= planting.planted_at
         %td
           - if planting.finished and planting.finished_at
-            = planting.planted_at
+            = planting.finished_at
           - elsif planting.finished
             Yes (no date specified)
         %td= planting.sunniness

--- a/spec/features/plantings/planting_a_crop_spec.rb
+++ b/spec/features/plantings/planting_a_crop_spec.rb
@@ -71,6 +71,9 @@ feature "Planting a crop", :js => true do
     end
     expect(page).to have_content "Planting was successfully created"
     expect(page).to have_content "Finished: August 30, 2014"
+
+    visit plantings_path
+    expect(page).to have_content "August 30, 2014"
   end
 
   scenario "Marking a planting as finished without a date" do

--- a/spec/views/plantings/index.html.haml_spec.rb
+++ b/spec/views/plantings/index.html.haml_spec.rb
@@ -8,8 +8,8 @@ describe "plantings/index" do
     @tomato = FactoryGirl.create(:tomato)
     @maize  = FactoryGirl.create(:maize)
     page = 1
-    per_page = 2
-    total_entries = 2
+    per_page = 3
+    total_entries = 3
     plantings = WillPaginate::Collection.create(page, per_page, total_entries) do |pager|
       pager.replace([
         FactoryGirl.create(:planting,
@@ -22,6 +22,13 @@ describe "plantings/index" do
           :crop => @maize,
           :description => '',
           :planted_at => Time.local(2013, 1, 13)
+        ),
+        FactoryGirl.create(:planting,
+          :garden => @garden,
+          :crop => @tomato,
+          :planted_at => Time.local(2013, 1, 13),
+          :finished_at => Time.local(2013, 1, 20),
+          :finished => true
         )
       ])
     end
@@ -38,6 +45,10 @@ describe "plantings/index" do
 
   it "displays planting time" do
     rendered.should contain 'January 13, 2013'
+  end
+
+  it "displays finished time" do
+    rendered.should contain 'January 20, 2013'
   end
 
   it "provides data links" do


### PR DESCRIPTION
This is a basic fix for the plantings index page. Under the finished column it was showing the planted at date instead of the date it finished.
