### PR TITLE
Fixed a bug which only occurs in the few months before February

### DIFF
--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -369,7 +369,7 @@ describe 'member' do
 
       # and again to make sure it works for currently paid accounts
       @member.update_account_after_purchase(@product)
-      @member.account.paid_until.to_s.should eq (Time.zone.now + 6.months).to_s
+      @member.account.paid_until.to_s.should eq (Time.zone.now + 3.months + 3.months).to_s
     end
   end
 


### PR DESCRIPTION
This is the fundamental problem:

```
2.1.2 :005 > Time.zone.now + 3.months
=> Sat, 28 Feb 2015 03:17:24 UTC +00:00
2.1.2 :006 > Time.zone.now + 3.months + 3.months
=> Thu, 28 May 2015 03:17:32 UTC +00:00
2.1.2 :007 > Time.zone.now + 6.months
=> Sat, 30 May 2015 03:17:37 UTC +00:00
```

I changed the test to use the "3.months + 3.months" formulation and it
now passes.
