### PR TITLE
don't load test and admin users in staging

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,13 +11,13 @@ def load_data
     create_cropbot
     load_crops
     load_plant_parts
+    load_paid_account_types
+    load_products
 
     # for development and staging environments only
-    if Rails.env.development? || Rails.env.staging?
+    if Rails.env.development?
       load_test_users
       load_admin_users
-      load_paid_account_types
-      load_products
     end
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,7 +14,9 @@ def load_data
     load_paid_account_types
     load_products
 
-    # for development and staging environments only
+    # We don't load these in an environment except development to
+    # prevent creating users in the wile - especially admins - with
+    # known passwords.
     if Rails.env.development?
       load_test_users
       load_admin_users

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -15,7 +15,7 @@ def load_data
     load_products
 
     # We don't load these in an environment except development to
-    # prevent creating users in the wile - especially admins - with
+    # prevent creating users in the wild - especially admins - with
     # known passwords.
     if Rails.env.development?
       load_test_users


### PR DESCRIPTION
This is something @pozorvlak mentioned would make sense. Seems sensible to run `load_paid_account_types` and `load_products` in staging, but what about the users? ( @Skud ) 