### PR TITLE
Crop request

### DIFF
--- a/app/controllers/crops_controller.rb
+++ b/app/controllers/crops_controller.rb
@@ -169,6 +169,6 @@ class CropsController < ApplicationController
   private
 
   def crop_params
-    params.require(:crop).permit(:en_wikipedia_url, :name, :parent_id, :creator_id, :approval_status, :request_notes, :reason_for_rejection, :scientific_names_attributes => [:scientific_name])
+    params.require(:crop).permit(:en_wikipedia_url, :name, :parent_id, :creator_id, :approval_status, :request_notes, :reason_for_rejection, :scientific_names_attributes => [:scientific_name, :_destroy, :id])
   end
 end

--- a/app/controllers/crops_controller.rb
+++ b/app/controllers/crops_controller.rb
@@ -32,7 +32,8 @@ class CropsController < ApplicationController
 
   # GET /crops/wrangle
   def wrangle
-    @crops = Crop.recent.paginate(:page => params[:page])
+    @recent_crops = Crop.recent.paginate(:page => params[:page])
+    @pending_approval = Crop.pending_approval
     @crop_wranglers = Role.crop_wranglers
     respond_to do |format|
       format.html

--- a/app/controllers/crops_controller.rb
+++ b/app/controllers/crops_controller.rb
@@ -106,9 +106,11 @@ class CropsController < ApplicationController
 
     if current_member.has_role? :crop_wrangler
       @crop.creator = current_member
+      success_msg = "Crop was successfully created."
     else
       @crop.requester = current_member
       @crop.approval_status = "pending"
+      success_msg = "Crop was successfully requested."
     end
 
     respond_to do |format|
@@ -119,7 +121,7 @@ class CropsController < ApplicationController
           end
         end
 
-        format.html { redirect_to @crop, notice: 'Crop was successfully created.' }
+        format.html { redirect_to @crop, notice: success_msg }
         format.json { render json: @crop, status: :created, location: @crop }
       else
         format.html { render action: "new" }

--- a/app/controllers/crops_controller.rb
+++ b/app/controllers/crops_controller.rb
@@ -147,6 +147,8 @@ class CropsController < ApplicationController
 
     previous_status = @crop.approval_status
 
+    @crop.creator = current_member if previous_status == "pending"
+
     respond_to do |format|
       if @crop.update(crop_params)
         if previous_status == "pending"

--- a/app/controllers/crops_controller.rb
+++ b/app/controllers/crops_controller.rb
@@ -101,8 +101,14 @@ class CropsController < ApplicationController
   # POST /crops
   # POST /crops.json
   def create
-    params[:crop][:creator_id] = current_member.id
     @crop = Crop.new(crop_params)
+
+    if current_member.has_role? :crop_wrangler
+      @crop.creator = current_member
+    else
+      @crop.requester = current_member
+      @crop.approved = false
+    end
 
     respond_to do |format|
       if @crop.save

--- a/app/controllers/crops_controller.rb
+++ b/app/controllers/crops_controller.rb
@@ -133,8 +133,15 @@ class CropsController < ApplicationController
   def update
     @crop = Crop.find(params[:id])
 
+    previous_status = @crop.approval_status
+
     respond_to do |format|
       if @crop.update(crop_params)
+        if previous_status == "pending"
+          requester = @crop.requester
+          new_status = @crop.approval_status
+          Notifier.crop_request_approved(requester, @crop).deliver! if new_status == "approved"
+        end
         format.html { redirect_to @crop, notice: 'Crop was successfully updated.' }
         format.json { head :no_content }
       else

--- a/app/controllers/crops_controller.rb
+++ b/app/controllers/crops_controller.rb
@@ -113,6 +113,12 @@ class CropsController < ApplicationController
 
     respond_to do |format|
       if @crop.save
+        if current_member.has_role? :crop_wrangler
+          Role.crop_wranglers.each do |w|
+            Notifier.new_crop_request(w, @crop).deliver!
+          end
+        end
+
         format.html { redirect_to @crop, notice: 'Crop was successfully created.' }
         format.json { render json: @crop, status: :created, location: @crop }
       else

--- a/app/controllers/crops_controller.rb
+++ b/app/controllers/crops_controller.rb
@@ -108,7 +108,7 @@ class CropsController < ApplicationController
       @crop.creator = current_member
     else
       @crop.requester = current_member
-      @crop.approved = false
+      @crop.approval_status = "pending"
     end
 
     respond_to do |format|
@@ -159,6 +159,6 @@ class CropsController < ApplicationController
   private
 
   def crop_params
-    params.require(:crop).permit(:en_wikipedia_url, :name, :parent_id, :creator_id, :scientific_names_attributes => [:scientific_name])
+    params.require(:crop).permit(:en_wikipedia_url, :name, :parent_id, :creator_id, :approval_status, :scientific_names_attributes => [:scientific_name])
   end
 end

--- a/app/controllers/crops_controller.rb
+++ b/app/controllers/crops_controller.rb
@@ -167,6 +167,6 @@ class CropsController < ApplicationController
   private
 
   def crop_params
-    params.require(:crop).permit(:en_wikipedia_url, :name, :parent_id, :creator_id, :approval_status, :reason_for_rejection, :scientific_names_attributes => [:scientific_name])
+    params.require(:crop).permit(:en_wikipedia_url, :name, :parent_id, :creator_id, :approval_status, :request_notes, :reason_for_rejection, :scientific_names_attributes => [:scientific_name])
   end
 end

--- a/app/controllers/crops_controller.rb
+++ b/app/controllers/crops_controller.rb
@@ -141,6 +141,7 @@ class CropsController < ApplicationController
           requester = @crop.requester
           new_status = @crop.approval_status
           Notifier.crop_request_approved(requester, @crop).deliver! if new_status == "approved"
+          Notifier.crop_request_rejected(requester, @crop).deliver! if new_status == "rejected"
         end
         format.html { redirect_to @crop, notice: 'Crop was successfully updated.' }
         format.json { head :no_content }
@@ -166,6 +167,6 @@ class CropsController < ApplicationController
   private
 
   def crop_params
-    params.require(:crop).permit(:en_wikipedia_url, :name, :parent_id, :creator_id, :approval_status, :scientific_names_attributes => [:scientific_name])
+    params.require(:crop).permit(:en_wikipedia_url, :name, :parent_id, :creator_id, :approval_status, :reason_for_rejection, :scientific_names_attributes => [:scientific_name])
   end
 end

--- a/app/controllers/crops_controller.rb
+++ b/app/controllers/crops_controller.rb
@@ -32,8 +32,18 @@ class CropsController < ApplicationController
 
   # GET /crops/wrangle
   def wrangle
-    @recent_crops = Crop.recent.paginate(:page => params[:page])
-    @pending_approval = Crop.pending_approval
+    @approval_status = params[:approval_status]
+    case @approval_status
+    when "pending"
+      @crops = Crop.pending_approval
+    when "rejected"
+      @crops = Crop.rejected
+    else
+      @crops = Crop.recent
+    end
+
+    @crops = @crops.paginate(:page => params[:page])
+
     @crop_wranglers = Role.crop_wranglers
     respond_to do |format|
       format.html

--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -27,4 +27,9 @@ class Notifier < ActionMailer::Base
     mail(:to => @member.email, :subject => "New crop request")    
   end
 
+  def crop_request_approved(member, crop)
+    @member, @crop = member, crop
+    mail(:to => @member.email, :subject => "#{crop.name.capitalize} has been approved")
+  end
+
 end

--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -22,4 +22,9 @@ class Notifier < ActionMailer::Base
     end
   end
 
+  def new_crop_request(member, request)
+    @member, @request = member, request
+    mail(:to => @member.email, :subject => "New crop request")    
+  end
+
 end

--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -32,4 +32,9 @@ class Notifier < ActionMailer::Base
     mail(:to => @member.email, :subject => "#{crop.name.capitalize} has been approved")
   end
 
