### PR TITLE
Pending rejected sci alt names

### DIFF
--- a/app/views/alternate_names/show.html.haml
+++ b/app/views/alternate_names/show.html.haml
@@ -1,5 +1,7 @@
 %p#notice= notice
 
+= render :partial => 'crops/approval_status_message', :locals => { :crop => @alternate_name.crop }
+
 %p
   %b Alternate name:
   = @alternate_name.name

--- a/app/views/crops/_approval_status_message.html.haml
+++ b/app/views/crops/_approval_status_message.html.haml
@@ -1,0 +1,11 @@
+- if crop.pending?
+  .alert.alert-danger
+    %b This crop is currently pending approval.
+    %p This crop was requested by #{crop.requester} #{time_ago_in_words(crop.created_at)} ago.
+    - unless crop.request_notes.blank?
+      %p
+        Request notes: #{crop.request_notes}
+
+- if crop.rejected?
+  .alert.alert-danger
+    %b This crop was rejected for the following reason: #{crop.reason_for_rejection == "other" ? crop.rejection_notes : crop.reason_for_rejection}.

--- a/app/views/crops/show.html.haml
+++ b/app/views/crops/show.html.haml
@@ -1,17 +1,7 @@
 - content_for :title, @crop.name
 - content_for :subtitle, @crop.default_scientific_name
 
-- if @crop.pending?
-  .alert.alert-danger
-    %b This crop is currently pending approval.
-    %p This crop was requested by #{@crop.requester} #{time_ago_in_words(@crop.created_at)} ago.
-    - unless @crop.request_notes.blank?
-      %p
-        Request notes: #{@crop.request_notes}
-
-- if @crop.rejected?
-  .alert.alert-danger
-    %b This crop was rejected for the following reason: #{@crop.reason_for_rejection == "other" ? @crop.rejection_notes : @crop.reason_for_rejection}.
+= render :partial => 'approval_status_message', :locals => { :crop => @crop }
 
 - if @crop.approved?
   - content_for :buttonbar do

--- a/app/views/scientific_names/show.html.haml
+++ b/app/views/scientific_names/show.html.haml
@@ -1,5 +1,7 @@
 %p#notice= notice
 
+= render :partial => 'crops/approval_status_message', :locals => { :crop => @scientific_name.crop }
+
 %p
   %b Scientific name:
   = @scientific_name.scientific_name

--- a/spec/features/crops/alternate_name_spec.rb
+++ b/spec/features/crops/alternate_name_spec.rb
@@ -69,6 +69,18 @@ feature "Alternate names" do
       expect(page).to have_content alternate_eggplant.crop.name
     end
 
+    context "When alternate name is rejected" do
+      let(:rejected_crop) { FactoryGirl.create(:rejected_crop) }
+      let(:pending_alt_name) { FactoryGirl.create(:alternate_name, :crop => rejected_crop) }
+
+      scenario "Displays crop rejection message" do
+        visit alternate_name_path(pending_alt_name)
+        expect(page).to have_content "This crop was rejected for the following reason: Totally fake"
+      end
+
+    end
+
+
   end
 
 end

--- a/spec/features/scientific_name_spec.rb
+++ b/spec/features/scientific_name_spec.rb
@@ -70,6 +70,14 @@ feature "Scientific names" do
         href: crop_path(zea_mays.crop)
     end
 
-  end
+    context "When scientific name is pending" do
+      let(:pending_crop) { FactoryGirl.create(:crop_request) }
+      let(:pending_sci_name) { FactoryGirl.create(:scientific_name, :crop => pending_crop) }
 
+      scenario "Displays crop pending message" do
+        visit scientific_name_path(pending_sci_name)
+        expect(page).to have_content "This crop is currently pending approval"
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes no. 10 from this [testing thread on Talk](http://talk.growstuff.org/t/please-test-requesting-new-crops-new-seed-attributes/223/17?u=tygriffin)

>As a crop wrangler: scientific names and alt names belonging to pending or rejected crops aren't visibly marked as such when you visit their pages. There should be a red warning at the top, same as for crops.