### PR TITLE
Upgrade poltergeist to v1.6.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -117,7 +117,7 @@ group :development, :test do
   gem 'coveralls', require: false       # coverage analysis
   gem 'capybara'                        # integration tests
   gem 'capybara-email'                  # integration tests for email
-  gem 'poltergeist', '~> 1.5.1'         # for headless JS testing
+  gem 'poltergeist', '~> 1.6'           # for headless JS testing
   gem 'i18n-tasks'                      # adds tests for finding missing and unused translations
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -268,7 +268,7 @@ GEM
     pg (0.17.1)
     plupload-rails (1.2.1)
       rails (>= 3.1)
-    poltergeist (1.5.1)
+    poltergeist (1.6.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
       multi_json (~> 1.0)
@@ -384,9 +384,9 @@ GEM
       nokogiri (>= 1.2.0)
       rack (>= 1.0)
       rack-test (>= 0.5.3)
-    websocket-driver (0.5.0)
+    websocket-driver (0.5.4)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.0)
+    websocket-extensions (0.1.2)
     will_paginate (3.0.7)
     xpath (2.0.0)
       nokogiri (~> 1.3)
@@ -443,7 +443,7 @@ DEPENDENCIES
   omniauth-flickr (>= 0.0.15)
   omniauth-twitter
   pg
-  poltergeist (~> 1.5.1)
+  poltergeist (~> 1.6)
   pry
   quiet_assets
   rails (= 4.1.9)


### PR DESCRIPTION
Poltergeist v1.5.1 is nearly a year old, and relies on PhantomJS 1.8, which is 2.5 years old and increasingly hard to find in OS package managers. Poltergeist v1.6 [claims to work with PhantomJS >= 1.8.1](https://github.com/teampoltergeist/poltergeist#installing-phantomjs); I've tested it with PhantomJS 2.0.0 and it runs our test suite without complaint.