### PR TITLE
Deployment from Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,10 @@ deploy:
   app: tranquil-basin-3130
   on:
     repo: Growstuff/growstuff
-    branch: travis_deploy
+  app:
+    master: growstuff-prod
+    dev: growstuff-staging
+    travis_deploy: tranquil-basin-3130
   run:
     - "rake db:migrate"
     - "script/deploy-tasks.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,18 @@
----
 language: ruby
-
 env: GROWSTUFF_SITE_NAME="Growstuff (travis)" RAILS_SECRET_TOKEN='xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
-bundler_args: --without development production staging
+bundler_args: "--without development production staging"
 rvm:
-  - 2.1.5
+- 2.1.5
 before_script:
-  - psql -c 'create database growstuff_test;' -U postgres
+- psql -c 'create database growstuff_test;' -U postgres
 script:
-  - bundle exec rake db:migrate --trace
-  - bundle exec rspec spec/
+- bundle exec rake db:migrate --trace
+- bundle exec rspec spec/
+deploy:
+  provider: heroku
+  api_key:
+    secure: WrQxf0fEKkCdXrjcejurobOnNNz3he4dDwjBbToXbQTQNDObPp7NetJrLsfM8FiUFEeOuvhIHHiDQtMvY720zGGAGxDptvgFS+0QHCUqoTRZA/yFfUmHlG2jROXTzk5uVK0AE4k6Ion5kX8+mM0EnMT/7u+MTFiukrJctSiEXfg=
+  app: tranquil-basin-3130
+  on:
+    repo: Growstuff/growstuff
+    branch: travis_deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,7 @@ deploy:
   on:
     repo: Growstuff/growstuff
     branch: travis_deploy
+  run:
+    - "rake db:migrate"
+    - "script/deploy-tasks.sh"
+    - restart

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ before_script:
 script:
 - bundle exec rake db:migrate --trace
 - bundle exec rspec spec/
+before_deploy:
+  - heroku maintenance:on
 deploy:
   provider: heroku
   api_key:
@@ -21,3 +23,5 @@ deploy:
     - "rake db:migrate"
     - "script/deploy-tasks.sh"
     - restart
+after_deploy:
+  - heroku maintenance:on

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ deploy:
   provider: heroku
   api_key:
     secure: WrQxf0fEKkCdXrjcejurobOnNNz3he4dDwjBbToXbQTQNDObPp7NetJrLsfM8FiUFEeOuvhIHHiDQtMvY720zGGAGxDptvgFS+0QHCUqoTRZA/yFfUmHlG2jROXTzk5uVK0AE4k6Ion5kX8+mM0EnMT/7u+MTFiukrJctSiEXfg=
-  app: tranquil-basin-3130
   on:
     repo: Growstuff/growstuff
   app:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ deploy:
   on:
     repo: Growstuff/growstuff
   app:
-    master: growstuff-prod
     dev: growstuff-staging
     travis_deploy: tranquil-basin-3130
   run:


### PR DESCRIPTION
A stab at #491. If you click "merge" on this PR then it *should* deploy recent changes to growstuff-staging and run migrations and the current deploy-tasks.sh. I haven't tested it on the dev branch, but [here's an example of it successfully deploying to my sandbox app](https://travis-ci.org/Growstuff/growstuff/builds/47582713).

This doesn't totally meet the spec, unfortunately:

 - it doesn't turn maintenance mode on for the duration of deployments (see https://travis-ci.org/Growstuff/growstuff/builds/47577519 and https://travis-ci.org/Growstuff/growstuff/builds/47580792 for two failed attempts at doing this). http://xseignard.github.io/2013/02/18/continuous-deployement-with-github-travis-and-heroku-for-node.js/ suggests a possible approach to turning on maintenance mode, but that looks unpleasantly hand-rolled.
 - it doesn't set environment variables on the heroku dynos (the `figaro` step in [the release management guidelines](http://wiki.growstuff.org/index.php/Release_management#Deploying_new_features_to_staging)), because I'm not sure how to expose them to Travis securely. Perhaps we could use [Travis' secure variables](http://docs.travis-ci.com/user/environment-variables/#Secure-Variables)? Not sure how that would work, TBH.

I've left the code in for deploying the `travis_deploy` branch to http://tranquil-basin-3130.herokuapp.com, which is an instance of Growstuff running on my Heroku account. We'll want to remove it eventually, but I suspect we'll need a deployment sandbox while we work through the issues on this PR :-)