+  def crop_request_rejected(member, crop)
+    @member, @crop = member, crop
+    mail(:to => @member.email, :subject => "#{crop.name.capitalize} has been rejected")
+  end
+
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -22,7 +22,7 @@ class Ability
     cannot :read, AccountType
 
     # and nobody should be able to view these expect admins and crop wranglers
-    cannot :read, Crop, :approval_status => "rejected"
+    cannot :read, Crop, :approval_status => ["rejected", "pending"]
 
     if member
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -23,6 +23,9 @@ class Ability
 
     # and nobody should be able to view these expect admins and crop wranglers
     cannot :read, Crop, :approval_status => ["rejected", "pending"]
+    # # ... unless the current member is also the requester
+    # can :read, Crop, :requester_id => member.id
+    # can :read, Crop, :approval_status => "approved"
 
     if member
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -45,6 +45,9 @@ class Ability
         can :manage, AlternateName
       end
 
+      # any member can create a crop provisionally
+      can :create, Crop
+
       # can create & destroy their own authentications against other sites.
       can :create, Authentication
       can :destroy, Authentication, :member_id => member.id

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -21,6 +21,9 @@ class Ability
     cannot :read, Account
     cannot :read, AccountType
 
+    # and nobody should be able to view these expect admins and crop wranglers
+    cannot :read, Crop, :approval_status => "rejected"
+
     if member
 
       # managing your own user settings

--- a/app/models/crop.rb
+++ b/app/models/crop.rb
@@ -105,6 +105,10 @@ class Crop < ActiveRecord::Base
     return true
   end
 
+  def pending?
+    approval_status == "pending"
+  end
+
   # Crop.interesting
   # returns a list of interesting crops, for use on the homepage etc
   def Crop.interesting

--- a/app/models/crop.rb
+++ b/app/models/crop.rb
@@ -21,11 +21,11 @@ class Crop < ActiveRecord::Base
   has_and_belongs_to_many :posts
   before_destroy {|crop| crop.posts.clear}
 
-  default_scope { where(:approved => true).order("lower(name) asc") }
-  scope :recent, -> { reorder("created_at desc") }
-  scope :toplevel, -> { where(:parent_id => nil) }
-  scope :popular, -> { reorder("plantings_count desc, lower(name) asc") }
-  scope :randomized, -> { reorder('random()') } # ok on sqlite and psql, but not on mysql
+  default_scope { order("lower(name) asc") }
+  scope :recent, -> { where(:approved => true).reorder("created_at desc") }
+  scope :toplevel, -> { where(approved => true, :parent_id => nil) }
+  scope :popular, -> { where(:approved => true).reorder("plantings_count desc, lower(name) asc") }
+  scope :randomized, -> { where(:approved => true).reorder('random()') } # ok on sqlite and psql, but not on mysql
   scope :pending_approval, -> { where(:approved => false) }
 
   validates :en_wikipedia_url,

--- a/app/models/crop.rb
+++ b/app/models/crop.rb
@@ -26,6 +26,7 @@ class Crop < ActiveRecord::Base
   scope :toplevel, -> { where(:parent_id => nil) }
   scope :popular, -> { reorder("plantings_count desc, lower(name) asc") }
   scope :randomized, -> { reorder('random()') } # ok on sqlite and psql, but not on mysql
+  scope :pending_approval, -> { where(:approved => false) }
 
   validates :en_wikipedia_url,
     :format => {

--- a/app/models/crop.rb
+++ b/app/models/crop.rb
@@ -32,7 +32,8 @@ class Crop < ActiveRecord::Base
     :format => {
       :with => /\Ahttps?:\/\/en\.wikipedia\.org\/wiki/,
       :message => 'is not a valid English Wikipedia URL'
-    }
+    },
+    :if => :approved?
 
   def to_s
     return name
@@ -107,6 +108,10 @@ class Crop < ActiveRecord::Base
 
   def pending?
     approval_status == "pending"
+  end
+
+  def approved?
+    approval_status == "approved"
   end
 
   # Crop.interesting

--- a/app/models/crop.rb
+++ b/app/models/crop.rb
@@ -14,6 +14,7 @@ class Crop < ActiveRecord::Base
   has_many :harvests
   has_many :plant_parts, -> { uniq }, :through => :harvests
   belongs_to :creator, :class_name => 'Member'
+  belongs_to :creator, :class_name => 'Member'
 
   belongs_to :parent, :class_name => 'Crop'
   has_many :varieties, :class_name => 'Crop', :foreign_key => 'parent_id'

--- a/app/models/crop.rb
+++ b/app/models/crop.rb
@@ -21,14 +21,15 @@ class Crop < ActiveRecord::Base
   has_and_belongs_to_many :posts
   before_destroy {|crop| crop.posts.clear}
 
-  default_scope { where(:approval_status => "approved").order("lower(name) asc") }
-  scope :recent, -> { reorder("created_at desc") }
-  scope :toplevel, -> { where(:parent_id => nil) }
-  scope :popular, -> { reorder("plantings_count desc, lower(name) asc") }
-  scope :randomized, -> { reorder('random()') } # ok on sqlite and psql, but not on mysql
+  default_scope { order("lower(name) asc") }
+  scope :recent, -> { where(:approval_status => "approved").reorder("created_at desc") }
+  scope :toplevel, -> { where(:approval_status => "approved", :parent_id => nil) }
+  scope :popular, -> { where(:approval_status => "approved").reorder("plantings_count desc, lower(name) asc") }
+  scope :randomized, -> { where(:approval_status => "approved").reorder('random()') } # ok on sqlite and psql, but not on mysql
   scope :pending_approval, -> { where(:approval_status => "pending") }
   scope :rejected, -> { where(:approval_status => "rejected") }
 
+  ## Wikipedia urls are only necessary when approving a crop
   validates :en_wikipedia_url,
     :format => {
       :with => /\Ahttps?:\/\/en\.wikipedia\.org\/wiki/,
@@ -36,8 +37,10 @@ class Crop < ActiveRecord::Base
     },
     :if => :approved?
 
+  ## Reasons are only necessary when rejecting
   validates :reason_for_rejection, :presence => true, :if => :rejected?
 
+  ## This validation addresses a race condition
   validate :approval_status_cannot_be_changed_again
 
   def to_s
@@ -237,7 +240,6 @@ class Crop < ActiveRecord::Base
 
   # Custom validations
 
-  # This validation addresses a race condition
   def approval_status_cannot_be_changed_again
     previous = previous_changes.include?(:approval_status) ? previous_changes.approval_status : {}
     if previous.include?(:rejected) || previous.include?(:approved)

--- a/app/models/crop.rb
+++ b/app/models/crop.rb
@@ -21,7 +21,7 @@ class Crop < ActiveRecord::Base
   has_and_belongs_to_many :posts
   before_destroy {|crop| crop.posts.clear}
 
-  default_scope { order("lower(name) asc") }
+  default_scope { where(:approved => true).order("lower(name) asc") }
   scope :recent, -> { reorder("created_at desc") }
   scope :toplevel, -> { where(:parent_id => nil) }
   scope :popular, -> { reorder("plantings_count desc, lower(name) asc") }

--- a/app/models/crop.rb
+++ b/app/models/crop.rb
@@ -37,6 +37,8 @@ class Crop < ActiveRecord::Base
 
   validates :reason_for_rejection, :presence => true, :if => :rejected?
 
+  validate :approval_status_cannot_be_changed_again
+
   def to_s
     return name
   end
@@ -230,6 +232,15 @@ class Crop < ActiveRecord::Base
   # just uses SQL LIKE for now, but can be made fancier later
   def self.search(query)
     where("name ILIKE ?", "%#{query}%")
+  end
+
+  # Custom validations
+
+  # This validation addresses a race condition
+  def approval_status_cannot_be_changed_again
+    if rejected? || approved?
+      errors.add(:approval_status, "has already been set to #{approval_status}")
+    end
   end
 
 end

