### PR TITLE
make the one-off save the si weight

### DIFF
--- a/lib/tasks/growstuff.rake
+++ b/lib/tasks/growstuff.rake
@@ -319,6 +319,7 @@ namespace :growstuff do
     task :populate_si_weight => :environment do
       Harvest.find_each do |h|
         h.set_si_weight
+        h.save
       end
     end
 


### PR DESCRIPTION
fix the deploy task for standard weights feature