### PR TITLE
add padding to cropname under thumbnails

### DIFF
--- a/app/assets/stylesheets/overrides.css.less
+++ b/app/assets/stylesheets/overrides.css.less
@@ -174,6 +174,7 @@ p.stats {
       padding-bottom: 2px;
 
       .cropname {
+        padding: 3px 0;
         overflow: hidden;
         text-overflow: ellipsis;
       }


### PR DESCRIPTION
Add 3px of top/bottom padding to crop names below thumbnails so that letter ascenders and descenders are not cut off by the image and scientific names. Should improve appearance of crop index and other places where crop thumbnails are used.