--- a/app/models/crop.rb
+++ b/app/models/crop.rb
@@ -21,11 +21,11 @@ class Crop < ActiveRecord::Base
   has_and_belongs_to_many :posts
   before_destroy {|crop| crop.posts.clear}
 
-  default_scope { order("lower(name) asc") }
-  scope :recent, -> { where(:approval_status => "approved").reorder("created_at desc") }
-  scope :toplevel, -> { where(:approval_status => "approved", :parent_id => nil) }
-  scope :popular, -> { where(:approval_status => "approved").reorder("plantings_count desc, lower(name) asc") }
-  scope :randomized, -> { where(:approval_status => "approved").reorder('random()') } # ok on sqlite and psql, but not on mysql
+  default_scope { where(:approval_status => "approved").order("lower(name) asc") }
+  scope :recent, -> { reorder("created_at desc") }
+  scope :toplevel, -> { where(:parent_id => nil) }
+  scope :popular, -> { reorder("plantings_count desc, lower(name) asc") }
+  scope :randomized, -> { reorder('random()') } # ok on sqlite and psql, but not on mysql
   scope :pending_approval, -> { where(:approval_status => "pending") }
   scope :rejected, -> { where(:approval_status => "rejected") }
 

--- a/app/models/crop.rb
+++ b/app/models/crop.rb
@@ -35,6 +35,8 @@ class Crop < ActiveRecord::Base
     },
     :if => :approved?
 
+  validates :reason_for_rejection, :presence => true, :if => :rejected?
+
   def to_s
     return name
   end
@@ -112,6 +114,10 @@ class Crop < ActiveRecord::Base
 
   def approved?
     approval_status == "approved"
+  end
+
+  def rejected?
+    approval_status == "rejected"
   end
 
   # Crop.interesting

--- a/app/models/crop.rb
+++ b/app/models/crop.rb
@@ -14,7 +14,7 @@ class Crop < ActiveRecord::Base
   has_many :harvests
   has_many :plant_parts, -> { uniq }, :through => :harvests
   belongs_to :creator, :class_name => 'Member'
-  belongs_to :creator, :class_name => 'Member'
+  belongs_to :requester, :class_name => 'Member'
 
   belongs_to :parent, :class_name => 'Crop'
   has_many :varieties, :class_name => 'Crop', :foreign_key => 'parent_id'

--- a/app/models/crop.rb
+++ b/app/models/crop.rb
@@ -22,11 +22,11 @@ class Crop < ActiveRecord::Base
   before_destroy {|crop| crop.posts.clear}
 
   default_scope { order("lower(name) asc") }
