### PR TITLE
Added roles to profile page

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -107,6 +107,15 @@ class Member < ActiveRecord::Base
     roles.any? { |r| r.name.gsub(/\s+/, "_").underscore.to_sym == role_sym }
   end
 
+  def list_roles
+    roles = ""
+    self.roles.each do |role|
+      roles += role.name + ", "
+    end
+    roles.slice!(-2..-1)
+    roles
+  end
+
   def current_order
     orders.where(:completed_at => nil).first
   end

--- a/app/views/members/_account.html.haml
+++ b/app/views/members/_account.html.haml
@@ -1,6 +1,9 @@
 %h3 Account details
 
 %p
+  %strong= member.list_roles
+
+%p
   %strong Member since:
   = member.created_at.to_s(:date)
 
@@ -8,4 +11,3 @@
   %strong Account type:
   = member.account_type
   account
-

--- a/app/views/members/show.html.haml
+++ b/app/views/members/show.html.haml
@@ -1,4 +1,5 @@
-- content_for :title, @member.login_name
+%h1= @member.login_name
+%p= @member.list_roles
 - content_for :subtitle, @member.location
 - content_for :buttonbar do
   - if can? :update, @member

--- a/app/views/members/show.html.haml
+++ b/app/views/members/show.html.haml
@@ -1,8 +1,5 @@
 - content_for :title, @member.login_name
-- content_for :subtitle do
-  = @member.location |
-  %br
-  = @member.list_roles
+- content_for :subtitle, @member.location
 - content_for :buttonbar do
   - if can? :update, @member
     = link_to 'Edit profile', edit_member_registration_path, :class => 'btn btn-default'

--- a/app/views/members/show.html.haml
+++ b/app/views/members/show.html.haml
@@ -1,6 +1,8 @@
-%h1= @member.login_name
-%p= @member.list_roles
-- content_for :subtitle, @member.location
+- content_for :title, @member.login_name
+- content_for :subtitle do
+  = @member.location |
+  %br
+  = @member.list_roles
 - content_for :buttonbar do
   - if can? :update, @member
     = link_to 'Edit profile', edit_member_registration_path, :class => 'btn btn-default'


### PR DESCRIPTION
Issue #557 

I couldn't get the roles to show up directly underneath the login name when using 'content_for' so I changed it to an h1 instead (I'm not well-versed in haml). Wasn't sure if you envisioned people holding multiple roles, so the list_roles method accounts for that.

This is my first pull request, so your feedback/corrections would be appreciated! 