### PR TITLE
Add placeholder to harvest screen's plant part select box.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -54,4 +54,5 @@ submit the change with your pull request.
 - Rocky Jaiswal / [rocky-jaiswal](https://github.com/rocky-jaiswal)
 - Robert Landreaux / [robertlandreaux](https://github.com/robertlandreaux)
 - Savant Krishna / [sksavant](https://github.com/sksavant)
+- Katy Ereira / [maccath](https://github.com/maccath)
 

--- a/app/views/harvests/_form.html.haml
+++ b/app/views/harvests/_form.html.haml
@@ -11,7 +11,7 @@
     .col-md-4
       = auto_suggest @harvest, :crop, :class => 'form-control col-md-2', :default => @crop
     .col-md-4
-      = collection_select(:harvest, :plant_part_id, PlantPart.all, :id, :name, { :selected => @harvest.plant_part_id }, { :class => 'form-control' })
+      = collection_select(:harvest, :plant_part_id, PlantPart.all, :id, :name, { :selected => @harvest.plant_part_id, :include_blank => 'e.g. fruit' }, { :class => 'form-control' })
     %span.help-block.col-md-8
       Can't find what you're looking for?
       = link_to "Request new crops.", new_crop_path


### PR DESCRIPTION
Relates to issue #719 

I've added a blank item with the text 'e.g. fruit' to the harvest plant part select box.

I used this text because it's consistent with the crop placeholder, and added it as `include_blank` instead of `prompt` so that it could be selected on edit.