-  scope :recent, -> { where(:approved => true).reorder("created_at desc") }
-  scope :toplevel, -> { where(approved => true, :parent_id => nil) }
-  scope :popular, -> { where(:approved => true).reorder("plantings_count desc, lower(name) asc") }
-  scope :randomized, -> { where(:approved => true).reorder('random()') } # ok on sqlite and psql, but not on mysql
-  scope :pending_approval, -> { where(:approved => false) }
+  scope :recent, -> { where(:approval_status => "approved").reorder("created_at desc") }
+  scope :toplevel, -> { where(approval_status => "approved", :parent_id => nil) }
+  scope :popular, -> { where(:approval_status => "approved").reorder("plantings_count desc, lower(name) asc") }
+  scope :randomized, -> { where(:approval_status => "approved").reorder('random()') } # ok on sqlite and psql, but not on mysql
+  scope :pending_approval, -> { where(:approval_status => "pending") }
 
   validates :en_wikipedia_url,
     :format => {

--- a/app/models/crop.rb
+++ b/app/models/crop.rb
@@ -120,6 +120,10 @@ class Crop < ActiveRecord::Base
     approval_status == "rejected"
   end
 
+  def approval_statuses
+    [ 'rejected', 'pending', 'approved' ]
+  end
+
   def reasons_for_rejection
     [ "already in database", "not edible", "not enough information", "other" ]
   end

--- a/app/models/crop.rb
+++ b/app/models/crop.rb
@@ -120,6 +120,10 @@ class Crop < ActiveRecord::Base
     approval_status == "rejected"
   end
 
+  def reasons_for_rejection
+    [ "already in database", "not edible", "not enough information", "other" ]
+  end
+
   # Crop.interesting
   # returns a list of interesting crops, for use on the homepage etc
   def Crop.interesting

--- a/app/models/crop.rb
+++ b/app/models/crop.rb
@@ -23,7 +23,7 @@ class Crop < ActiveRecord::Base
 
   default_scope { order("lower(name) asc") }
   scope :recent, -> { where(:approval_status => "approved").reorder("created_at desc") }
-  scope :toplevel, -> { where(approval_status => "approved", :parent_id => nil) }
+  scope :toplevel, -> { where(:approval_status => "approved", :parent_id => nil) }
   scope :popular, -> { where(:approval_status => "approved").reorder("plantings_count desc, lower(name) asc") }
   scope :randomized, -> { where(:approval_status => "approved").reorder('random()') } # ok on sqlite and psql, but not on mysql
   scope :pending_approval, -> { where(:approval_status => "pending") }

--- a/app/views/crops/_form.html.haml
+++ b/app/views/crops/_form.html.haml
@@ -51,7 +51,7 @@
       .form-group
         = f.label :approval_status, 'Approval Status', :class=> 'control-label col-md-2'
         .col-md-8
-          = f.select(:approval_status, ['rejected', 'pending', 'approved'], {}, {:class => 'form-control'})
+          = f.select(:approval_status, @crop.approval_statuses, {}, {:class => 'form-control'})
 
       .form-group
         = f.label :reason_for_rejection, 'Reason for rejection', :class => 'control-label col-md-2'

--- a/app/views/crops/_form.html.haml
+++ b/app/views/crops/_form.html.haml
@@ -47,5 +47,10 @@
       = f.select(:approval_status, ['rejected', 'pending', 'approved'], {}, {:class => 'form-control'})
 
   .form-group
+    = f.label :reason_for_rejection, 'Reason for rejection', :class => 'control-label col-md-2'
+    .col-md-8= f.text_area :reason_for_rejection, :rows => 6, :class => 'form-control'
+
+
+  .form-group
     .form-actions.col-md-offset-2.col-md-8
       = f.submit 'Save', :class => 'btn btn-primary'

--- a/app/views/crops/_form.html.haml
+++ b/app/views/crops/_form.html.haml
@@ -18,12 +18,21 @@
     = f.label :name, :class => 'control-label col-md-2'
     .col-md-8
       = f.text_field :name, :class => 'form-control'
-      %span.help-block Name in US English; singular; capitalize proper nouns only.
+      %span.help-block 
+        - if can? :wrangle, @crop 
+          Name in US English; singular; capitalize proper nouns only.
+        - else 
+          Please provide the common name for the crop, in English, if you know it.
+
   .form-group
     = f.label :en_wikipedia_url, 'Wikipedia URL', :class => 'control-label col-md-2'
     .col-md-8
       = f.text_field :en_wikipedia_url, :class => 'form-control'
-      %span.help-block Link to this crop's page on the English language Wikipedia.
+      %span.help-block 
+        - if can? :wrangle, @crop
+          Link to this crop's page on the English language Wikipedia.
+        - else
+          Please provide a link to the crop's page on the English language Wikipedia. Crops without Wikipedia pages cannot be added to our database at this time.
 
   - if can? :wrangle, @crop 
 
@@ -67,7 +76,9 @@
       = f.label :request_notes, 'Comments', :class => 'control-label col-md-2'
       .col-md-8= f.text_area :request_notes, :rows => 6, :class => 'form-control'
 
-
+    %p
+      %span.help-block
+        When you submit this form, your suggestion will be sent to our team of #{link_to 'volunteer crop wranglers', 'http://talk.growstuff.org/c/crop-wrangling'} for review. We'll let you know the outcome as soon as we can.
 
   .form-group
     .form-actions.col-md-offset-2.col-md-8

--- a/app/views/crops/_form.html.haml
+++ b/app/views/crops/_form.html.haml
@@ -27,28 +27,31 @@
     .col-md-8
       = collection_select(:crop, :parent_id, Crop.all, :id, :name, {:include_blank => true}, :class => 'form-control')
       %span.help-block Optional. For setting up crop hierarchies for varieties etc.
-  %p
-    %span.help-block
-      You may enter up to 3 scientific names for a crop. Most crops will have only one.
-  = f.fields_for :scientific_names do |sn|
-    .form-group
-      = sn.label :scientific_name, "Scientific name", :class => 'control-label col-md-2'
-      .col-md-8
-        = sn.text_field :scientific_name, :class => 'form-control'
-      .col-md-2
-        - if sn.object && sn.object.persisted?
-          %label.checkbox
-            = sn.check_box :_destroy
-            = sn.label :_destroy, "Delete"
 
-  .form-group
-    = f.label :approval_status, 'Approval Status', :class=> 'control-label col-md-2'
-    .col-md-8
-      = f.select(:approval_status, ['rejected', 'pending', 'approved'], {}, {:class => 'form-control'})
+  - if can? :wrangle, @crop 
+    %p
+      %span.help-block
+        You may enter up to 3 scientific names for a crop. Most crops will have only one.
+    = f.fields_for :scientific_names do |sn|
+      .form-group
+        = sn.label :scientific_name, "Scientific name", :class => 'control-label col-md-2'
+        .col-md-8
+          = sn.text_field :scientific_name, :class => 'form-control'
+        .col-md-2
+          - if sn.object && sn.object.persisted?
+            %label.checkbox
+              = sn.check_box :_destroy
+              = sn.label :_destroy, "Delete"
 
-  .form-group
-    = f.label :reason_for_rejection, 'Reason for rejection', :class => 'control-label col-md-2'
-    .col-md-8= f.text_area :reason_for_rejection, :rows => 6, :class => 'form-control'
+    - unless @crop.new_record?
+      .form-group
+        = f.label :approval_status, 'Approval Status', :class=> 'control-label col-md-2'
+        .col-md-8
+          = f.select(:approval_status, ['rejected', 'pending', 'approved'], {}, {:class => 'form-control'})
+
+      .form-group
+        = f.label :reason_for_rejection, 'Reason for rejection', :class => 'control-label col-md-2'
+        .col-md-8= f.text_area :reason_for_rejection, :rows => 6, :class => 'form-control'
 
 
   .form-group

--- a/app/views/crops/_form.html.haml
+++ b/app/views/crops/_form.html.haml
@@ -40,6 +40,12 @@
           %label.checkbox
             = sn.check_box :_destroy
             = sn.label :_destroy, "Delete"
+
+  .form-group
+    = f.label :approval_status, 'Approval Status', :class=> 'control-label col-md-2'
+    .col-md-8
+      = f.select(:approval_status, ['rejected', 'pending', 'approved'], {}, {:class => 'form-control'})
+
   .form-group
     .form-actions.col-md-offset-2.col-md-8
       = f.submit 'Save', :class => 'btn btn-primary'

--- a/app/views/crops/_form.html.haml
+++ b/app/views/crops/_form.html.haml
@@ -47,7 +47,7 @@
               = sn.check_box :_destroy
               = sn.label :_destroy, "Delete"
 
-    - unless @crop.new_record?
+    - unless @crop.new_record? || !@crop.pending?
       .form-group
         = f.label :approval_status, 'Approval Status', :class=> 'control-label col-md-2'
         .col-md-8

--- a/app/views/crops/_form.html.haml
+++ b/app/views/crops/_form.html.haml
@@ -47,7 +47,7 @@
               = sn.check_box :_destroy
               = sn.label :_destroy, "Delete"
 
-    - unless @crop.new_record? || !@crop.pending?
+    - unless @crop.new_record?
       .form-group
         = f.label :approval_status, 'Approval Status', :class=> 'control-label col-md-2'
         .col-md-8

--- a/app/views/crops/_form.html.haml
+++ b/app/views/crops/_form.html.haml
@@ -6,11 +6,13 @@
         - @crop.errors.full_messages.each do |msg|
           %li= msg
 
-  %p
-    %span.help-block
-      For detailed crop wrangling guidelines, please consult the
-      =link_to "crop wrangling guide", "http://wiki.growstuff.org/index.php/Crop_wrangling"
-      on the Growstuff wiki.
+  - if can? :wrangle, @crop
+    %p
+      %span.help-block
+        For detailed crop wrangling guidelines, please consult the
+
+        =link_to "crop wrangling guide", "http://wiki.growstuff.org/index.php/Crop_wrangling"
+        on the Growstuff wiki.
 
   .form-group
     = f.label :name, :class => 'control-label col-md-2'
@@ -22,13 +24,15 @@
     .col-md-8
       = f.text_field :en_wikipedia_url, :class => 'form-control'
       %span.help-block Link to this crop's page on the English language Wikipedia.
-  .form-group
-    = f.label :parent_id, 'Parent crop', :class => 'control-label col-md-2'
-    .col-md-8
-      = collection_select(:crop, :parent_id, Crop.all, :id, :name, {:include_blank => true}, :class => 'form-control')
-      %span.help-block Optional. For setting up crop hierarchies for varieties etc.
 
   - if can? :wrangle, @crop 
+
+    .form-group
+      = f.label :parent_id, 'Parent crop', :class => 'control-label col-md-2'
+      .col-md-8
+        = collection_select(:crop, :parent_id, Crop.all, :id, :name, {:include_blank => true}, :class => 'form-control')
+        %span.help-block Optional. For setting up crop hierarchies for varieties etc.
+
     %p
       %span.help-block
         You may enter up to 3 scientific names for a crop. Most crops will have only one.
@@ -52,6 +56,16 @@
       .form-group
         = f.label :reason_for_rejection, 'Reason for rejection', :class => 'control-label col-md-2'
         .col-md-8= f.text_area :reason_for_rejection, :rows => 6, :class => 'form-control'
+
+  - else
+    %p
+      %span.help-block
+        Provide any additional information that might help us assess your request.
+
+    .form-group
+      = f.label :request_notes, 'Comments', :class => 'control-label col-md-2'
+      .col-md-8= f.text_area :request_notes, :rows => 6, :class => 'form-control'
+
 
 
   .form-group

--- a/app/views/crops/_form.html.haml
+++ b/app/views/crops/_form.html.haml
@@ -55,7 +55,8 @@
 
       .form-group
         = f.label :reason_for_rejection, 'Reason for rejection', :class => 'control-label col-md-2'
-        .col-md-8= f.text_area :reason_for_rejection, :rows => 6, :class => 'form-control'
+        .col-md-8
+          = f.select(:reason_for_rejection, @crop.reasons_for_rejection, {:include_blank => true}, {:class => 'form-control'})
 
   - else
     %p

--- a/app/views/crops/edit.html.haml
+++ b/app/views/crops/edit.html.haml
@@ -1,4 +1,4 @@
-- content_for :title, "Editing crop"
+- content_for :title, "Review crop: #{@crop.name}"
 
 %p
   Added by

--- a/app/views/crops/new.html.haml
+++ b/app/views/crops/new.html.haml
@@ -1,3 +1,14 @@
-- content_for :title, "New crop"
+- content_for :title, (can?(:wrangle, @crop) ? "New crop" : "Suggest a crop") 
+
+- unless can? :wrangler, @crop
+  
+  %p Thanks for taking the time to suggest a crop! Our crop database is managed by volunteers, and we appreciate your help. Here are some things to consider when suggesting a new crop:
+
+  %ul
+    %li First, you might want to search our crops to make sure we don't have it already, perhaps under an alternate name.
+
+    %li The Growstuff database only contains edible crops. In future we hope to support other crops, but for now, if your suggestion is not edible we won't be able to add it.
+
+    %li At this time, we are only adding crops which have a Wikipedia page. If you want to add a specific variety of crop that doesn't have its own Wikipedia entry, please use the more general form of the crop instead and put the name of your variety in the notes/description.
 
 = render 'form'

--- a/app/views/crops/new.html.haml
+++ b/app/views/crops/new.html.haml
@@ -5,7 +5,7 @@
   %p Thanks for taking the time to suggest a crop! Our crop database is managed by volunteers, and we appreciate your help. Here are some things to consider when suggesting a new crop:
 
   %ul
-    %li First, you might want to search our crops to make sure we don't have it already, perhaps under an alternate name.
+    %li First, you might want to #{link_to 'search our crops', crops_search_path} to make sure we don't have it already, perhaps under an alternate name.
 
     %li The Growstuff database only contains edible crops. In future we hope to support other crops, but for now, if your suggestion is not edible we won't be able to add it.
 

--- a/app/views/crops/show.html.haml
+++ b/app/views/crops/show.html.haml
@@ -1,5 +1,14 @@
 - content_for :title, @crop.name
 - content_for :subtitle, @crop.default_scientific_name
+
+- if can?(:wrangle, @crop) && @crop.pending?
+  .alert.alert-warning
+    %b This crop is currently pending approval.
+    - if @crop.request_notes
+      %p
+        Request notes: #{@crop.request_notes}
+  
+
 - content_for :buttonbar do
   - if can? :create, Planting
     = link_to "Plant this", new_planting_path(:crop_id => @crop.id), :class => 'btn btn-default'

--- a/app/views/crops/show.html.haml
+++ b/app/views/crops/show.html.haml
@@ -1,7 +1,7 @@
 - content_for :title, @crop.name
 - content_for :subtitle, @crop.default_scientific_name
 
-- if can?(:wrangle, @crop) && @crop.pending?
+- if @crop.pending?
   .alert.alert-warning
     %b This crop is currently pending approval.
     %p This crop was requested by #{@crop.requester} on #{@crop.created_at}.

--- a/app/views/crops/show.html.haml
+++ b/app/views/crops/show.html.haml
@@ -8,7 +8,10 @@
     - unless @crop.request_notes.blank?
       %p
         Request notes: #{@crop.request_notes}
-  
+
+- if @crop.rejected?
+  .alert.alert-warning
+    %b This crop was rejected for the following reason: #{@crop.reason_for_rejection}.
 
 - content_for :buttonbar do
   - if can? :create, Planting

--- a/app/views/crops/show.html.haml
+++ b/app/views/crops/show.html.haml
@@ -4,7 +4,8 @@
 - if can?(:wrangle, @crop) && @crop.pending?
   .alert.alert-warning
     %b This crop is currently pending approval.
-    - if @crop.request_notes
+    %p This crop was requested by #{@crop.requester} on #{@crop.created_at}.
+    - unless @crop.request_notes.blank?
       %p
         Request notes: #{@crop.request_notes}
   

--- a/app/views/crops/wrangle.html.haml
+++ b/app/views/crops/wrangle.html.haml
@@ -37,7 +37,7 @@
   = page_entries_info @crops, :model => "crops"
   = will_paginate @crops
 
-%table#recently-added.table.table-striped
+%table{:class => "table table-striped", :id => @approval_status.blank? ? 'recently-added-crops' : "#{@approval_status}-crops"}
   %tr
     %th System name
     %th English Wikipedia URL

--- a/app/views/crops/wrangle.html.haml
+++ b/app/views/crops/wrangle.html.haml
@@ -15,11 +15,35 @@
       %li.crop_wrangler
         = link_to crop_wrangler.login_name, crop_wrangler
 
+%h2 Requested crops
+
+%table.table.table-striped
+  %thead
+    %tr
+      %th System name
+      %th English Wikipedia URL
+      %th Scientific names
+      %th Requested by
+      %th When requested
+  %tbody
+    - @pending_approval.each do |c| 
+      %tr
+        %td= link_to c.name, c
+        %td= link_to c.en_wikipedia_url, c.en_wikipedia_url
+        %td
+          - c.scientific_names.each do |s|
+            = link_to s.scientific_name, s
+            %br/
+        %td= link_to c.requester, c.requester
+        %td
+          = distance_of_time_in_words(c.created_at, Time.zone.now)
+          ago.
+
 %h2 Recently added crops
 
 %div.pagination
-  = page_entries_info @crops, :model => "crops"
-  = will_paginate @crops
+  = page_entries_info @recent_crops, :model => "crops"
+  = will_paginate @recent_crops
 
 %table.table.table-striped
   %tr
@@ -28,7 +52,7 @@
     %th Scientific names
     %th Added by
     %th When
-  - @crops.each do |c|
+  - @recent_crops.each do |c|
     %tr
       %td= link_to c.name, c
       %td= link_to c.en_wikipedia_url, c.en_wikipedia_url
@@ -42,5 +66,5 @@
         ago.
 
 %div.pagination
-  = page_entries_info @crops, :model => "crops"
-  = will_paginate @crops
+  = page_entries_info @recent_crops, :model => "crops"
+  = will_paginate @recent_crops

--- a/app/views/crops/wrangle.html.haml
+++ b/app/views/crops/wrangle.html.haml
@@ -17,7 +17,7 @@
 
 %h2 Requested crops
 
-%table.table.table-striped
+%table#requested-crops.table.table-striped
   %thead
     %tr
       %th System name

--- a/app/views/crops/wrangle.html.haml
+++ b/app/views/crops/wrangle.html.haml
@@ -15,47 +15,42 @@
       %li.crop_wrangler
         = link_to crop_wrangler.login_name, crop_wrangler
 
-%h2 Requested crops
+.tabbable
+  %ul.nav.nav-tabs
+    %li{:class => @approval_status.blank? ? 'active' : ''}
+      = link_to "Recendly added", wrangle_crops_path
+    %li{:class => @approval_status == "pending" ? 'active' : ''}
+      = link_to "Pending approval", wrangle_crops_path(:approval_status => "pending")
+    %li{:class => @approval_status == "rejected" ? 'active' : ''}
+      = link_to "Rejected", wrangle_crops_path(:approval_status => "rejected")
 
-- if @pending_approval
-  %table#requested-crops.table.table-striped
-    %thead
-      %tr
-        %th System name
-        %th English Wikipedia URL
-        %th Scientific names
-        %th Requested by
-        %th When requested
-    %tbody
-      - @pending_approval.each do |c| 
-        %tr
-          %td= link_to c.name, c
-          %td= link_to c.en_wikipedia_url, c.en_wikipedia_url
-          %td
-            - c.scientific_names.each do |s|
-              = link_to s.scientific_name, s
-              %br/
-          %td= link_to c.requester, c.requester
-          %td
-            = distance_of_time_in_words(c.created_at, Time.zone.now)
-            ago.
-- else
-  %p There are no crops pending approval.
+%h2 
+  - if @approval_status == "pending"
+    Requested Crops
+  - elsif @approval_status == "rejected"
+    Rejected Crops
+  - else
+    Recently added crops
 
-%h2 Recently added crops
 
 %div.pagination
-  = page_entries_info @recent_crops, :model => "crops"
-  = will_paginate @recent_crops
+  = page_entries_info @crops, :model => "crops"
+  = will_paginate @crops
 
 %table#recently-added.table.table-striped
   %tr
     %th System name
     %th English Wikipedia URL
     %th Scientific names
-    %th Added by
+    %th 
+      - if @approval_status == "pending"
+        Requested by
+      - elsif @approval_status == "rejected"
+        Rejected by
+      - else
+        Added by
     %th When
-  - @recent_crops.each do |c|
+  - @crops.each do |c|
     %tr
       %td= link_to c.name, c
       %td= link_to c.en_wikipedia_url, c.en_wikipedia_url
@@ -63,11 +58,17 @@
         - c.scientific_names.each do |s|
           = link_to s.scientific_name, s
           %br/
-      %td= link_to c.creator, c.creator
+      %td
+        - if @approval_status == "pending"
+          = link_to c.requester, c.requester
+        - else
+          = link_to c.creator, c.creator
       %td
         = distance_of_time_in_words(c.created_at, Time.zone.now)
         ago.
 
 %div.pagination
-  = page_entries_info @recent_crops, :model => "crops"
-  = will_paginate @recent_crops
+  = page_entries_info @crops, :model => "crops"
+  = will_paginate @crops
+
+

--- a/app/views/crops/wrangle.html.haml
+++ b/app/views/crops/wrangle.html.haml
@@ -17,27 +17,30 @@
 
 %h2 Requested crops
 
-%table#requested-crops.table.table-striped
-  %thead
-    %tr
-      %th System name
-      %th English Wikipedia URL
-      %th Scientific names
-      %th Requested by
-      %th When requested
-  %tbody
-    - @pending_approval.each do |c| 
+- if @pending_approval
+  %table#requested-crops.table.table-striped
+    %thead
       %tr
-        %td= link_to c.name, c
-        %td= link_to c.en_wikipedia_url, c.en_wikipedia_url
-        %td
-          - c.scientific_names.each do |s|
-            = link_to s.scientific_name, s
-            %br/
-        %td= link_to c.requester, c.requester
-        %td
-          = distance_of_time_in_words(c.created_at, Time.zone.now)
-          ago.
+        %th System name
+        %th English Wikipedia URL
+        %th Scientific names
+        %th Requested by
+        %th When requested
+    %tbody
+      - @pending_approval.each do |c| 
+        %tr
+          %td= link_to c.name, c
+          %td= link_to c.en_wikipedia_url, c.en_wikipedia_url
+          %td
+            - c.scientific_names.each do |s|
+              = link_to s.scientific_name, s
+              %br/
+          %td= link_to c.requester, c.requester
+          %td
+            = distance_of_time_in_words(c.created_at, Time.zone.now)
+            ago.
+- else
+  %p There are no crops pending approval.
 
 %h2 Recently added crops
 
@@ -45,7 +48,7 @@
   = page_entries_info @recent_crops, :model => "crops"
   = will_paginate @recent_crops
 
-%table.table.table-striped
+%table#recently-added.table.table-striped
   %tr
     %th System name
     %th English Wikipedia URL

--- a/app/views/notifier/crop_request_approved.html.haml
+++ b/app/views/notifier/crop_request_approved.html.haml
@@ -1,0 +1,13 @@
+- site_name = ENV['GROWSTUFF_SITE_NAME']
+%p Hello #{@member.login_name},
+
+%p
+  Your request for the new crop: #{link_to @crop.name, crop_url(@crop)} has been approved!
+
+%ul
+  %li
+    = link_to "Plant #{@crop.name}", new_planting_url(crop_id: @crop.id)
+  %li
+    = link_to "Harvest #{@crop.name}", new_harvest_url(crop_id: @crop.id)
+  %li
+    = link_to "Stash seeds for #{@crop.name}", new_seed_url(crop_id: @crop.id)

--- a/app/views/notifier/crop_request_rejected.html.haml
+++ b/app/views/notifier/crop_request_rejected.html.haml
@@ -1,0 +1,7 @@
+- site_name = ENV['GROWSTUFF_SITE_NAME']
+%p Hello #{@member.login_name},
+
+%p
+  Your request for the new crop: #{link_to @crop.name, crop_url(@crop)} has been rejected for the following reason.
+
+  = @crop.reason_for_rejection

--- a/app/views/notifier/new_crop_request.html.haml
+++ b/app/views/notifier/new_crop_request.html.haml
@@ -1,0 +1,7 @@
+- site_name = ENV['GROWSTUFF_SITE_NAME']
+%p Hello #{@member.login_name},
+
+%p
+  A new crop has been requested. View, edit, approve or reject the request:
+
+  = link_to "Request for #{@request}", crop_url(@request)

--- a/db/migrate/20150130224814_add_requester_and_approved_to_crops.rb
+++ b/db/migrate/20150130224814_add_requester_and_approved_to_crops.rb
@@ -1,0 +1,7 @@
+class AddRequesterAndApprovedToCrops < ActiveRecord::Migration
+  def change
+    add_column :crops, :requester_id, :integer
+    add_column :crops, :approved, :boolean, default: true
+    add_index :crops, :requester_id
+  end
+end

--- a/db/migrate/20150130224814_add_requester_and_approved_to_crops.rb
+++ b/db/migrate/20150130224814_add_requester_and_approved_to_crops.rb
@@ -1,7 +1,0 @@
-class AddRequesterAndApprovedToCrops < ActiveRecord::Migration
-  def change
-    add_column :crops, :requester_id, :integer
-    add_column :crops, :approved, :boolean, default: true
-    add_index :crops, :requester_id
-  end
-end

--- a/db/migrate/20150130224814_add_requester_to_crops.rb
+++ b/db/migrate/20150130224814_add_requester_to_crops.rb
@@ -1,0 +1,6 @@
+class AddRequesterToCrops < ActiveRecord::Migration
+  def change
+    add_column :crops, :requester_id, :integer
+    add_index :crops, :requester_id
+  end
+end

--- a/db/migrate/20150201053200_add_approval_status_to_crops.rb
+++ b/db/migrate/20150201053200_add_approval_status_to_crops.rb
@@ -1,0 +1,5 @@
+class AddApprovalStatusToCrops < ActiveRecord::Migration
+  def change
+    add_column :crops, :approval_status, :string, default: "approved"
+  end
+end

--- a/db/migrate/20150201062506_add_reason_for_rejection_to_crops.rb
+++ b/db/migrate/20150201062506_add_reason_for_rejection_to_crops.rb
@@ -1,0 +1,5 @@
+class AddReasonForRejectionToCrops < ActiveRecord::Migration
+  def change
+    add_column :crops, :reason_for_rejection, :text
+  end
+end

--- a/db/migrate/20150201064502_add_request_notes_to_crops.rb
+++ b/db/migrate/20150201064502_add_request_notes_to_crops.rb
@@ -1,0 +1,5 @@
+class AddRequestNotesToCrops < ActiveRecord::Migration
+  def change
+    add_column :crops, :request_notes, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150130224814) do
+ActiveRecord::Schema.define(version: 20150201053200) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -62,16 +62,16 @@ ActiveRecord::Schema.define(version: 20150130224814) do
   end
 
   create_table "crops", force: true do |t|
