### PR TITLE
Deployment from Travis containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,10 @@ deploy:
   app: tranquil-basin-3130
   on:
     repo: Growstuff/growstuff
-    branch: travis_deploy
+  app:
+    master: growstuff-prod
+    dev: growstuff-staging
+    travis_deploy: tranquil-basin-3130
   run:
     - "rake db:migrate"
     - "script/deploy-tasks.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,18 @@
----
 language: ruby
-
 env: GROWSTUFF_SITE_NAME="Growstuff (travis)" RAILS_SECRET_TOKEN='xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
-bundler_args: --without development production staging
+bundler_args: "--without development production staging"
 rvm:
-  - 2.1.5
+- 2.1.5
 before_script:
-  - psql -c 'create database growstuff_test;' -U postgres
+- psql -c 'create database growstuff_test;' -U postgres
 script:
-  - bundle exec rake db:migrate --trace
-  - bundle exec rspec spec/
+- bundle exec rake db:migrate --trace
+- bundle exec rspec spec/
+deploy:
+  provider: heroku
+  api_key:
+    secure: WrQxf0fEKkCdXrjcejurobOnNNz3he4dDwjBbToXbQTQNDObPp7NetJrLsfM8FiUFEeOuvhIHHiDQtMvY720zGGAGxDptvgFS+0QHCUqoTRZA/yFfUmHlG2jROXTzk5uVK0AE4k6Ion5kX8+mM0EnMT/7u+MTFiukrJctSiEXfg=
+  app: tranquil-basin-3130
+  on:
+    repo: Growstuff/growstuff
+    branch: travis_deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,7 @@ deploy:
   on:
     repo: Growstuff/growstuff
     branch: travis_deploy
+  run:
+    - "rake db:migrate"
+    - "script/deploy-tasks.sh"
+    - restart

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: ruby
 env: GROWSTUFF_SITE_NAME="Growstuff (travis)" RAILS_SECRET_TOKEN='xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
 bundler_args: "--without development production staging"
@@ -8,8 +9,6 @@ before_script:
 script:
 - bundle exec rake db:migrate --trace
 - bundle exec rspec spec/
-before_deploy:
-  - heroku maintenance:on
 deploy:
   provider: heroku
   api_key:
@@ -23,5 +22,3 @@ deploy:
     - "rake db:migrate"
     - "script/deploy-tasks.sh"
     - restart
-after_deploy:
-  - heroku maintenance:on

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ before_script:
 script:
 - bundle exec rake db:migrate --trace
 - bundle exec rspec spec/
+before_deploy:
+  - heroku maintenance:on
 deploy:
   provider: heroku
   api_key:
@@ -21,3 +23,5 @@ deploy:
     - "rake db:migrate"
     - "script/deploy-tasks.sh"
     - restart
+after_deploy:
+  - heroku maintenance:on

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: ruby
+cache: bundler
 env: GROWSTUFF_SITE_NAME="Growstuff (travis)" RAILS_SECRET_TOKEN='xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
 bundler_args: "--without development production staging"
 rvm:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ deploy:
   provider: heroku
   api_key:
     secure: WrQxf0fEKkCdXrjcejurobOnNNz3he4dDwjBbToXbQTQNDObPp7NetJrLsfM8FiUFEeOuvhIHHiDQtMvY720zGGAGxDptvgFS+0QHCUqoTRZA/yFfUmHlG2jROXTzk5uVK0AE4k6Ion5kX8+mM0EnMT/7u+MTFiukrJctSiEXfg=
-  app: tranquil-basin-3130
   on:
     repo: Growstuff/growstuff
   app:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 sudo: false
 language: ruby
 cache: bundler
-env: GROWSTUFF_SITE_NAME="Growstuff (travis)" RAILS_SECRET_TOKEN='xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+env:
+  matrix:
+    - GROWSTUFF_SITE_NAME="Growstuff (travis)" RAILS_SECRET_TOKEN='xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+  global:
+    secure: "Z5TpM2jEX4UCvNePnk/LwltQX48U2u9BRc+Iypr1x9QW2o228QJhPIOH39a8RMUrepGnkQIq9q3ZRUn98RfrJz1yThtlNFL3NmzdQ57gKgjGwfpa0e4Dwj/ZJqV2D84tDGjvdVYLP7zzaYZxQcwk/cgNpzKf/jq97HLNP7CYuf4="
 bundler_args: "--without development production staging"
 rvm:
 - 2.1.5
