### PR TITLE
add deprecation notice to all controller and view specs

### DIFF
--- a/spec/controllers/account_types_controller_spec.rb
+++ b/spec/controllers/account_types_controller_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe AccountTypesController do

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe AccountsController do

--- a/spec/controllers/admin/orders_controller_spec.rb
+++ b/spec/controllers/admin/orders_controller_spec.rb
@@ -1,3 +1,20 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
+
 require 'rails_helper'
 
 describe Admin::OrdersController do

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe AdminController do

--- a/spec/controllers/authentications_controller_spec.rb
+++ b/spec/controllers/authentications_controller_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe AuthenticationsController do

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe CommentsController do

--- a/spec/controllers/crops_controller_spec.rb
+++ b/spec/controllers/crops_controller_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe CropsController do

--- a/spec/controllers/forums_controller_spec.rb
+++ b/spec/controllers/forums_controller_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe ForumsController do

--- a/spec/controllers/gardens_controller_spec.rb
+++ b/spec/controllers/gardens_controller_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe GardensController do

--- a/spec/controllers/harvests_controller_spec.rb
+++ b/spec/controllers/harvests_controller_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe HarvestsController do

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe HomeController do

--- a/spec/controllers/member_controller_spec.rb
+++ b/spec/controllers/member_controller_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe MembersController do

--- a/spec/controllers/notifications_controller_spec.rb
+++ b/spec/controllers/notifications_controller_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe NotificationsController do

--- a/spec/controllers/order_items_controller_spec.rb
+++ b/spec/controllers/order_items_controller_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe OrderItemsController do

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe OrdersController do

--- a/spec/controllers/photos_controller_spec.rb
+++ b/spec/controllers/photos_controller_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe PhotosController do

--- a/spec/controllers/places_controller_spec.rb
+++ b/spec/controllers/places_controller_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe PlacesController do

--- a/spec/controllers/plant_parts_controller_spec.rb
+++ b/spec/controllers/plant_parts_controller_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe PlantPartsController do

--- a/spec/controllers/plantings_controller_spec.rb
+++ b/spec/controllers/plantings_controller_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe PlantingsController do

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe PostsController do

--- a/spec/controllers/products_controller_spec.rb
+++ b/spec/controllers/products_controller_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe ProductsController do

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe RegistrationsController do

--- a/spec/controllers/roles_controller_spec.rb
+++ b/spec/controllers/roles_controller_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe RolesController do

--- a/spec/controllers/scientific_names_controller_spec.rb
+++ b/spec/controllers/scientific_names_controller_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe ScientificNamesController do

--- a/spec/controllers/seeds_controller_spec.rb
+++ b/spec/controllers/seeds_controller_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe SeedsController do

--- a/spec/controllers/shop_controller_spec.rb
+++ b/spec/controllers/shop_controller_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe ShopController do

--- a/spec/views/about/contact_spec.rb
+++ b/spec/views/about/contact_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe 'about/contact.html.haml', :type => "view" do

--- a/spec/views/account_types/edit.html.haml_spec.rb
+++ b/spec/views/account_types/edit.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "account_types/edit" do

--- a/spec/views/account_types/index.html.haml_spec.rb
+++ b/spec/views/account_types/index.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "account_types/index" do

--- a/spec/views/account_types/new.html.haml_spec.rb
+++ b/spec/views/account_types/new.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "account_types/new" do

--- a/spec/views/account_types/show.html.haml_spec.rb
+++ b/spec/views/account_types/show.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "account_types/show" do

--- a/spec/views/accounts/edit.html.haml_spec.rb
+++ b/spec/views/accounts/edit.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "accounts/edit" do

--- a/spec/views/accounts/index.html.haml_spec.rb
+++ b/spec/views/accounts/index.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "accounts/index" do

--- a/spec/views/accounts/new.html.haml_spec.rb
+++ b/spec/views/accounts/new.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "accounts/new" do

--- a/spec/views/accounts/show.html.haml_spec.rb
+++ b/spec/views/accounts/show.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "accounts/show" do

--- a/spec/views/admin/index_spec.rb
+++ b/spec/views/admin/index_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe 'admin/index.html.haml', :type => "view" do

--- a/spec/views/admin/newsletter_spec.rb
+++ b/spec/views/admin/newsletter_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe 'admin/newsletter.html.haml', :type => "view" do

--- a/spec/views/admin/orders/index_spec.rb
+++ b/spec/views/admin/orders/index_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe 'admin/orders/index.html.haml', :type => "view" do

--- a/spec/views/comments/edit.html.haml_spec.rb
+++ b/spec/views/comments/edit.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "comments/edit" do

--- a/spec/views/comments/index.html.haml_spec.rb
+++ b/spec/views/comments/index.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "comments/index" do

