### PR TITLE
#578 More extensive database seeding - bulk creating members, gardens and plantings

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -111,35 +111,35 @@ end
 
 def load_admin_users
   puts "Adding admin and crop wrangler members..."
-  @admin_user = Member.create(
+  @admin_user = Member.new(
     :login_name => "admin1",
     :email => "admin1@example.com",
     :password => "password1",
     :tos_agreement => true
   )
-  @admin_user.confirm!
+  @admin_user.skip_confirmation!
   @admin_user.roles << @admin
   @admin_user.save!
 
-  @wrangler_user = Member.create(
+  @wrangler_user = Member.new(
     :login_name => "wrangler1",
     :email => "wrangler1@example.com",
     :password => "password1",
     :tos_agreement => true
   )
-  @wrangler_user.confirm!
+  @wrangler_user.skip_confirmation!
   @wrangler_user.roles << @wrangler
   @wrangler_user.save!
 end
 
 def create_cropbot
-  @cropbot_user = Member.create(
+  @cropbot_user = Member.new(
     :login_name => "cropbot",
     :email => Growstuff::Application.config.bot_email,
     :password => SecureRandom.urlsafe_base64(64),
     :tos_agreement => true
   )
-  @cropbot_user.confirm!
+  @cropbot_user.skip_confirmation!
   @cropbot_user.roles << @wrangler
   @cropbot_user.save!
   @cropbot_user.account.account_type = AccountType.find_by_name("Staff")

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -100,7 +100,9 @@ def load_test_users
       owner_id: @user.id,
       garden_id: @user.gardens.first.id,
       planted_at: Date.today,
-      crop_id: Crop.find(i % Crop.all.size + 1).id
+      crop_id: Crop.find(i % Crop.all.size + 1).id,
+      sunniness: select_random_item(Planting::SUNNINESS_VALUES),
+      planted_from: select_random_item(Planting::PLANTED_FROM_VALUES)
     )
   end
 
@@ -196,6 +198,8 @@ def load_plant_parts
   end
 end
 
-
+def select_random_item(array)
+  array[rand(0..array.size-1) % array.size]
+end
 
 load_data

--- a/db/seeds/suburbs.csv
+++ b/db/seeds/suburbs.csv
@@ -1,0 +1,570 @@
+Downer,Australian Capital Territory,ACT,-35.244,149.1435
+O'Connor,Australian Capital Territory,ACT,-35.2564,149.1125
+Watson,Australian Capital Territory,ACT,-35.2347,149.1594
+Dickson,Australian Capital Territory,ACT,-35.2528,149.1417
+Lyneham,Australian Capital Territory,ACT,-35.2398,149.1307
+Hackett,Australian Capital Territory,ACT,-35.2495,149.1635
+Ainslie,Australian Capital Territory,ACT,-35.2622,149.1478
+Red Hill,Australian Capital Territory,ACT,-35.3334,149.1206
+Griffith,Australian Capital Territory,ACT,-35.3253,149.1371
+Forrest,Australian Capital Territory,ACT,-35.315,149.1286
+Manuka,Australian Capital Territory,ACT,-35.3126,149.1278
+Kingston,Australian Capital Territory,ACT,-35.3152,149.1466
+Narrabundah,Australian Capital Territory,ACT,-35.3357,149.1492
+Causeway,Australian Capital Territory,ACT,-35.3126,149.1278
+Garran,Australian Capital Territory,ACT,-35.331,149.0899
+Hughes,Australian Capital Territory,ACT,-35.3327,149.0949
+Curtin,Australian Capital Territory,ACT,-35.3246,149.0776
+Lyons,Australian Capital Territory,ACT,-35.3406,149.074
+Woden,Australian Capital Territory,ACT,-35.3481,149.0905
+O'Malley,Australian Capital Territory,ACT,-35.3525,149.1128
+Phillip,Australian Capital Territory,ACT,-35.3503,149.0915
+Swinger Hill,Australian Capital Territory,ACT,-35.3481,149.0905
+Chifley,Australian Capital Territory,ACT,-35.3534,149.0768
+Farrer,Australian Capital Territory,ACT,-35.3767,149.105
+Isaacs,Australian Capital Territory,ACT,-35.3686,149.1156
+Torrens,Australian Capital Territory,ACT,-35.372,149.0877
+Pearce,Australian Capital Territory,ACT,-35.3622,149.0834
+Mawson,Australian Capital Territory,ACT,-35.3634,149.0986
+Civic Square,Australian Capital Territory,ACT,-35.31,149.1933
+Pialligo,Australian Capital Territory,ACT,-35.3043,149.1792
+Fyshwick,Australian Capital Territory,ACT,-35.3333,149.1667
+Canberra Airport,Australian Capital Territory,ACT,-35.3172,149.1753
+Symonston,Australian Capital Territory,ACT,-35.3516,149.1592
+Majura,Australian Capital Territory,ACT,-35.2667,149.2
+Canberra Bc,Australian Capital Territory,ACT,-35.2778,149.0111
+Canberra Mc,Australian Capital Territory,ACT,-35.2498,149.0591
+Wright,Australian Capital Territory,ACT,-35.3503,149.0155
+Coombs,Australian Capital Territory,ACT,-35.3503,149.0155
+Rivett,Australian Capital Territory,ACT,-35.3471,149.0379
+Stromlo,Australian Capital Territory,ACT,-35.3503,149.0155
+Duffy,Australian Capital Territory,ACT,-35.3346,149.0319
+Coree,Australian Capital Territory,ACT,-35.3503,149.0155
+Chapman,Australian Capital Territory,ACT,-35.3562,149.0374
+Uriarra Village,Australian Capital Territory,ACT,-35.3503,149.0155
+Waramanga,Australian Capital Territory,ACT,-35.353,149.0621
+Weston Creek,Australian Capital Territory,ACT,-35.4171,148.7769
+Uriarra,Australian Capital Territory,ACT,-35.4171,148.7769
+Weston,Australian Capital Territory,ACT,-35.4171,148.7769
+Fisher,Australian Capital Territory,ACT,-35.4171,148.7769
+Stirling,Australian Capital Territory,ACT,-35.4171,148.7769
+Holder,Australian Capital Territory,ACT,-35.4171,148.7769
+Mount Stromlo,Australian Capital Territory,ACT,-35.4171,148.7769
+Braddon,Australian Capital Territory,ACT,-35.2708,149.1357
+Campbell,Australian Capital Territory,ACT,-35.2891,149.1538
+Turner,Australian Capital Territory,ACT,-35.2688,149.1247
+Reid,Australian Capital Territory,ACT,-35.2858,149.1391
+Scullin,Australian Capital Territory,ACT,-35.2346,149.039
+Aranda,Australian Capital Territory,ACT,-35.2582,149.0804
+Cook,Australian Capital Territory,ACT,-35.2601,149.0657
+Jamison Centre,Australian Capital Territory,ACT,-35.2498,149.0591
+Macquarie,Australian Capital Territory,ACT,-35.2513,149.0636
+Hawker,Australian Capital Territory,ACT,-35.2471,149.0367
+Page,Australian Capital Territory,ACT,-35.2386,149.0499
+Weetangera,Australian Capital Territory,ACT,-35.2498,149.0591
+Melba,Australian Capital Territory,ACT,-35.2102,149.0541
+Spence,Australian Capital Territory,ACT,-35.2101,149.034
+Higgins,Australian Capital Territory,ACT,-35.2324,149.0272
+Holt,Australian Capital Territory,ACT,-35.2244,149.0119
+Latham,Australian Capital Territory,ACT,-35.2165,149.0314
+Kippax Centre,Australian Capital Territory,ACT,-35.2101,149.034
+Flynn,Australian Capital Territory,ACT,-35.2059,149.0439
+Florey,Australian Capital Territory,ACT,-35.2259,149.05
+Fraser,Australian Capital Territory,ACT,-35.1917,149.0453
+Kippax,Australian Capital Territory,ACT,-35.2101,149.034
+Dunlop,Australian Capital Territory,ACT,-35.194,149.0198
+Macgregor,Australian Capital Territory,ACT,-35.2098,149.011
+Charnwood,Australian Capital Territory,ACT,-35.2002,149.0341
+Belconnen,Australian Capital Territory,ACT,-35.2167,149.0833
+Belconnen DC,Australian Capital Territory,ACT,-35.2199,149.0869
+Giralang,Australian Capital Territory,ACT,-35.2109,149.096
+Belconnen,Australian Capital Territory,ACT,-35.2167,149.0833
+Kaleen,Australian Capital Territory,ACT,-35.2181,149.1052
+Bruce,Australian Capital Territory,ACT,-35.2407,149.0466
+Evatt,Australian Capital Territory,ACT,-35.2119,149.0689
+University Of Canberra,Australian Capital Territory,ACT,-35.2498,149.0591
+Mckellar,Australian Capital Territory,ACT,-35.2407,149.0466
+Lawson,Australian Capital Territory,ACT,-35.2498,149.0591
+Hall,Australian Capital Territory,ACT,-35.1906,148.9137
+Oaks Estate,Australian Capital Territory,ACT,-35.3397,149.2121
+Kowen,Australian Capital Territory,ACT,-35.3914,149.2166
+Tharwa,Australian Capital Territory,ACT,-35.5714,149.1275
+Hume,Australian Capital Territory,ACT,-35.3855,149.1658
+Paddys River,Australian Capital Territory,ACT,-35.3914,149.2166
+Beard,Australian Capital Territory,ACT,-35.3914,149.2166
+Tuggeranong,Australian Capital Territory,ACT,-35.4158,149.0649
+Greenway,Australian Capital Territory,ACT,-35.4158,149.0649
+Tuggeranong Dc,Australian Capital Territory,ACT,-35.4333,149.15
+Kambah,Australian Capital Territory,ACT,-35.3862,149.058
+Kambah Village,Australian Capital Territory,ACT,-35.3862,149.058
+Erindale Centre,Australian Capital Territory,ACT,-35.3998,149.0888
+Wanniassa,Australian Capital Territory,ACT,-35.3978,149.0909
+Oxley,Australian Capital Territory,ACT,-35.4095,149.0786
+Fadden,Australian Capital Territory,ACT,-35.4019,149.1176
+Monash,Australian Capital Territory,ACT,-35.4158,149.0906
+Macarthur,Australian Capital Territory,ACT,-35.4086,149.132
+Gowrie,Australian Capital Territory,ACT,-35.4119,149.109
+Calwell,Australian Capital Territory,ACT,-35.4404,149.1071
+Gilmore,Australian Capital Territory,ACT,-35.4324,149.1099
+Theodore,Australian Capital Territory,ACT,-35.4496,149.1197
+Richardson,Australian Capital Territory,ACT,-35.4279,149.1138
+Chisholm,Australian Capital Territory,ACT,-35.422,149.1248
+Isabella Plains,Australian Capital Territory,ACT,-35.428,149.094
+Bonython,Australian Capital Territory,ACT,-35.4333,149.0782
+Gordon,Australian Capital Territory,ACT,-35.4568,149.085
+Banks,Australian Capital Territory,ACT,-35.4719,149.0997
+Conder,Australian Capital Territory,ACT,-35.4593,149.1042
+Crace,Australian Capital Territory,ACT,-35.2028,149.1074
+Mitchell,Australian Capital Territory,ACT,-35.2145,149.1293
+Gungahlin,Australian Capital Territory,ACT,-35.1867,149.1362
+Casey,Australian Capital Territory,ACT,-35.167,149.0947
+Kinlyside,Australian Capital Territory,ACT,-35.1842,149.1131
+Franklin,Australian Capital Territory,ACT,-35.1995,149.1433
+Ngunnawal,Australian Capital Territory,ACT,-35.1728,149.1115
+Taylor,Australian Capital Territory,ACT,-35.1842,149.1131
+Palmerston,Australian Capital Territory,ACT,-35.1945,149.1194
+Nicholls,Australian Capital Territory,ACT,-35.1873,149.0965
+Ginninderra Village,Australian Capital Territory,ACT,-35.1875,149.1244
+Forde,Australian Capital Territory,ACT,-35.1682,149.1461
+Moncrieff,Australian Capital Territory,ACT,-35.179,149.1435
+Harrison,Australian Capital Territory,ACT,-35.1991,149.1563
+Jacka,Australian Capital Territory,ACT,-35.179,149.1435
+Amaroo,Australian Capital Territory,ACT,-35.1696,149.128
+Bonner,Australian Capital Territory,ACT,-35.179,149.1435
+Sydney,New South Wales,NSW,-33.8678,151.2073
+Moree,New South Wales,NSW,-29.3965,149.5878
+Kempsey,New South Wales,NSW,-31.079,152.8309
+Seven Oaks,New South Wales,NSW,-31.0123,152.7651
+Clybucca,New South Wales,NSW,-30.95,152.95
+Lower Creek,New South Wales,NSW,-30.9307,152.6368
+Collombatti,New South Wales,NSW,-30.9812,152.8251
+Deep Creek,New South Wales,NSW,-31.0123,152.7651
+Hickeys Creek,New South Wales,NSW,-30.9,152.6
+Gladstone,New South Wales,NSW,-30.9307,152.6368
+Smithtown,New South Wales,NSW,-31.0186,152.9503
+Mungay Creek,New South Wales,NSW,-31.0123,152.7651
+Comara,New South Wales,NSW,-30.9307,152.6368
+Crescent Head,New South Wales,NSW,-31.1887,152.973
+Millbank,New South Wales,NSW,-30.9307,152.6368
+Pola Creek,New South Wales,NSW,-31.0123,152.7651
+Kinchela,New South Wales,NSW,-30.9667,153
+Verges Creek,New South Wales,NSW,-31.0878,152.8997
+Turners Flat,New South Wales,NSW,-31.0167,152.7
+Yessabah,New South Wales,NSW,-31.0123,152.7651
+Sherwood,New South Wales,NSW,-31.0667,152.7333
+Bellbrook,New South Wales,NSW,-30.8167,152.5167
+Hampden Hall,New South Wales,NSW,-31.0123,152.7651
+Old Station,New South Wales,NSW,-31.0123,152.7651
+Belmore River,New South Wales,NSW,-31.1167,152.9833
+Frederickton,New South Wales,NSW,-31.0375,152.8753
+Aldavilla,New South Wales,NSW,-31.0833,152.7667
+East Kempsey,New South Wales,NSW,-31.0123,152.7651
+Euroka,New South Wales,NSW,-31.077,152.8005
+Toorooka,New South Wales,NSW,-30.9307,152.6368
+Willi Willi,New South Wales,NSW,-30.9333,152.45
+Temagog,New South Wales,NSW,-31.0123,152.7651
+Mooneba,New South Wales,NSW,-31.05,152.6833
+South Kempsey,New South Wales,NSW,-31.079,152.8309
+Wittitrin,New South Wales,NSW,-31.1333,152.6667
+Rainbow Reach,New South Wales,NSW,-31.0123,152.7651
+Yarravel,New South Wales,NSW,-31.043,152.7619
+Hat Head,New South Wales,NSW,-31.0555,153.0472
+Burnt Bridge,New South Wales,NSW,-31.1,152.8167
+Moparrabah,New South Wales,NSW,-31.0123,152.7651
+Austral Eden,New South Wales,NSW,-31.0333,152.9167
+Bellimbopinni,New South Wales,NSW,-30.9307,152.6368
+Dondingalong,New South Wales,NSW,-31.1332,152.7514
+Corangula,New South Wales,NSW,-31.0123,152.7651
+Carrai,New South Wales,NSW,-30.9307,152.6368
+Summer Island,New South Wales,NSW,-31.0123,152.7651
+West Kempsey,New South Wales,NSW,-31.0123,152.7651
+Skillion Flat,New South Wales,NSW,-31.0167,152.7333
+Barraganyatti,New South Wales,NSW,-30.85,152.9333
+Telegraph Point,New South Wales,NSW,-31.3333,152.8
+Cooperabung,New South Wales,NSW,-31.3,152.8
+Yarrahapinni,New South Wales,NSW,-30.8281,152.9538
+Tamban,New South Wales,NSW,-30.8667,152.8333
+Grassy Head,New South Wales,NSW,-31.1374,152.7419
+Allgomera,New South Wales,NSW,-30.8182,152.7955
+Bonville,New South Wales,NSW,-30.3761,153.0349
+Upper Rollands Plains,New South Wales,NSW,-31.25,152.6333
+Rollands Plains,New South Wales,NSW,-31.1272,152.7256
+Eungai Rail,New South Wales,NSW,-30.8463,152.9006
+Fishermans Reach,New South Wales,NSW,-31.0274,152.8364
+Stuarts Point,New South Wales,NSW,-30.8208,152.9933
+Bril Bril,New South Wales,NSW,-31.0274,152.8364
+Eungai Creek,New South Wales,NSW,-30.8333,152.8833
+Hacks Ferry,New South Wales,NSW,-31.0274,152.8364
+Kundabung,New South Wales,NSW,-31.2,152.85
+Kippara,New South Wales,NSW,-31.0274,152.8364
+Gum Scrub,New South Wales,NSW,-31.1272,152.7256
+Marlo Merrican,New South Wales,NSW,-31.0274,152.8364
+Crossmaglen,New South Wales,NSW,-31.1374,152.7419
+Ballengarra,New South Wales,NSW,-31.1272,152.7256
+Mid North Coast Mc,New South Wales,NSW,-31.1374,152.7419
+Mid North Coast Msc,New South Wales,NSW,-31.1374,152.7419
+Stewarts River,New South Wales,NSW,-31.7333,152.65
+Deauville,New South Wales,NSW,-31.6915,152.7267
+Lakewood,New South Wales,NSW,-31.6321,152.7582
+North Haven,New South Wales,NSW,-31.7131,152.6781
+Crowdy Bay National Park,New South Wales,NSW,-31.788,152.7311
+Moorland,New South Wales,NSW,-31.7131,152.6781
+West Haven,New South Wales,NSW,-31.6344,152.7825
+Herons Creek,New South Wales,NSW,-31.5833,152.7333
+Camden Head,New South Wales,NSW,-31.6469,152.8346
+Waitui,New South Wales,NSW,-31.6915,152.7267
+Johns River,New South Wales,NSW,-31.75,152.7
+Dunbogan,New South Wales,NSW,-31.65,152.8167
+Glen Niven,Queensland,QLD,-28.6,151.9667
+The Summit,Queensland,QLD,-28.5833,151.9667
+Applethorpe,Queensland,QLD,-28.6167,151.9667
+Pikedale,Queensland,QLD,-28.65,151.6333
+Kyoomba,Queensland,QLD,-28.7421,151.6647
+Mingoola,Queensland,QLD,-28.9833,151.5167
+Mount Tully,Queensland,QLD,-28.7241,151.825
+Cannon Creek,Queensland,QLD,-28.5833,151.8667
+Stanthorpe,Queensland,QLD,-28.6572,151.9337
+Greenlands,Queensland,QLD,-28.7241,151.825
+Broadwater,Queensland,QLD,-28.7241,151.825
+Springdale,Queensland,QLD,-28.7241,151.825
+Thorndale,Queensland,QLD,-28.7241,151.825
+Pikes Creek,Queensland,QLD,-28.7241,151.825
+Eukey,Queensland,QLD,-28.7667,151.9833
+Sugarloaf,Queensland,QLD,-28.7241,151.825
+Storm King,Queensland,QLD,-28.7241,151.825
+Glenlyon,Queensland,QLD,-28.7241,151.825
+Dalcouth,Queensland,QLD,-28.7241,151.825
+Severnlea,Queensland,QLD,-28.7,151.9167
+Amiens,Queensland,QLD,-28.5833,151.8167
+Nundubbermere,Queensland,QLD,-28.7241,151.825
+Fletcher,Queensland,QLD,-28.7667,151.85
+Glen Aplin,Queensland,QLD,-28.7643,151.8918
+Wyberba,Queensland,QLD,-28.85,151.8667
+Ballandean,Queensland,QLD,-28.8576,151.8345
+Lyra,Queensland,QLD,-28.8333,151.8667
+Girraween,Queensland,QLD,-28.8278,151.8556
+Somme,Queensland,QLD,-28.8278,151.8556
+Wallangarra,Queensland,QLD,-28.9239,151.9282
+Limevale,Queensland,QLD,-28.7333,151.2
+Riverton,Queensland,QLD,-28.7884,151.01
+Glenarbon,Queensland,QLD,-28.7884,151.01
+Texas,Queensland,QLD,-28.7884,151.01
+Beebo,Queensland,QLD,-28.7884,151.01
+Watsons Crossing,Queensland,QLD,-28.7884,151.01
+Maidenhead,Queensland,QLD,-28.7884,151.01
+Silver Spur,Queensland,QLD,-28.7884,151.01
+Smithlea,Queensland,QLD,-28.7884,151.01
+Bonshaw,Queensland,QLD,-28.7884,151.01
+Coolmunda,Queensland,QLD,-28.4084,151.2129
+Inglewood,Queensland,QLD,-28.4789,151.1134
+Bybera,Queensland,QLD,-28.4789,151.1134
+Terrica,Queensland,QLD,-28.4789,151.1134
+Warroo,Queensland,QLD,-28.4789,151.1134
+Greenup,Queensland,QLD,-28.4789,151.1134
+Brush Creek,Queensland,QLD,-28.4789,151.1134
+Whetstone,Queensland,QLD,-28.4789,151.1134
+Mosquito Creek,Queensland,QLD,-28.4789,151.1134
+Yelarbon,Queensland,QLD,-28.5725,150.7513
+Kurumbul,Queensland,QLD,-28.2692,150.6904
+Wyaga,Queensland,QLD,-28.194,150.3565
+Lundavra,Queensland,QLD,-28.194,150.3565
+Goodar,Queensland,QLD,-28.194,150.3565
+Goondiwindi,Queensland,QLD,-28.5464,150.3073
+Billa Billa,Queensland,QLD,-28.194,150.3565
+Yagaburne,Queensland,QLD,-28.194,150.3565
+Callandoon,Queensland,QLD,-28.194,150.3565
+Calingunee,Queensland,QLD,-28.194,150.3565
+Kindon,Queensland,QLD,-28.194,150.3565
+Wondalli,Queensland,QLD,-28.194,150.3565
+Kingsthorpe,Queensland,QLD,-27.4756,151.8141
+Acland,Queensland,QLD,-27.3,151.6833
+Biddeston,Queensland,QLD,-27.5667,151.7167
+Muldu,Queensland,QLD,-27.4617,151.6957
+Aubigny,Queensland,QLD,-27.5167,151.65
+Oakey,Queensland,QLD,-27.4331,151.7206
+Yargullen,Queensland,QLD,-27.4617,151.6957
+Balgowan,Queensland,QLD,-27.4617,151.6957
+Rosalie Plains,Queensland,QLD,-27.4617,151.6957
+Silverleigh,Queensland,QLD,-27.4617,151.6957
+Mount Irving,Queensland,QLD,-27.4617,151.6957
+Kelvinhaugh,Queensland,QLD,-27.4617,151.6957
+Amamoor Creek,Queensland,QLD,-26.1931,152.5564
+Bells Bridge,Queensland,QLD,-26.1258,152.5387
+St Mary,Queensland,QLD,-26.1931,152.5564
+Tuchekoi,Queensland,QLD,-26.2008,152.6451
+Mcintosh Creek,Queensland,QLD,-26.1931,152.5564
+Woondum,Queensland,QLD,-26.25,152.7333
+Neusa Vale,Queensland,QLD,-26.1931,152.5564
+Cedar Pocket,Queensland,QLD,-26.2008,152.6451
+Widgee Crossing North,Queensland,QLD,-26.1931,152.5564
+Veteran,Queensland,QLD,-26.2008,152.6451
+Kandanga,Queensland,QLD,-26.3833,152.6667
+The Palms,Queensland,QLD,-26.205,152.5865
+Greens Creek,Queensland,QLD,-26.1931,152.5564
+Coondoo,Queensland,QLD,-26.1667,152.8833
+Ross Creek,Queensland,QLD,-26.1931,152.5564
+Dagun,Queensland,QLD,-26.3167,152.6833
+Bella Creek,Queensland,QLD,-26.1931,152.5564
+Langshaw,Queensland,QLD,-26.3,152.5667
+Kia Ora,Queensland,QLD,-26.1931,152.5564
+Willalo,South Australia,SA,-33.4,138.8833
+Whyte Yarcowie,South Australia,SA,-33.2047,139.0367
+Canowie Belt,South Australia,SA,-33.1833,138.75
+Terowie,South Australia,SA,-33.1667,138.9
+Franklyn,South Australia,SA,-32.9379,138.9062
+Mannanarie,South Australia,SA,-33.05,138.6167
+Ucolta,South Australia,SA,-32.95,138.9667
+Peterborough,South Australia,SA,-32.9721,138.8407
+Sunnybrae,South Australia,SA,-32.8905,138.9224
+Hardy,South Australia,SA,-32.8905,138.9224
+Cavenagh,South Australia,SA,-32.8905,138.9224
+Parnaroo,South Australia,SA,-32.9833,139.1333
+Oodla Wirra,South Australia,SA,-32.8833,139.0667
+Minvalara,South Australia,SA,-32.9,138.75
+Paratoo,South Australia,SA,-32.7,139.3667
+Dawson,South Australia,SA,-32.8,138.9667
+Erskine,South Australia,SA,-32.7333,138.85
+Yatina,South Australia,SA,-32.9333,138.6667
+Pekina,South Australia,SA,-32.8333,138.55
+Morchard,South Australia,SA,-32.8452,138.6651
+Orroroo,South Australia,SA,-32.7344,138.6139
+Amyton,South Australia,SA,-32.6,138.3333
+Hammond,South Australia,SA,-32.8452,138.6651
+Yalpara,South Australia,SA,-32.5333,138.9333
+Tarcowie,South Australia,SA,-32.8452,138.6651
+Eurelia,South Australia,SA,-32.55,138.5667
+Johnburgh,South Australia,SA,-32.45,138.7
+Black Rock,South Australia,SA,-32.8333,138.7
+Willowie,South Australia,SA,-32.6833,138.3333
+Walloway,South Australia,SA,-32.6333,138.5833
+Minburra,South Australia,SA,-32.6695,138.5539
+Coomooroo,South Australia,SA,-32.6695,138.5539
+Cradock,South Australia,SA,-32.3697,138.6443
+Yanyarrie,South Australia,SA,-32.3042,138.5417
+Carrieton,South Australia,SA,-32.3697,138.6443
+Belton,South Australia,SA,-32.2333,138.7
+Moockra,South Australia,SA,-32.4667,138.4333
+Quorn,South Australia,SA,-32.3468,138.0418
+Willochra,South Australia,SA,-32.2333,138.1333
+Saltia,South Australia,SA,-32.3489,138.125
+Bruce,South Australia,SA,-32.4667,138.2
+Stephenston,South Australia,SA,-32.3489,138.125
+Yarrah,South Australia,SA,-32.3489,138.125
+Hawker,South Australia,SA,-31.8892,138.42
+Kanyaka,South Australia,SA,-31.8892,138.42
+Barndioota,South Australia,SA,-31.8892,138.42
+Manna Hill,South Australia,SA,-32.325,140.0441
+Waukaringa,South Australia,SA,-32.3,139.4333
+Cockburn,South Australia,SA,-32.325,140.0441
+Nackara,South Australia,SA,-32.8,139.2333
+Yunta,South Australia,SA,-32.325,140.0441
+Mingary,South Australia,SA,-32.1333,140.7333
+Olary,South Australia,SA,-32.325,140.0441
+Auburn,South Australia,SA,-34.0269,138.6852
+Undalya,South Australia,SA,-34.0667,138.6833
+Leasingham,South Australia,SA,-33.9942,138.6248
+Watervale,South Australia,SA,-33.9942,138.6248
+Clare,South Australia,SA,-33.8332,138.6106
+Spring Farm,South Australia,SA,-33.8972,138.5785
+Hoyleton,South Australia,SA,-33.8532,138.5559
+Barinia,South Australia,SA,-33.8972,138.5785
+Benbournie,South Australia,SA,-33.8972,138.5785
+Stanley Flat,South Australia,SA,-33.8972,138.5785
+Sevenhill,South Australia,SA,-33.8972,138.5785
+Polish Hill River,South Australia,SA,-33.8972,138.5785
+Hill River,South Australia,SA,-33.8972,138.5785
+Kybunga,South Australia,SA,-33.8972,138.5785
+Gillentown,South Australia,SA,-33.8972,138.5785
+Boconnoc Park,South Australia,SA,-33.8972,138.5785
+Armagh,South Australia,SA,-33.825,138.5748
+Spring Gully,South Australia,SA,-33.8972,138.5785
+Emu Flat,South Australia,SA,-33.8972,138.5785
+Penwortham,South Australia,SA,-33.8972,138.5785
+Spalding,South Australia,SA,-33.4979,138.6075
+Andrews,South Australia,SA,-34.6763,138.662
+Broughton River Valley,South Australia,SA,-34.0871,138.6347
+Euromina,South Australia,SA,-34.0871,138.6347
+Mayfield,South Australia,SA,-34.0871,138.6347
+Washpool,South Australia,SA,-34.0871,138.6347
+Hacklins Corner,South Australia,SA,-34.0871,138.6347
+Hilltown,South Australia,SA,-33.8458,138.6125
+Barabba,South Australia,SA,-34.35,138.5833
+Owen,South Australia,SA,-34.272,138.5444
+Pinery,South Australia,SA,-34.3,138.45
+Risdon Park,South Australia,SA,-33.1966,137.994
+Lonnavale,Tasmania,TAS,-42.9754,146.8397
+Crabtree,Tasmania,TAS,-42.9633,147.0786
+Glaziers Bay,Tasmania,TAS,-43.1458,146.9984
+Wattle Grove,Tasmania,TAS,-43.2109,146.8676
+Waterloo,Tasmania,TAS,-43.2109,146.8676
+Strathblane,Tasmania,TAS,-43.2109,146.8676
+Lower Wattle Grove,Tasmania,TAS,-43.1269,147.0275
+Lower Longley,Tasmania,TAS,-42.9833,147.1333
+Catamaran,Tasmania,TAS,-43.2109,146.8676
+Petcheys Bay,Tasmania,TAS,-43.2109,146.8676
+Raminea,Tasmania,TAS,-43.2109,146.8676
+Cygnet,Tasmania,TAS,-43.1533,147.0725
+Abels Bay,Tasmania,TAS,-43.1696,147.1296
+Eggs And Bacon Bay,Tasmania,TAS,-43.2455,147.1047
+Nicholls Rivulet,Tasmania,TAS,-43.1696,147.1296
+Gardners Bay,Tasmania,TAS,-43.1696,147.1296
+Charlotte Cove,Tasmania,TAS,-43.189,147.148
+Randalls Bay,Tasmania,TAS,-43.1696,147.1296
+Verona Sands,Tasmania,TAS,-43.1696,147.1296
+Garden Island Creek,Tasmania,TAS,-43.25,147.1667
+Deep Bay,Tasmania,TAS,-43.2082,147.134
+Franklin,Tasmania,TAS,-43.0888,147.0091
+Brooks Bay,Tasmania,TAS,-43.1708,146.9784
+Geeveston,Tasmania,TAS,-43.1634,146.9255
+Surges Bay,Tasmania,TAS,-43.2775,146.4256
+Surveyors Bay,Tasmania,TAS,-43.1708,146.9784
+Castle Forbes Bay,Tasmania,TAS,-43.2775,146.4256
+Port Huon,Tasmania,TAS,-43.1554,146.9634
+Cairns Bay,Tasmania,TAS,-43.2775,146.4256
+Police Point,Tasmania,TAS,-43.2775,146.4256
+Dover,Tasmania,TAS,-43.2774,146.9734
+Stonor,Tasmania,TAS,-42.4,147.3833
+Swanston,Tasmania,TAS,-42.3482,147.4726
+Andover,Tasmania,TAS,-42.3333,147.45
+Rhyndaston,Tasmania,TAS,-42.3325,147.4857
+Oatlands,Tasmania,TAS,-42.3325,147.4857
+York Plains,Tasmania,TAS,-42.3325,147.4857
+Woodsdale,Tasmania,TAS,-42.4667,147.5667
+Tunbridge,Tasmania,TAS,-42.3325,147.4857
+Parattah,Tasmania,TAS,-42.35,147.4
+Woodbury,Tasmania,TAS,-42.3325,147.4857
+Baden,Tasmania,TAS,-42.3325,147.4857
+Mount Seymour,Tasmania,TAS,-42.3325,147.4857
+Lemont,Tasmania,TAS,-42.3325,147.4857
+Antill Ponds,Tasmania,TAS,-42.3325,147.4857
+Tunnack,Tasmania,TAS,-42.45,147.45
+Orford,Tasmania,TAS,-42.3064,147.9158
+Spring Beach,Tasmania,TAS,-42.5864,147.9145
+Dolphin Sands,Tasmania,TAS,-42.4221,147.8876
+Swansea,Tasmania,TAS,-42.3064,147.9158
+Runnymede,Tasmania,TAS,-42.3064,147.9158
+Little Swanport,Tasmania,TAS,-42.3225,147.9578
+Rheban,Tasmania,TAS,-42.6278,147.9236
+Triabunna,Tasmania,TAS,-42.5018,147.9136
+South Kingsville,Victoria,VIC,-37.8302,144.8709
+Spotswood,Victoria,VIC,-37.8299,144.8878
+Newport,Victoria,VIC,-37.8443,144.8848
+Williamstown North,Victoria,VIC,-37.857,144.8977
+Williamstown,Victoria,VIC,-37.857,144.8977
+Altona,Victoria,VIC,-37.8696,144.8304
+Seaholme,Victoria,VIC,-37.864,144.845
+Robinson,Victoria,VIC,-37.7867,144.8548
+Braybrook,Victoria,VIC,-37.7867,144.8548
+Glengala,Victoria,VIC,-37.775,144.8333
+Sunshine,Victoria,VIC,-37.7833,144.8333
+Sunshine North,Victoria,VIC,-37.775,144.8333
+Albion,Victoria,VIC,-37.7667,144.8333
+Sunshine West,Victoria,VIC,-37.775,144.8333
+St Albans,Victoria,VIC,-37.745,144.8005
+Kings Park,Victoria,VIC,-37.7337,144.772
+Albanvale,Victoria,VIC,-37.7461,144.7686
+Kealba,Victoria,VIC,-37.7371,144.8283
+Deer Park East,Victoria,VIC,-37.7764,144.8016
+Ardeer,Victoria,VIC,-37.7759,144.8014
+Ravenhall,Victoria,VIC,-37.7541,144.7651
+Deer Park,Victoria,VIC,-37.7667,144.7833
+Burnside Heights,Victoria,VIC,-37.7541,144.7651
+Caroline Springs,Victoria,VIC,-37.7412,144.7363
+Deer Park North,Victoria,VIC,-37.7541,144.7651
+Cairnlea,Victoria,VIC,-37.7593,144.7878
+Burnside,Victoria,VIC,-37.7494,144.753
+Mambourin,Victoria,VIC,-37.8291,144.5622
+Mount Cottrell,Victoria,VIC,-37.8167,144.5833
+Wyndham Vale,Victoria,VIC,-37.8415,144.541
+Altona East,Victoria,VIC,-37.8349,144.8474
+Altona North,Victoria,VIC,-37.8349,144.8474
+Altona Gate,Victoria,VIC,-37.8349,144.8474
+Laverton North,Victoria,VIC,-37.8259,144.6886
+Williams Landing,Victoria,VIC,-37.7963,144.7565
+Seabrook,Victoria,VIC,-37.8809,144.7587
+Altona Meadows,Victoria,VIC,-37.8739,144.772
+Laverton,Victoria,VIC,-37.862,144.7698
+Hoppers Crossing,Victoria,VIC,-37.8826,144.7003
+Tarneit,Victoria,VIC,-37.8667,144.6667
+Truganina,Victoria,VIC,-37.8167,144.75
+Cocoroc,Victoria,VIC,-37.8887,144.726
+Point Cook,Victoria,VIC,-37.9148,144.7509
+Quandong,Victoria,VIC,-37.8887,144.726
+Werribee,Victoria,VIC,-37.9,144.6667
+Gillieston,Victoria,VIC,-36.4516,145.181
+Mooroopna North West,Victoria,VIC,-36.4455,145.1411
+Cooma,Victoria,VIC,-36.4516,145.181
+Waranga,Victoria,VIC,-36.6,145.1167
+Girgarre East,Victoria,VIC,-36.4333,145.0667
+Byrneside,Victoria,VIC,-36.4167,145.1833
+Merrigum,Victoria,VIC,-36.3724,145.1322
+Yalca,Victoria,VIC,-35.9833,145.3167
+Nathalia,Victoria,VIC,-36.0577,145.2041
+Yielima,Victoria,VIC,-35.9333,145.2167
+Kotupna,Victoria,VIC,-36.15,145.15
+Picola,Victoria,VIC,-35.9818,145.0847
+Barmah,Victoria,VIC,-36.0167,144.9667
+Lower Moira,Victoria,VIC,-36.0833,144.9833
+Picola West,Victoria,VIC,-36.0333,145.0278
+Katunga,Victoria,VIC,-35.9666,145.4269
+Ulupna,Victoria,VIC,-35.8833,145.4
+Strathmerton,Victoria,VIC,-35.8774,145.4452
+Mywee,Victoria,VIC,-35.8667,145.5
+Bearii,Victoria,VIC,-35.8857,145.3453
+Cobram,Victoria,VIC,-35.9207,145.6407
+Koonoomoo,Victoria,VIC,-35.9503,145.6546
+Yarroweyah,Victoria,VIC,-35.9333,145.55
+Muckatah,Victoria,VIC,-36.0167,145.65
+Cobram,Victoria,VIC,-35.9207,145.6407
+Cobram East,Victoria,VIC,-35.9746,145.7364
+Dookie,Victoria,VIC,-36.3273,145.6897
+Yabba North,Victoria,VIC,-36.3077,145.6839
+Mount Major,Victoria,VIC,-36.2755,145.7146
+Youanmite,Victoria,VIC,-36.3077,145.6839
+Nalinga,Victoria,VIC,-36.4167,145.7167
+Waggarandall,Victoria,VIC,-36.25,145.8
+Yabba South,Victoria,VIC,-36.2755,145.7146
+Dookie College,Victoria,VIC,-36.0413,145.6097
+Katamatite,Victoria,VIC,-36.0759,145.6872
+Katamatite East,Victoria,VIC,-36.0759,145.6872
+Reedy Creek,Victoria,VIC,-37.2667,145.1333
+Waterford Park,Victoria,VIC,-37.3002,145.0668
+Strath Creek,Victoria,VIC,-37.2333,145.2167
+Clonbinane,Victoria,VIC,-37.292,145.1406
+Broadford,Victoria,VIC,-37.2028,145.0484
+Sunday Creek,Victoria,VIC,-37.2602,145.1482
+Tyaak,Victoria,VIC,-37.2167,145.1333
+Sugarloaf Creek,Victoria,VIC,-37.2602,145.1482
+Hazeldene,Victoria,VIC,-37.292,145.1406
+Tallarook,Victoria,VIC,-37.0937,145.1
+Northwood,Victoria,VIC,-36.9667,145.1167
+Caveat,Victoria,VIC,-37.0605,145.2132
+Highlands,Victoria,VIC,-37.1,145.4
+Hilldene,Victoria,VIC,-37.0333,145.0667
+Whiteheads Creek,Victoria,VIC,-37.0468,145.2864
+Seymour South,Victoria,VIC,-37.0605,145.2132
+Dropmore,Victoria,VIC,-37.0605,145.2132
+Kerrisdale,Victoria,VIC,-37.0517,145.3285
+Seymour,Victoria,VIC,-37.0517,145.3285
+Trawool,Victoria,VIC,-37.0517,145.3285
+Seymour,Victoria,VIC,-37.0266,145.1392
+Puckapunyal,Victoria,VIC,-36.9949,145.0401
+Puckapunyal Milpo,Victoria,VIC,-36.9604,145.0527
+Mangalore,Victoria,VIC,-36.9333,145.1833
+Avenel,Victoria,VIC,-36.9452,145.3379
+Upton Hill,Victoria,VIC,-36.9009,145.2337
+Locksley,Victoria,VIC,-36.9011,145.4139
+Longwood,Victoria,VIC,-36.9011,145.4139
+Strathbogie,Victoria,VIC,-36.85,145.75
+Moglonemby,Victoria,VIC,-36.65,145.5333
+Euroa,Victoria,VIC,-36.7555,145.5708
+Guthridge,Victoria,VIC,-38.106,147.0608
+Wurruk,Victoria,VIC,-38.1167,147.0333
+Cobains,Victoria,VIC,-38.0833,147.15
+Bundalaguah,Victoria,VIC,-38.0333,147.0167
+Flynn,Western Australia,WA,-31.9264,116.7354
+Balladong,Western Australia,WA,-31.9264,116.7354
+Cold Harbour,Western Australia,WA,-31.9264,116.7354
+Narraloggan,Western Australia,WA,-31.9264,116.7354
+Wilberforce,Western Australia,WA,-31.9264,116.7354
+Kelmscott Dc,Western Australia,WA,-32.1167,116.0056


### PR DESCRIPTION
Made some improvement on the database seeding process, covering some items from issue #578. Just did this as I wanted to test performance on geo related processing.

This will let you...
- Create N number of members and 
- Populate member's location
- Populate garden's location
- Creates a planting from various crops, sunniness and planted_from for each user.

The default number of members is still 3, but you can specify the number of members as...
<code>rake db:seed member_size=100</code>
or
<code>rake db:reset member_size=100<code>
Tested up to 1000 worked fine.