### PR TITLE
#520 Show private message I'm replying to

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -55,4 +55,5 @@ submit the change with your pull request.
 - Robert Landreaux / [robertlandreaux](https://github.com/robertlandreaux)
 - Savant Krishna / [sksavant](https://github.com/sksavant)
 - Jake Yesbeck / [yez](https://github.com/yez)
+- Andrey Bazhutkin / [andrba](https://github.com/andrba)
 

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -36,6 +36,21 @@ class NotificationsController < ApplicationController
     end
   end
 
+  # GET /notifications/1/reply
+  def reply
+    @notification = Notification.new
+    @sender_notification = Notification.find(params[:id])
+    @recipient = @sender_notification.sender
+    @subject   = @sender_notification.subject =~ /^Re: / ?
+      @sender_notification.subject :
+      "Re: " + @sender_notification.subject
+    
+
+    respond_to do |format|
+      format.html # reply.html.haml
+    end
+  end
+
   # DELETE /notifications/1
   def destroy
     @notification = Notification.find(params[:id])

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -5,12 +5,7 @@ module NotificationsHelper
       new_comment_url(:post_id => notification.post.id)
     else
       # by default, reply link sends a PM in return
-      new_notification_url(
-        :recipient_id => notification.sender.id,
-        :subject => notification.subject =~ /^Re: / ?
-          notification.subject :
-          "Re: " + notification.subject
-      )
+      reply_notification_url(notification)
     end
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -46,6 +46,7 @@ class Ability
       # can read/delete notifications that were sent to them
       can :read, Notification, :recipient_id => member.id
       can :destroy, Notification, :recipient_id => member.id
+      can :reply, Notification, :recipient_id => member.id
       # can send a private message to anyone but themselves
       # note: sadly, we can't test for this from the view, but it works
       # for the model/controller

--- a/app/views/notifications/_notification.html.haml
+++ b/app/views/notifications/_notification.html.haml
@@ -1,0 +1,13 @@
+%p
+  From
+  = link_to notification.sender, notification.sender
+  on
+  = notification.created_at
+
+  - if notification.post_id
+    in response to:
+    = link_to notification.post.subject, notification.post
+
+.well
+  :growstuff_markdown
+    #{ strip_tags(notification.body) }

--- a/app/views/notifications/reply.html.haml
+++ b/app/views/notifications/reply.html.haml
@@ -1,0 +1,6 @@
+= content_for :title, "Send a message to #{@recipient}"
+
+= render @sender_notification
+
+=render 'form'
+

--- a/app/views/notifications/show.html.haml
+++ b/app/views/notifications/show.html.haml
@@ -1,18 +1,6 @@
 = content_for :title, @notification.subject
 
-%p
-  From
-  = link_to @notification.sender, @notification.sender
-  on
-  = @notification.created_at
-
-  - if @notification.post_id
-    in response to:
-    = link_to @notification.post.subject, @notification.post
-
-.well
-  :growstuff_markdown
-    #{ strip_tags(@notification.body) }
+= render @notification
 
 %p
   =link_to 'Delete', @notification, method: :delete, data: { confirm: 'Are you sure?' }, :class => 'btn btn-default'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,7 +41,9 @@ Growstuff::Application.routes.draw do
   resources :comments
   resources :roles
   resources :forums
-  resources :notifications
+  resources :notifications do
+    get 'reply', on: :member
+  end
 
   resources :follows, :only => [:create, :destroy]
   get '/members/:login_name/follows' => 'members#view_follows', :as => 'member_follows'

--- a/spec/controllers/notifications_controller_spec.rb
+++ b/spec/controllers/notifications_controller_spec.rb
@@ -60,18 +60,6 @@ describe NotificationsController do
       assigns(:notification).should eq(notification)
     end
 
-    it "assigns the reply link for a PM" do
-      notification = FactoryGirl.create(:notification, :recipient_id => subject.current_member.id, :post_id => nil)
-      subject = "Re: " + notification.subject
-
-      get :show, {:id => notification.to_param}
-      assigns(:reply_link).should_not be_nil
-      assigns(:reply_link).should eq new_notification_url(
-        :recipient_id => notification.sender_id,
-        :subject => subject
-      )
-    end
-
     it "assigns the reply link for a post comment" do
       notification = FactoryGirl.create(:notification, :recipient_id => subject.current_member.id)
 

--- a/spec/features/notifications_spec.rb
+++ b/spec/features/notifications_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+feature "Notifications", :js => true do
+  let(:sender) { FactoryGirl.create(:member) }
+  let(:recipient) { FactoryGirl.create(:member) }
+  
+  context "On existing notification" do
+    let!(:notification) { FactoryGirl.create(:notification, sender: sender, recipient: recipient, body: "Notification body", :post_id => nil) }
+
+    background do
+      login_as(recipient)
+      visit notification_path(notification)
+    end
+
+    scenario "Replying to the notification" do
+      click_link "Reply"
+      expect(page).to have_content "Notification body"
+
+      fill_in 'notification_body', with: "Response body"
+      click_button "Send"
+
+      expect(page).to have_content "Message was successfully sent"
+    end
+  end
+end

--- a/spec/helpers/notifications_helper_spec.rb
+++ b/spec/helpers/notifications_helper_spec.rb
@@ -13,10 +13,7 @@ describe NotificationsHelper do
 
       link = helper.reply_link(notification)
       link.should_not be_nil
-      link.should eq new_notification_url(
-        :recipient_id => notification.sender_id,
-        :subject => subject
-      )
+      link.should eq reply_notification_url(notification)
     end
 
     it "replies to post comments with post comments" do


### PR DESCRIPTION
Issue #520 

This PR adds a new action ```reply``` to the ```NotificationsController```. 
The ```reply_link``` for the private message replies is changed to /notifications/:id/reply.

It will render the notification the user is replying to.

![image](https://cloud.githubusercontent.com/assets/2174682/7827406/4fb24c5c-046a-11e5-8d57-e98311af3d51.png)