--- a/spec/views/comments/index.rss.haml_spec.rb
+++ b/spec/views/comments/index.rss.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe 'comments/index.rss.haml' do

--- a/spec/views/comments/new.html.haml_spec.rb
+++ b/spec/views/comments/new.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "comments/new" do

--- a/spec/views/comments/show.html.haml_spec.rb
+++ b/spec/views/comments/show.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "comments/show" do

--- a/spec/views/crops/_grown_for.html.haml_spec.rb
+++ b/spec/views/crops/_grown_for.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "crops/_grown_for" do

--- a/spec/views/crops/_planting_advice.html.haml_spec.rb
+++ b/spec/views/crops/_planting_advice.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "crops/_planting_advice" do

--- a/spec/views/crops/_popover.html.haml_spec.rb
+++ b/spec/views/crops/_popover.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "crops/_popover" do

--- a/spec/views/crops/edit.html.haml_spec.rb
+++ b/spec/views/crops/edit.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "crops/edit" do

--- a/spec/views/crops/hierarchy.html.haml_spec.rb
+++ b/spec/views/crops/hierarchy.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "crops/hierarchy" do

--- a/spec/views/crops/index.html.haml_spec.rb
+++ b/spec/views/crops/index.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "crops/index" do

--- a/spec/views/crops/index.rss.haml_spec.rb
+++ b/spec/views/crops/index.rss.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe 'crops/index.rss.haml' do

--- a/spec/views/crops/new.html.haml_spec.rb
+++ b/spec/views/crops/new.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "crops/new" do

--- a/spec/views/crops/wrangle.html.haml_spec.rb
+++ b/spec/views/crops/wrangle.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "crops/wrangle" do

--- a/spec/views/devise/mailer/confirmation_instructions_spec.rb
+++ b/spec/views/devise/mailer/confirmation_instructions_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe 'devise/mailer/confirmation_instructions.html.haml', :type => "view" do

--- a/spec/views/devise/mailer/reset_password_instructions_spec.rb
+++ b/spec/views/devise/mailer/reset_password_instructions_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe 'devise/mailer/reset_password_instructions.html.haml', :type => "view" do

--- a/spec/views/devise/mailer/unlock_instructions_spec.rb
+++ b/spec/views/devise/mailer/unlock_instructions_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 describe 'devise/mailer/unlock_instructions.html.haml', :type => "view" do
   context "logged in" do

--- a/spec/views/devise/registrations/edit_spec.rb
+++ b/spec/views/devise/registrations/edit_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe 'devise/registrations/edit.html.haml', :type => "view" do

--- a/spec/views/devise/registrations/new_spec.rb
+++ b/spec/views/devise/registrations/new_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe 'devise/registrations/new.html.haml', :type => "view" do

--- a/spec/views/devise/sessions/new_spec.rb
+++ b/spec/views/devise/sessions/new_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe 'devise/sessions/new.html.haml', :type => "view" do

--- a/spec/views/devise/unlocks/new_spec.rb
+++ b/spec/views/devise/unlocks/new_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe 'devise/unlocks/new.html.haml', :type => "view" do

--- a/spec/views/forums/edit.html.haml_spec.rb
+++ b/spec/views/forums/edit.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "forums/edit" do

--- a/spec/views/forums/index.html.haml_spec.rb
+++ b/spec/views/forums/index.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "forums/index" do

--- a/spec/views/forums/new.html.haml_spec.rb
+++ b/spec/views/forums/new.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "forums/new" do

--- a/spec/views/forums/show.html.haml_spec.rb
+++ b/spec/views/forums/show.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "forums/show" do

--- a/spec/views/gardens/edit.html.haml_spec.rb
+++ b/spec/views/gardens/edit.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "gardens/edit" do

--- a/spec/views/gardens/index.html.haml_spec.rb
+++ b/spec/views/gardens/index.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "gardens/index" do

--- a/spec/views/gardens/new.html.haml_spec.rb
+++ b/spec/views/gardens/new.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "gardens/new" do

--- a/spec/views/gardens/show.html.haml_spec.rb
+++ b/spec/views/gardens/show.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "gardens/show" do

--- a/spec/views/harvests/edit.html.haml_spec.rb
+++ b/spec/views/harvests/edit.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "harvests/edit" do

--- a/spec/views/harvests/index.html.haml_spec.rb
+++ b/spec/views/harvests/index.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "harvests/index" do

--- a/spec/views/harvests/new.html.haml_spec.rb
+++ b/spec/views/harvests/new.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "harvests/new" do

--- a/spec/views/harvests/show.html.haml_spec.rb
+++ b/spec/views/harvests/show.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "harvests/show" do

--- a/spec/views/home/_blurb.html.haml_spec.rb
+++ b/spec/views/home/_blurb.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe 'home/_blurb.html.haml', :type => "view" do

