### PR TITLE
Added search form on the places index page.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -57,3 +57,4 @@ submit the change with your pull request.
 - Jake Yesbeck / [yez](https://github.com/yez)
 - Mauricio Gonzalez / [mauricio-gonzalez](https://github.com/mauricio-gonzalez)
 - Andrey Bazhutkin / [andrba](https://github.com/andrba)
+- Gabriel Sandoval / [gabrielsandoval](https://github.com/gabrielsandoval)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -458,3 +458,6 @@ DEPENDENCIES
   unicorn
   webrat
   will_paginate (~> 3.0)
+
+BUNDLED WITH
+   1.10.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -458,6 +458,3 @@ DEPENDENCIES
   unicorn
   webrat
   will_paginate (~> 3.0)
-
-BUNDLED WITH
-   1.10.3

--- a/app/controllers/places_controller.rb
+++ b/app/controllers/places_controller.rb
@@ -21,9 +21,17 @@ class PlacesController < ApplicationController
   end
 
   def search
-    respond_to do |format|
-      format.html do
-        redirect_to place_path(params[:new_place])
+    if params[:new_place].empty?
+      respond_to do |format|
+        format.html do
+          redirect_to places_path, alert: 'Please enter a valid location'
+        end
+      end
+    else
+      respond_to do |format|
+        format.html do
+          redirect_to place_path(params[:new_place])
+        end
       end
     end
   end

--- a/app/views/places/_search_form.html.haml
+++ b/app/views/places/_search_form.html.haml
@@ -1,0 +1,6 @@
+%form{:action => search_places_path, :method => :get, :class => 'form-inline', :role => 'form'}
+  .form-group
+    = label_tag :new_place, "Change location:", :class => 'sr-only'
+    = text_field_tag :new_place, '', :class => 'form-control', :placeholder => "New location..."
+  = submit_tag "Search", :class => 'btn btn-primary'
+%br/

--- a/app/views/places/_search_form.html.haml
+++ b/app/views/places/_search_form.html.haml
@@ -2,5 +2,5 @@
   .form-group
     = label_tag :new_place, "Change location:", :class => 'sr-only'
     = text_field_tag :new_place, '', :class => 'form-control', :placeholder => "New location..."
-  = submit_tag "Search", :class => 'btn btn-primary'
+  = submit_tag "Search", :class => 'btn btn-primary', :id => "search_button"
 %br/

--- a/app/views/places/index.html.haml
+++ b/app/views/places/index.html.haml
@@ -1,4 +1,4 @@
 -content_for :title, "#{ENV['GROWSTUFF_SITE_NAME']} Community Map"
-
+= render partial: 'search_form'
 %div#placesmap
 

--- a/app/views/places/show.html.haml
+++ b/app/views/places/show.html.haml
@@ -1,11 +1,6 @@
 -content_for :title, "#{ENV['GROWSTUFF_SITE_NAME']} members near #{@place}"
 
-%form{:action => search_places_path, :method => :get, :class => 'form-inline', :role => 'form'}
-  .form-group
-    = label_tag :new_place, "Change location:", :class => 'sr-only'
-    = text_field_tag :new_place, '', :class => 'form-control', :placeholder => "New location..."
-  = submit_tag "Search", :class => 'btn btn-primary'
-%br/
+= render partial: 'search_form'
 
 %div#placesmap{ :style => "height:300px"}
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -3,6 +3,7 @@ development:
   database: growstuff_dev
   host: localhost
   user: postgres
+  password: password
 
 test:
   adapter: postgresql

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -68,6 +68,20 @@ Geocoder::Lookup::Test.add_stub(
 )
 
 Geocoder::Lookup::Test.add_stub(
+  "Philippines", [
+    {
+      'latitude'     => 12.7503486,
+      'longitude'    => 122.7312101,
+      'address'      => 'Manila, Mnl, Philippines',
+      'state'        => 'Manila',
+      'state_code'   => 'Mnl',
+      'country'      => 'Philippines',
+      'country_code' => 'PH'
+    }
+  ]
+)
+
+Geocoder::Lookup::Test.add_stub(
   "Greenwich, UK", [
     {
       'latitude' =>         51.483061,

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -15,3 +15,16 @@ if Geocoder.config.lookup != :test
   Geocoder.configure(:lookup => :nominatim)
 end
 
+Geocoder::Lookup::Test.add_stub(
+  "Philippines", [
+    {
+      'latitude'     => 12.7503486,
+      'longitude'    => 122.7312101,
+      'address'      => 'Manila, Mnl, Philippines',
+      'state'        => 'Manila',
+      'state_code'   => 'Mnl',
+      'country'      => 'Philippines',
+      'country_code' => 'PH'
+    }
+  ]
+)

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -14,17 +14,3 @@ Geocoder.configure(
 if Geocoder.config.lookup != :test
   Geocoder.configure(:lookup => :nominatim)
 end
-
-Geocoder::Lookup::Test.add_stub(
-  "Philippines", [
-    {
-      'latitude'     => 12.7503486,
-      'longitude'    => 122.7312101,
-      'address'      => 'Manila, Mnl, Philippines',
-      'state'        => 'Manila',
-      'state_code'   => 'Mnl',
-      'country'      => 'Philippines',
-      'country_code' => 'PH'
-    }
-  ]
-)

--- a/spec/features/places/searching_a_place_spec.rb
+++ b/spec/features/places/searching_a_place_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.feature "User searches", :type => :feature do
+	
+	scenario "with a valid place" do
+		visit "/places"
+		search_with("Philippines")
+		assert true
+	end
+
+	scenario "with a blank search string" do
+		visit "/places"
+		search_with("")
+		assert true
+	end
+
+	def search_with(search_string)
+		fill_in "new_place", :with => search_string
+		click_button "search_button"
+	end
+
+end

--- a/spec/features/places/searching_a_place_spec.rb
+++ b/spec/features/places/searching_a_place_spec.rb
@@ -3,15 +3,20 @@ require "rails_helper"
 RSpec.feature "User searches", :type => :feature do
 	
 	scenario "with a valid place" do
-		visit "/places"
+		visit places_path
 		search_with("Philippines")
-		assert true
+		expect(page).to have_content "members near Philippines"
+		expect(page).to have_button "search_button"
+		page.has_content?('placesmap')
+		expect(page).to have_content "Nearby members"
 	end
 
 	scenario "with a blank search string" do
-		visit "/places"
+		visit places_path
 		search_with("")
-		assert true
+		expect(page).to have_content "Please enter a valid location"
+		expect(page).to have_button "search_button"
+		page.has_content?('placesmap')
 	end
 
 	def search_with(search_string)


### PR DESCRIPTION

![image](https://cloud.githubusercontent.com/assets/6015897/8270877/11095254-182c-11e5-9560-13410c9f88a4.png)

places#show has a search form but places#index doesn't have. I added a search form in the index page of the 'places' so that the users may easily search the place they want to see.

@pozorvlak Sorry I messed up my last PR. Here is a new one. I left the gitignore untouched this time.