-    t.string   "name",                            null: false
+    t.string   "name",                                  null: false
     t.string   "en_wikipedia_url"
-    t.datetime "created_at",                      null: false
-    t.datetime "updated_at",                      null: false
+    t.datetime "created_at",                            null: false
+    t.datetime "updated_at",                            null: false
     t.string   "slug"
     t.integer  "parent_id"
     t.integer  "plantings_count",  default: 0
     t.integer  "creator_id"
     t.integer  "requester_id"
-    t.boolean  "approved",         default: true
+    t.string   "approval_status",  default: "approved"
   end
 
   add_index "crops", ["name"], name: "index_crops_on_name", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150201062506) do
+ActiveRecord::Schema.define(version: 20150201064502) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -73,6 +73,7 @@ ActiveRecord::Schema.define(version: 20150201062506) do
     t.integer  "requester_id"
     t.string   "approval_status",      default: "approved"
     t.text     "reason_for_rejection"
+    t.text     "request_notes"
   end
 
   add_index "crops", ["name"], name: "index_crops_on_name", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150127043022) do
+ActiveRecord::Schema.define(version: 20150130224814) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -62,17 +62,20 @@ ActiveRecord::Schema.define(version: 20150127043022) do
   end
 
   create_table "crops", force: true do |t|
-    t.string   "name",                         null: false
+    t.string   "name",                            null: false
     t.string   "en_wikipedia_url"
