### PR TITLE
Redirect to sign-in page for any action that requires authentication

### DIFF
--- a/app/controllers/account_types_controller.rb
+++ b/app/controllers/account_types_controller.rb
@@ -1,5 +1,7 @@
 class AccountTypesController < ApplicationController
   load_and_authorize_resource
+  before_filter :authenticate_member!
+  
   # GET /account_types
   def index
     @account_types = AccountType.all

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -1,5 +1,7 @@
 class AccountsController < ApplicationController
   load_and_authorize_resource
+  before_filter :authenticate_member!
+  
   # GET /accounts
   def index
     @accounts = Account.all

--- a/app/controllers/alternate_names_controller.rb
+++ b/app/controllers/alternate_names_controller.rb
@@ -1,5 +1,6 @@
 class AlternateNamesController < ApplicationController
   load_and_authorize_resource
+  before_filter :authenticate_member!, :except => [:index, :show]
 
   # GET /alternate_names
   # GET /alternate_names.json

--- a/app/controllers/authentications_controller.rb
+++ b/app/controllers/authentications_controller.rb
@@ -1,4 +1,5 @@
 class AuthenticationsController < ApplicationController
+  before_filter :authenticate_member!
   load_and_authorize_resource
 
   # GET /authentications

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,5 +1,6 @@
 class CommentsController < ApplicationController
   load_and_authorize_resource
+  before_filter :authenticate_member!, :except => [:index, :show]
 
   cache_sweeper :comment_sweeper
 

--- a/app/controllers/crops_controller.rb
+++ b/app/controllers/crops_controller.rb
@@ -1,6 +1,7 @@
 class CropsController < ApplicationController
   load_and_authorize_resource
   skip_authorize_resource :only => [:hierarchy, :search]
+  before_filter :authenticate_member!, :except => [:index, :hierarchy, :search, :show]
 
   cache_sweeper :crop_sweeper
 

--- a/app/controllers/gardens_controller.rb
+++ b/app/controllers/gardens_controller.rb
@@ -1,6 +1,7 @@
 class GardensController < ApplicationController
   load_and_authorize_resource
-
+  before_filter :authenticate_member!, :except => [:index, :show]
+  
   cache_sweeper :garden_sweeper
 
   # GET /gardens

--- a/app/controllers/harvests_controller.rb
+++ b/app/controllers/harvests_controller.rb
@@ -1,6 +1,7 @@
 class HarvestsController < ApplicationController
 
   load_and_authorize_resource
+  before_filter :authenticate_member!, :except => [:index, :show]
 
   # GET /harvests
   # GET /harvests.json

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,6 +1,8 @@
 class NotificationsController < ApplicationController
   include NotificationsHelper
+  before_filter :authenticate_member!
   load_and_authorize_resource
+
   # GET /notifications
   def index
     @notifications = Notification.find_all_by_recipient_id(current_member)

--- a/app/controllers/order_items_controller.rb
+++ b/app/controllers/order_items_controller.rb
@@ -1,4 +1,5 @@
 class OrderItemsController < ApplicationController
+  before_filter :authenticate_member!
   load_and_authorize_resource
 
   # POST /order_items

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,4 +1,5 @@
 class OrdersController < ApplicationController
+  before_filter :authenticate_member!
   load_and_authorize_resource
 
   # GET /orders

--- a/app/controllers/photos_controller.rb
+++ b/app/controllers/photos_controller.rb
@@ -1,5 +1,6 @@
 class PhotosController < ApplicationController
   load_and_authorize_resource
+  before_filter :authenticate_member!, :except => [:index, :show]
 
   cache_sweeper :photo_sweeper
 

--- a/app/controllers/plantings_controller.rb
+++ b/app/controllers/plantings_controller.rb
@@ -1,5 +1,6 @@
 class PlantingsController < ApplicationController
   load_and_authorize_resource
+  before_filter :authenticate_member!, :except => [:index, :show]
 
   cache_sweeper :planting_sweeper
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,5 +1,6 @@
 class PostsController < ApplicationController
   load_and_authorize_resource
+  before_filter :authenticate_member!, :except => [:index, :show]
 
   cache_sweeper :post_sweeper
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,5 +1,7 @@
 class ProductsController < ApplicationController
   load_and_authorize_resource
+  before_filter :authenticate_member!
+
   # GET /products
   def index
     @products = Product.all

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -1,5 +1,7 @@
 class RolesController < ApplicationController
   load_and_authorize_resource
+  before_filter :authenticate_member!
+  
   # GET /roles
   def index
     @roles = Role.all

--- a/app/controllers/scientific_names_controller.rb
+++ b/app/controllers/scientific_names_controller.rb
@@ -1,5 +1,6 @@
 class ScientificNamesController < ApplicationController
   load_and_authorize_resource
+  before_filter :authenticate_member!, :except => [:index, :show]
 
   cache_sweeper :scientific_name_sweeper
 

--- a/app/controllers/seeds_controller.rb
+++ b/app/controllers/seeds_controller.rb
@@ -1,5 +1,6 @@
 class SeedsController < ApplicationController
   load_and_authorize_resource
+  before_filter :authenticate_member!, :except => [:index, :show]
 
   cache_sweeper :seed_sweeper
 

--- a/spec/features/signin_spec.rb
+++ b/spec/features/signin_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 feature "signin" do
   let(:member){FactoryGirl.create(:member)}
+  let(:notification){FactoryGirl.create(:notification)}
 
   scenario "redirect to previous page after signin" do
     visit crops_path # some random page
@@ -19,6 +20,11 @@ feature "signin" do
     fill_in 'Password', with: member.password
     click_button 'Sign in'
     current_path.should eq root_path
+  end
+
+  scenario "redirect to signin page for if not authenticated to view notification" do
+    visit notification_path(notification)
+    current_path.should eq new_member_session_path
   end
 
 end


### PR DESCRIPTION
Pivotal tracker issue:

https://www.pivotaltracker.com/story/show/55865366

This makes Devise redirect to login page whenever an action requires authentication. The vast majority of these use (a variant) of this single line in the controller:

``` ruby
before_filter :authenticate_member!, :except => [:index, :show].
```

I've added a test to check if it redirects to the login page to read notifications, as that was the problem reported. I don't know if it's worth adding tests for the rest of them, as that feels like we'd be testing Devise's functionality...
