### PR TITLE
#558 Currency refactoring in specs.

### DIFF
--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe ApplicationHelper do
   it "formats prices" do
     price_in_dollars(999).should eq '9.99'
-    price_with_currency(999).should eq '9.99 AUD'
+    price_with_currency(999).should eq '9.99 %s' % Growstuff::Application.config.currency
   end
 
   it "parses dates" do

--- a/spec/views/shop/index_spec.rb
+++ b/spec/views/shop/index_spec.rb
@@ -35,8 +35,8 @@ describe 'shop/index.html.haml', :type => "view" do
       assert_select("h2", :text => @product1.name)
     end
 
-    it 'shows prices in AUD' do
-      rendered.should have_content '9.99 AUD'
+    it 'shows prices in configured currency' do
+      rendered.should have_content '9.99 %s' % Growstuff::Application.config.currency
     end
 
     it 'should contain an exchange rate link' do
@@ -45,7 +45,7 @@ describe 'shop/index.html.haml', :type => "view" do
     end
 
     it 'shows recommended price for products that have it' do
-      rendered.should have_content '12.00 AUD'
+      rendered.should have_content '12.00 %s' % Growstuff::Application.config.currency
     end
 
     it 'should contain an exchange rate link for recommended price' do


### PR DESCRIPTION
Issue #558
I noticed that the application_helper.rb spec file wasn't following the naming conventions. I had to rename it.