-    t.datetime "created_at",                   null: false
-    t.datetime "updated_at",                   null: false
+    t.datetime "created_at",                      null: false
+    t.datetime "updated_at",                      null: false
     t.string   "slug"
     t.integer  "parent_id"
     t.integer  "plantings_count",  default: 0
     t.integer  "creator_id"
+    t.integer  "requester_id"
+    t.boolean  "approved",         default: true
   end
 
   add_index "crops", ["name"], name: "index_crops_on_name", using: :btree
+  add_index "crops", ["requester_id"], name: "index_crops_on_requester_id", using: :btree
   add_index "crops", ["slug"], name: "index_crops_on_slug", unique: true, using: :btree
 
   create_table "crops_posts", id: false, force: true do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150201053200) do
+ActiveRecord::Schema.define(version: 20150201062506) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -62,16 +62,17 @@ ActiveRecord::Schema.define(version: 20150201053200) do
   end
 
   create_table "crops", force: true do |t|
-    t.string   "name",                                  null: false
+    t.string   "name",                                      null: false
     t.string   "en_wikipedia_url"
-    t.datetime "created_at",                            null: false
-    t.datetime "updated_at",                            null: false
+    t.datetime "created_at",                                null: false
+    t.datetime "updated_at",                                null: false
     t.string   "slug"
     t.integer  "parent_id"
