### PR TITLE
Fix cache key

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -57,7 +57,7 @@ class CommentsController < ApplicationController
 
     respond_to do |format|
       if @comment.save
-        format.html { redirect_to @comment.post, notice: 'Comment was successfully created.' }
+        format.html { redirect_to @comment.post, notice: "Comment was successfully created." }
         format.json { render json: @comment, status: :created, location: @comment }
       else
         format.html { render action: "new" }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,6 +24,7 @@ module ApplicationHelper
       :target => "_blank"
   end 
 
+  # Produces a cache key for uniquely identifying cached fragments.
   def cache_key_for(klass, identifier="all")
     count          = klass.count
     max_updated_at = klass.maximum(:updated_at).try(:utc).try(:to_s, :number)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,10 +24,10 @@ module ApplicationHelper
       :target => "_blank"
   end 
 
-  def cache_key_for(klass)
+  def cache_key_for(klass, identifier="all")
     count          = klass.count
     max_updated_at = klass.maximum(:updated_at).try(:utc).try(:to_s, :number)
-    "#{klass.name.downcase.pluralize}/all-#{count}-#{max_updated_at}"
+    "#{klass.name.downcase.pluralize}/#{identifier}-#{count}-#{max_updated_at}"
   end
 
 end

--- a/app/views/home/_crops.html.haml
+++ b/app/views/home/_crops.html.haml
@@ -1,6 +1,6 @@
 .row
   .col-md-6.hidden-xs
-    - cache cache_key_for(Crop), :expires_in => 1.day do
+    - cache cache_key_for(Crop, 'interesting'), :expires_in => 1.day do
       %h2= t('.our_crops')
       - Crop.interesting.each do |c|
         .col-md-3{:style => 'margin:0px; padding: 3px'}
@@ -13,7 +13,7 @@
 
 .row
   .col-md-12
-    - cache cache_key_for(Crop) do
+    - cache cache_key_for(Crop, 'recent') do
       %p{ :style => 'margin-top: 11.25px' }
         %strong
           #{t('.recently_added')}:


### PR DESCRIPTION
In response to [this bug](http://talk.growstuff.org/t/please-test-rails-4/173/28).

It seems the issue is that the `cache_key_for` method (defined in ApplicationHelper) always returns the same key if the same class is passed into it, so I've added an additional argument which can be included in the key to make it uniquely identifying. As it stands the key is generated by looking at the model name, the total count of records for that model and the time of the most recently updated record. If any of those change, the key is refreshed.

I turned caching on in development and this fix appears to work.

I might suggest making a separate story to rip out all this caching stuff and then rebuild it based on New Relic stats.