--- a/spec/views/home/_crops.html.haml_spec.rb
+++ b/spec/views/home/_crops.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe 'home/_crops.html.haml', :type => "view" do

--- a/spec/views/home/_members.html.haml_spec.rb
+++ b/spec/views/home/_members.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe 'home/_members.html.haml', :type => "view" do

--- a/spec/views/home/_seeds.html.haml_spec.rb
+++ b/spec/views/home/_seeds.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe 'home/_seeds.html.haml', :type => "view" do

--- a/spec/views/home/_stats.html.haml_spec.rb
+++ b/spec/views/home/_stats.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe 'home/_stats.html.haml', :type => "view" do

--- a/spec/views/home/index_spec.rb
+++ b/spec/views/home/index_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe 'home/index.html.haml', :type => "view" do

--- a/spec/views/layouts/_header_spec.rb
+++ b/spec/views/layouts/_header_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe 'layouts/_header.html.haml', :type => "view" do

--- a/spec/views/layouts/_meta_spec.rb
+++ b/spec/views/layouts/_meta_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe 'layouts/_meta.html.haml', :type => "view" do

--- a/spec/views/layouts/application_spec.rb
+++ b/spec/views/layouts/application_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe 'layouts/application.html.haml', :type => "view" do

--- a/spec/views/members/_location.html.haml_spec.rb
+++ b/spec/views/members/_location.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "members/_location" do

--- a/spec/views/members/index.html.haml_spec.rb
+++ b/spec/views/members/index.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "members/index" do

--- a/spec/views/members/show.rss.haml_spec.rb
+++ b/spec/views/members/show.rss.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe 'members/show.rss.haml', :type => "view" do

--- a/spec/views/notifications/index.html.haml_spec.rb
+++ b/spec/views/notifications/index.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "notifications/index" do

--- a/spec/views/notifications/new.html.haml_spec.rb
+++ b/spec/views/notifications/new.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "notifications/new" do

--- a/spec/views/notifications/show.html.haml_spec.rb
+++ b/spec/views/notifications/show.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "notifications/show" do

--- a/spec/views/notifier/notify.html.haml_spec.rb
+++ b/spec/views/notifier/notify.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe 'notifier/notify.html.haml', :type => "view" do

--- a/spec/views/orders/index.html.haml_spec.rb
+++ b/spec/views/orders/index.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "orders/index" do

--- a/spec/views/orders/show.html.haml_spec.rb
+++ b/spec/views/orders/show.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "orders/show" do

--- a/spec/views/photos/edit.html.haml_spec.rb
+++ b/spec/views/photos/edit.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "photos/edit" do

--- a/spec/views/photos/index.html.haml_spec.rb
+++ b/spec/views/photos/index.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "photos/index" do

--- a/spec/views/photos/new.html.haml_spec.rb
+++ b/spec/views/photos/new.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "photos/new" do

--- a/spec/views/photos/show.html.haml_spec.rb
+++ b/spec/views/photos/show.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "photos/show" do

--- a/spec/views/places/_map_attribution.html.haml_spec.rb
+++ b/spec/views/places/_map_attribution.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "places/_map_attribution.html.haml", :type => :view do

--- a/spec/views/places/index.html.haml_spec.rb
+++ b/spec/views/places/index.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "places/index" do

--- a/spec/views/places/show.html.haml_spec.rb
+++ b/spec/views/places/show.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "places/show" do

--- a/spec/views/plant_parts/edit.html.haml_spec.rb
+++ b/spec/views/plant_parts/edit.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "plant_parts/edit" do

--- a/spec/views/plant_parts/index.html.haml_spec.rb
+++ b/spec/views/plant_parts/index.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "plant_parts/index" do

--- a/spec/views/plant_parts/new.html.haml_spec.rb
+++ b/spec/views/plant_parts/new.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "plant_parts/new" do

--- a/spec/views/plant_parts/show.html.haml_spec.rb
+++ b/spec/views/plant_parts/show.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "plant_parts/show" do

--- a/spec/views/plantings/_form.html.haml_spec.rb
+++ b/spec/views/plantings/_form.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "plantings/_form" do

--- a/spec/views/plantings/_thumbnail.html.haml_spec.rb
+++ b/spec/views/plantings/_thumbnail.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "plantings/_thumbnail" do

--- a/spec/views/plantings/edit.html.haml_spec.rb
+++ b/spec/views/plantings/edit.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "plantings/edit" do

--- a/spec/views/plantings/index.html.haml_spec.rb
+++ b/spec/views/plantings/index.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "plantings/index" do

--- a/spec/views/plantings/index.rss.haml_spec.rb
+++ b/spec/views/plantings/index.rss.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe 'plantings/index.rss.haml' do

--- a/spec/views/plantings/new.html.haml_spec.rb
+++ b/spec/views/plantings/new.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "plantings/new" do