-    t.integer  "plantings_count",  default: 0
+    t.integer  "plantings_count",      default: 0
     t.integer  "creator_id"
     t.integer  "requester_id"
-    t.string   "approval_status",  default: "approved"
+    t.string   "approval_status",      default: "approved"
+    t.text     "reason_for_rejection"
   end
 
   add_index "crops", ["name"], name: "index_crops_on_name", using: :btree

--- a/spec/controllers/crops_controller_spec.rb
+++ b/spec/controllers/crops_controller_spec.rb
@@ -7,7 +7,8 @@ describe CropsController do
   def valid_attributes
     {
       :name => "Tomato",
-      :en_wikipedia_url => 'http://en.wikipedia.org/wiki/Tomato'
+      :en_wikipedia_url => 'http://en.wikipedia.org/wiki/Tomato',
+      :approval_status => 'approved'
     }
   end
 

--- a/spec/factories/crop.rb
+++ b/spec/factories/crop.rb
@@ -66,6 +66,7 @@ FactoryGirl.define do
 
     factory :rejected_crop do
       name "Fail bean"
+      approval_status "rejected"
       reason_for_rejection "Totally fake"
     end
 

--- a/spec/factories/crop.rb
+++ b/spec/factories/crop.rb
@@ -59,6 +59,11 @@ FactoryGirl.define do
       name "Ultra berry"
     end
 
+    factory :rejected_crop do
+      name "Fail bean"
+      reason_for_rejection "Totally fake"
+    end
+
   end
 
 end

--- a/spec/factories/crop.rb
+++ b/spec/factories/crop.rb
@@ -54,6 +54,11 @@ FactoryGirl.define do
       name "Swiss chard"
     end
 
+    #for testing crop request
+    factory :crop_request do
+      name "Ultra berry"
+    end
+
   end
 
 end

--- a/spec/factories/crop.rb
+++ b/spec/factories/crop.rb
@@ -57,6 +57,10 @@ FactoryGirl.define do
     #for testing crop request
     factory :crop_request do
       name "Ultra berry"
+      en_wikipedia_url ""
+      approval_status "pending"
+      association :requester, factory: :member
+      request_notes "Please approve this even though it's fake."
     end
 
     factory :rejected_crop do

--- a/spec/factories/crop.rb
+++ b/spec/factories/crop.rb
@@ -3,6 +3,7 @@ FactoryGirl.define do
   factory :crop do
     name "magic bean"
     en_wikipedia_url "http://en.wikipedia.org/wiki/Magic_bean"
+    approval_status "approved"
     creator
 
     factory :tomato do

--- a/spec/features/crops/crop_wranglers_spec.rb
+++ b/spec/features/crops/crop_wranglers_spec.rb
@@ -5,6 +5,8 @@ feature "crop wranglers" do
     let!(:crop_wranglers) { FactoryGirl.create_list(:crop_wrangling_member, 3) }
     let(:wrangler){crop_wranglers.first}
     let!(:crops) { FactoryGirl.create_list(:crop, 2) }
+    let!(:requested_crop) { FactoryGirl.create(:crop_request) }
+    let!(:rejected_crop) { FactoryGirl.create(:rejected_crop) }
 
     background do
       login_as(wrangler)
@@ -25,7 +27,7 @@ feature "crop wranglers" do
     scenario "can see list of crops with extra detail of who created a crop" do
       visit root_path
       click_link 'Crop Wrangling'
-      within '#recently-added' do
+      within '#recently-added-crops' do
         expect(page).to have_content "#{crops.first.creator.login_name}"
       end
     end
@@ -48,6 +50,24 @@ feature "crop wranglers" do
       expect(page).to have_content 'Crop was successfully created'
       expect(page).to have_content 'planticus maximus'
     end
+
+    scenario "View pending crops" do
+      visit wrangle_crops_path(:approval_status => "pending")
+      within "#pending-crops" do
+        click_link "Ultra berry"
+      end
+      expect(page).to have_content "This crop is currently pending approval."
+      expect(page).to have_content "Please approve this even though it's fake."
+    end
+
+    scenario "View rejected crops" do
+      visit wrangle_crops_path(:approval_status => "rejected")
+      within "#rejected-crops" do
+        click_link "Fail bean"
+      end
+      expect(page).to have_content "This crop was rejected for the following reason: Totally fake"
+    end
+
     
   end
   

--- a/spec/features/crops/crop_wranglers_spec.rb
+++ b/spec/features/crops/crop_wranglers_spec.rb
@@ -25,7 +25,7 @@ feature "crop wranglers" do
     scenario "can see list of crops with extra detail of who created a crop" do
       visit root_path
       click_link 'Crop Wrangling'
-      within '.table' do
+      within '#recently-added' do
         expect(page).to have_content "#{crops.first.creator.login_name}"
       end
     end

--- a/spec/features/crops/request_new_crop_spec.rb
+++ b/spec/features/crops/request_new_crop_spec.rb
@@ -26,16 +26,6 @@ feature "Requesting a new crop" do
 
     before { login_as wrangler }
 
-    scenario "View pending crops" do
-      visit wrangle_crops_path
-      within "#requested-crops" do
-        expect(page).to have_content "Ultra berry"
-      end
-      click_link "Ultra berry"
-      expect(page).to have_content "This crop is currently pending approval."
-      expect(page).to have_content "Please approve this even though it's fake."
-    end
-
     scenario "Approve a request" do
       visit edit_crop_path(crop)
       select "approved", from: "Approval Status"
@@ -49,6 +39,7 @@ feature "Requesting a new crop" do
     scenario "Rejecting a crop" do
       visit edit_crop_path(crop)
       select "rejected", from: "Approval Status"
+      select "not edible", from: "Reason for rejection"
       click_button "Save"
       expect(page).to have_content "Crop was successfully updated."
     end

