### PR TITLE
Release7 tweaks

### DIFF
--- a/app/assets/stylesheets/overrides.css.less
+++ b/app/assets/stylesheets/overrides.css.less
@@ -124,7 +124,7 @@ p.stats {
   color: @brown;
 }
 
-.crop-thumbnail {
+.photo-thumbnail {
   position:relative;
   padding:0;
   img {
@@ -151,35 +151,40 @@ p.stats {
   }
 }
 
-.member-thumbnail {
-  img {
-    height: 85px;
-    width: 85px;
-    max-width: 85px
-  }
-}
 
 .thumbnail {
   border: none;
   text-align: center;
   margin-bottom: 1.5em;
 
-  .scientific-name small, .crop-name a {
-    display: inline-block;
-    max-width: 100%;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    line-height: 1em;
-    padding-bottom: 2px;
+  .member-thumbnail {
+    text-align: left;
+    img {
+      height: 85px;
+      width: 85px;
+      max-width: 85px
+    }
   }
 
-  .crop-name a {
-    padding-top: 2px;
-  }
+  .crop-thumbnail {
+    height: 220px;
+    .scientific-name small, .crop-name a {
+      display: inline-block;
+      max-width: 100%;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      line-height: 1em;
+      padding-bottom: 2px;
+    }
 
-  .scientific-name small {
-    margin-bottom: -2px;
+    .crop-name a {
+      padding-top: 2px;
+    }
+
+    .scientific-name small {
+      margin-bottom: -2px;
+    }
   }
 }
 

--- a/app/assets/stylesheets/overrides.css.less
+++ b/app/assets/stylesheets/overrides.css.less
@@ -160,8 +160,10 @@ p.stats {
 }
 
 .thumbnail {
+  border: none;
+  text-align: center;
   margin-bottom: 1.5em;
-  
+
   .scientific-name small, .crop-name a {
     display: inline-block;
     max-width: 100%;

--- a/app/views/crops/_thumbnail.html.haml
+++ b/app/views/crops/_thumbnail.html.haml
@@ -1,6 +1,6 @@
 .thumbnail(style='height: 220px')
   - if crop
-    = link_to image_tag((crop.default_photo ?  crop.default_photo.thumbnail_url : 'placeholder_150.png'), :alt => crop.name, :class => 'img-rounded'), crop
+    = link_to image_tag((crop.default_photo ?  crop.default_photo.thumbnail_url : 'placeholder_150.png'), :alt => crop.name, :class => 'img'), crop
     %p.crop-name
       = link_to crop.name, crop
       - if crop.scientific_names.count > 0

--- a/app/views/crops/_thumbnail.html.haml
+++ b/app/views/crops/_thumbnail.html.haml
@@ -1,4 +1,4 @@
-.thumbnail(style='height: 220px')
+.thumbnail.crop-thumbnail
   - if crop
     = link_to image_tag((crop.default_photo ?  crop.default_photo.thumbnail_url : 'placeholder_150.png'), :alt => crop.name, :class => 'img'), crop
     %p.crop-name

--- a/app/views/home/_crops.html.haml
+++ b/app/views/home/_crops.html.haml
@@ -1,15 +1,20 @@
 .row
-  .col-md-6.hidden-xs
+  .col-md-8
     - cache cache_key_for(Crop, 'interesting'), :expires_in => 1.day do
       %h2= t('.our_crops')
-      - Crop.interesting.each do |c|
-        .col-md-3{:style => 'margin:0px; padding: 3px'}
-          = render :partial => 'crops/image_with_popover', :locals => { :crop => c }
+      .hidden-xs
+        - Crop.interesting.first(8).each do |c|
+          .col-md-3
+            = render :partial => 'crops/thumbnail', :locals => { :crop => c }
+      .visible-xs
+        - Crop.interesting.first(3).each do |c|
+          .col-md-3
+            = render :partial => 'crops/thumbnail', :locals => { :crop => c }
 
-  .col-md-6
+  .col-md-4.hidden-xs
     - cache cache_key_for(Planting) do
       %h2= t('.recently_planted')
-      = render :partial => 'plantings/list', :locals => { :plantings => Planting.interesting.first(4) }
+      = render :partial => 'plantings/list', :locals => { :plantings => Planting.interesting.first(6) }
 
 .row
   .col-md-12

--- a/app/views/home/_members.html.haml
+++ b/app/views/home/_members.html.haml
@@ -6,7 +6,7 @@
 
       .row
         - members.each do |m|
-          .col-md-6.homepage-members
+          .col-md-4.homepage-members
             = render :partial => "members/thumbnail", :locals => { :member => m }
 
       %p.text-right

--- a/app/views/photos/_thumbnail.html.haml
+++ b/app/views/photos/_thumbnail.html.haml
@@ -1,5 +1,5 @@
-.thumbnail.crop-thumbnail
-  = link_to image_tag(photo.thumbnail_url, :alt => photo.title, :class => 'img-rounded img-responsive'), photo
+.thumbnail.photo-thumbnail
+  = link_to image_tag(photo.thumbnail_url, :alt => photo.title, :class => 'img img-responsive'), photo
   .text
     %p
       = link_to photo.title, photo


### PR DESCRIPTION
Mostly just tweaking the display of crops on the homepage, now that the column spacing is different

- made columns 8/4 rather than 6/6
- show 8 interesting crops, not 12
- show 6 recent plantings, not 4
- use crop thumbnail with visible name/info/etc, rather than popup version
- fix up some thumbnail CSS
- made members display 2 across not 3 across
- made some variations to what's shown on mobile screens (now: crops, which have clickable links, and were previously supressed)

Screenshot shows how it looks:

![screenshot 2015-01-16 21 34 56](https://cloud.githubusercontent.com/assets/103436/5775094/a261b8f0-9dc9-11e4-87a0-45844e9a5438.png)