--- a/spec/views/plantings/show.html.haml_spec.rb
+++ b/spec/views/plantings/show.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "plantings/show" do

--- a/spec/views/policy/community_spec.rb
+++ b/spec/views/policy/community_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe 'policy/community.html.haml', :type => "view" do

--- a/spec/views/policy/tos_spec.rb
+++ b/spec/views/policy/tos_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe 'policy/tos.html.haml', :type => "view" do

--- a/spec/views/posts/_single.html.haml_spec.rb
+++ b/spec/views/posts/_single.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "posts/_single" do

--- a/spec/views/posts/edit.html.haml_spec.rb
+++ b/spec/views/posts/edit.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "posts/edit" do

--- a/spec/views/posts/index.html.haml_spec.rb
+++ b/spec/views/posts/index.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "posts/index" do

--- a/spec/views/posts/index.rss.haml_spec.rb
+++ b/spec/views/posts/index.rss.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe 'posts/index.rss.haml', :type => "view" do

--- a/spec/views/posts/new.html.haml_spec.rb
+++ b/spec/views/posts/new.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "posts/new" do

--- a/spec/views/posts/show.html.haml_spec.rb
+++ b/spec/views/posts/show.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "posts/show" do

--- a/spec/views/posts/show.rss.haml_spec.rb
+++ b/spec/views/posts/show.rss.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe 'posts/show.rss.haml' do

--- a/spec/views/products/edit.html.haml_spec.rb
+++ b/spec/views/products/edit.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "products/edit" do

--- a/spec/views/products/index.html.haml_spec.rb
+++ b/spec/views/products/index.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "products/index" do

--- a/spec/views/products/new.html.haml_spec.rb
+++ b/spec/views/products/new.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "products/new" do

--- a/spec/views/products/show.html.haml_spec.rb
+++ b/spec/views/products/show.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "products/show" do

--- a/spec/views/roles/edit.html.haml_spec.rb
+++ b/spec/views/roles/edit.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "roles/edit" do

--- a/spec/views/roles/index.html.haml_spec.rb
+++ b/spec/views/roles/index.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "roles/index" do

--- a/spec/views/roles/new.html.haml_spec.rb
+++ b/spec/views/roles/new.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "roles/new" do

--- a/spec/views/roles/show.html.haml_spec.rb
+++ b/spec/views/roles/show.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "roles/show" do

--- a/spec/views/scientific_names/edit.html.haml_spec.rb
+++ b/spec/views/scientific_names/edit.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "scientific_names/edit" do

--- a/spec/views/scientific_names/index.html.haml_spec.rb
+++ b/spec/views/scientific_names/index.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "scientific_names/index" do

--- a/spec/views/scientific_names/new.html.haml_spec.rb
+++ b/spec/views/scientific_names/new.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "scientific_names/new" do

--- a/spec/views/scientific_names/show.html.haml_spec.rb
+++ b/spec/views/scientific_names/show.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "scientific_names/show" do

--- a/spec/views/seeds/edit.html.haml_spec.rb
+++ b/spec/views/seeds/edit.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "seeds/edit" do

--- a/spec/views/seeds/index.html.haml_spec.rb
+++ b/spec/views/seeds/index.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "seeds/index" do

--- a/spec/views/seeds/index.rss.haml_spec.rb
+++ b/spec/views/seeds/index.rss.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe 'seeds/index.rss.haml' do

--- a/spec/views/seeds/new.html.haml_spec.rb
+++ b/spec/views/seeds/new.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "seeds/new" do

--- a/spec/views/seeds/show.html.haml_spec.rb
+++ b/spec/views/seeds/show.html.haml_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe "seeds/show" do

--- a/spec/views/shop/index_spec.rb
+++ b/spec/views/shop/index_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe 'shop/index.html.haml', :type => "view" do

--- a/spec/views/support/index_spec.rb
+++ b/spec/views/support/index_spec.rb
@@ -1,3 +1,19 @@
+## DEPRECATION NOTICE: Do not add new tests to this file!
+##
+## View and controller tests are deprecated in the Growstuff project. 
+## We no longer write new view and controller tests, but instead write 
+## feature tests (in spec/features) using Capybara (https://github.com/jnicklas/capybara). 
+## These test the full stack, behaving as a browser, and require less complicated setup 
+## to run. Please feel free to delete old view/controller tests as they are reimplemented 
+## in feature tests. 
+##
+## If you submit a pull request containing new view or controller tests, it will not be 
+## merged.
+
+
+
+
+
 require 'rails_helper'
 
 describe 'support/index.html.haml', :type => "view" do


### PR DESCRIPTION
Fixes #622

Additionally, we can put all controller and view specs under a "deprecated" directory, so it's extra obvious. The paths would look like this: `spec/views/deprecated/`. Probably not necessary though.