--- a/spec/features/crops/request_new_crop_spec.rb
+++ b/spec/features/crops/request_new_crop_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+feature "Requesting a new crop" do
+
+  context "As a regular member" do
+
+    let(:member) { FactoryGirl.create(:member) }
+
+    before { login_as member }
+
+    scenario "Submit request" do
+      visit new_crop_path
+      fill_in "Name", with: "Couch potato"
+      fill_in "Comments", with: "Couch are real for real."
+      click_button "Save"
+      expect(page).to have_content "Crop was successfully requested."
+    end
+
+  end
+
+  context "As a crop wrangler" do
+
+    let(:wrangler) { FactoryGirl.create(:crop_wrangling_member) }
+    let!(:crop) { FactoryGirl.create(:crop_request) }
+
+    before { login_as wrangler }
+
+    scenario "View pending crops" do
+      visit wrangle_crops_path
+      within "#requested-crops" do
+        expect(page).to have_content "Ultra berry"
+      end
+      click_link "Ultra berry"
+      expect(page).to have_content "This crop is currently pending approval."
+      expect(page).to have_content "Please approve this even though it's fake."
+    end
+
+    scenario "Approve a request" do
+      visit edit_crop_path(crop)
+      select "approved", from: "Approval Status"
+      click_button "Save"
+      expect(page).to have_content "En wikipedia url is not a valid English Wikipedia URL"
+      fill_in "Wikipedia URL", with: "http://en.wikipedia.org/wiki/Aung_San_Suu_Kyi"
+      click_button "Save"
+      expect(page).to have_content "Crop was successfully updated."
+    end
+
+    scenario "Rejecting a crop" do
+      visit edit_crop_path(crop)
+      select "rejected", from: "Approval Status"
+      click_button "Save"
+      expect(page).to have_content "Crop was successfully updated."
+    end
+
+  end
+
+end

--- a/spec/features/crops/request_new_crop_spec.rb
+++ b/spec/features/crops/request_new_crop_spec.rb
@@ -22,6 +22,7 @@ feature "Requesting a new crop" do
 
     let(:wrangler) { FactoryGirl.create(:crop_wrangling_member) }
     let!(:crop) { FactoryGirl.create(:crop_request) }
+    let!(:already_approved) { FactoryGirl.create(:crop) }
 
     before { login_as wrangler }
 

--- a/spec/mailers/notifier_spec.rb
+++ b/spec/mailers/notifier_spec.rb
@@ -97,5 +97,31 @@ describe Notifier do
 
   end
 
+  describe "crop rejected" do
+    let(:member) { FactoryGirl.create(:member) }
+    let(:crop) { FactoryGirl.create(:rejected_crop) }
+    let(:mail) { Notifier.crop_request_rejected(member, crop) }
+
+    it 'sets the subject correctly' do
+      expect(mail.subject).to eq "Fail bean has been rejected"
+    end
+
+    it 'comes from noreply@growstuff.org' do
+      expect(mail.from).to eq ['noreply@growstuff.org']
+    end
+
+    it 'sends the mail to the recipient of the notification' do
+      expect(mail.to).to eq [member.email]
+    end
+
+    it 'includes the rejected crop URL' do
+      expect(mail.body.encoded).to match crop_url(crop)
+    end
+
+    it 'includes the reason for rejection' do
+      expect(mail.body.encoded).to match "Totally fake"
+    end
+  end
+
 
 end

--- a/spec/mailers/notifier_spec.rb
+++ b/spec/mailers/notifier_spec.rb
@@ -44,4 +44,29 @@ describe Notifier do
     end
 
   end
+
+
+  describe "new crop request" do
+    let(:member) { FactoryGirl.create(:crop_wrangling_member) }
+    let(:crop) { FactoryGirl.create(:crop_request) }
+    let(:mail) { Notifier.new_crop_request(member, crop) }
+
+    it 'sets the subject correctly' do
+      mail.subject.should == "New crop request"
+    end
+
+    it 'comes from noreply@growstuff.org' do
+      mail.from.should == ['noreply@growstuff.org']
+    end
+
+    it 'sends the mail to the recipient of the notification' do
+      mail.to.should == [member.email]
+    end
+
+    it 'includes the requested crop URL' do
+      mail.body.encoded.should match crop_url(crop)
+    end
+
+  end
+
 end

--- a/spec/mailers/notifier_spec.rb
+++ b/spec/mailers/notifier_spec.rb
@@ -90,9 +90,9 @@ describe Notifier do
     end
 
     it 'includes links to plant, harvest and stash seeds for the new crop' do
-      expect(mail.body.encoded).to match new_planting_url(crop_id: crop.id)
-      expect(mail.body.encoded).to match new_harvest_url(crop_id: crop.id)
-      expect(mail.body.encoded).to match new_seed_url(crop_id: crop.id)
+      expect(mail.body.encoded).to match new_planting_url
+      expect(mail.body.encoded).to match new_harvest_url
+      expect(mail.body.encoded).to match new_seed_url
     end
 
   end

--- a/spec/mailers/notifier_spec.rb
+++ b/spec/mailers/notifier_spec.rb
@@ -66,7 +66,36 @@ describe Notifier do
     it 'includes the requested crop URL' do
       mail.body.encoded.should match crop_url(crop)
     end
+  end
+
+  describe "crop approved" do
+    let(:member) { FactoryGirl.create(:member) }
+    let(:crop) { FactoryGirl.create(:crop) }
+    let(:mail) { Notifier.crop_request_approved(member, crop) }
+
+    it 'sets the subject correctly' do
+      expect(mail.subject).to eq "Magic bean has been approved"
+    end
+
+    it 'comes from noreply@growstuff.org' do
+      expect(mail.from).to eq ['noreply@growstuff.org']
+    end
+
+    it 'sends the mail to the recipient of the notification' do
+      expect(mail.to).to eq [member.email]
+    end
+
+    it 'includes the approved crop URL' do
+      expect(mail.body.encoded).to match crop_url(crop)
+    end
+
+    it 'includes links to plant, harvest and stash seeds for the new crop' do
+      expect(mail.body.encoded).to match new_planting_url(crop_id: crop.id)
+      expect(mail.body.encoded).to match new_harvest_url(crop_id: crop.id)
+      expect(mail.body.encoded).to match new_seed_url(crop_id: crop.id)
+    end
 
   end
+
 
 end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -45,9 +45,12 @@ describe Ability do
 
     context "standard member" do
       it "can't manage crops" do
-        @ability.should_not be_able_to(:create, Crop)
         @ability.should_not be_able_to(:update, @crop)
         @ability.should_not be_able_to(:destroy, @crop)
+      end
+
+      it "can request crops" do
+        @ability.should be_able_to(:create, Crop)
       end
 
       it "can read crops" do

--- a/spec/views/crops/wrangle.html.haml_spec.rb
+++ b/spec/views/crops/wrangle.html.haml_spec.rb
@@ -12,7 +12,7 @@ describe "crops/wrangle" do
     crops = WillPaginate::Collection.create(page, per_page, total_entries) do |pager|
       pager.replace([ @tomato, @maize ])
     end
-    assign(:crops, crops)
+    assign(:recent_crops, crops)
     assign(:crop_wranglers, Role.crop_wranglers)
   end
 

--- a/spec/views/crops/wrangle.html.haml_spec.rb
+++ b/spec/views/crops/wrangle.html.haml_spec.rb
@@ -12,7 +12,7 @@ describe "crops/wrangle" do
     crops = WillPaginate::Collection.create(page, per_page, total_entries) do |pager|
       pager.replace([ @tomato, @maize ])
     end
-    assign(:recent_crops, crops)
+    assign(:crops, crops)
     assign(:crop_wranglers, Role.crop_wranglers)
   end
 


### PR DESCRIPTION
Fixes #602

**WIP: Needs feedback**

1. Is the language natural enough for regular members on the new crops form page?

2. Should we use Javascript to pop up the reason for rejection only when `approval_status` is "rejected" on the edit crops form?

3. Is the `reason_for_rejection` required if rejected?

4. Should the reasons for rejection be hardcoded in the model or should they be in a database table? (Database seems to make more sense. That way, if a wrangler selects "other" as a reason, wranglers can be presented the option to create a new reason.)

5. How should we avoid race conditions? Should we simply prevent a wrangler from marking a crop rejected if it's already approved and vice versa - with a descriptive error message?

6. Should it be impossible to navigate to rejected crop by going to it's url directly? Should rejected crops be listed anywhere?