@@ -10,6 +14,8 @@ before_script:
 script:
 - bundle exec rake db:migrate --trace
 - bundle exec rspec spec/
+before_deploy:
+  - bundle exec script/heroku_maintenance.rb on
 deploy:
   provider: heroku
   api_key:
@@ -19,7 +25,10 @@ deploy:
   app:
     dev: growstuff-staging
     travis_deploy: tranquil-basin-3130
+    travis_containers: tranquil-basin-3130
   run:
     - "rake db:migrate"
     - "script/deploy-tasks.sh"
     - restart
+after_deploy:
+  - bundle exec script/heroku_maintenance.rb off

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ deploy:
   on:
     repo: Growstuff/growstuff
   app:
-    master: growstuff-prod
     dev: growstuff-staging
     travis_deploy: tranquil-basin-3130
   run:

--- a/Gemfile
+++ b/Gemfile
@@ -109,3 +109,7 @@ group :development, :test do
   gem 'poltergeist', '~> 1.5.1'         # for headless JS testing
   gem 'i18n-tasks'                      # adds tests for finding missing and unused translations
 end
+
+group :travis do
+  gem 'heroku-api'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,7 @@ GEM
       thread
       thread_safe
     erubis (2.7.0)
+    excon (0.43.0)
     execjs (2.2.2)
     factory_girl (4.5.0)
       activesupport (>= 3.0.0)
@@ -136,6 +137,9 @@ GEM
       html2haml (>= 1.0.1)
       railties (>= 4.0.1)
     hashie (3.3.2)
+    heroku-api (0.3.22)
+      excon (~> 0.38)
+      multi_json (~> 1.8)
     highline (1.6.21)
     hike (1.2.3)
     hpricot (0.8.6)
@@ -356,6 +360,7 @@ DEPENDENCIES
   gravatar-ultimate
   haml
   haml-rails
+  heroku-api
   i18n-tasks
   jquery-rails
   jquery-ui-rails (~> 5.0.2)

--- a/script/heroku_maintenance.rb
+++ b/script/heroku_maintenance.rb
@@ -1,0 +1,27 @@
+#!/usr/bin/env ruby
+
+require 'heroku-api'
+
+heroku = Heroku::API.new(:api_key => ENV['HEROKU_API_KEY'])
+branch = ENV['TRAVIS_BRANCH']
+case branch
+when 'master'
+  app = 'growstuff-prod'
+when 'dev'
+  app = 'growstuff-staging'
+when 'travis_deploy', 'travis_containers'
+  app = 'tranquil-basin-3130'
+else
+  abort "No Heroku app found for branch #{branch}"
+end
+
+case ARGV[0]
+when "on"
+  maintenance_state = 1
+when "off"
+  maintenance_state = 0
+else
+  abort "usage: #{$0} (on|off)"
+end
+
+heroku.post_app_maintenance(app, maintenance_state)

--- a/script/heroku_maintenance.rb
+++ b/script/heroku_maintenance.rb
@@ -1,16 +1,13 @@
 #!/usr/bin/env ruby
 
 require 'heroku-api'
+require 'yaml'
 
 heroku = Heroku::API.new(:api_key => ENV['HEROKU_API_KEY'])
 branch = ENV['TRAVIS_BRANCH']
-case branch
-when 'master'
-  app = 'growstuff-prod'
-when 'dev'
-  app = 'growstuff-staging'
-when 'travis_deploy', 'travis_containers'
-  app = 'tranquil-basin-3130'
+travis_config = YAML.load_file('.travis.yml')
+if travis_config['deploy']['app'].has_key? branch
+  app = travis_config['deploy']['app'][branch]
 else
   abort "No Heroku app found for branch #{branch}"
 end
@@ -24,4 +21,5 @@ else
   abort "usage: #{$0} (on|off)"
 end
 
+puts "Turning #{maintenance_state} maintenance mode on app #{app}"
 heroku.post_app_maintenance(app, maintenance_state)


### PR DESCRIPTION
This is (I think) an improvement over #661 in two ways:
 - it caches the results of `bundle install`, speeding up builds by a factor of around 2.5
 - it doesn't install the whole Heroku toolbelt, which felt like overkill.

It turns maintenance mode on for deployment (and off again afterwards!), but doesn't try to update the environment variables on the Heroku dyno. It also duplicates the branch => app name logic, which is ugly. Perhaps we could parse .travis.yml in `heroku_maintenance.rb`? **Edit** fixed in 5755245.