### PR TITLE
Show edited date/time on posts/comments and Show last login date on member profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ Pathogen:
 custom_plan.rb
 zeus.json
 .bundle
+config/application.yml

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -58,3 +58,4 @@ submit the change with your pull request.
 - Mauricio Gonzalez / [mauricio-gonzalez](https://github.com/mauricio-gonzalez)
 - Andrey Bazhutkin / [andrba](https://github.com/andrba)
 - Gabriel Sandoval / [gabrielsandoval](https://github.com/gabrielsandoval)
+- Cjay Billones / [CjayBillones](https://github.com/CjayBillones)

--- a/app/views/comments/_single.html.haml
+++ b/app/views/comments/_single.html.haml
@@ -5,10 +5,10 @@
         = render :partial => "members/avatar", :locals => { :member => comment.author }
       .col-md-11
         .comment-meta
-          Posted by
+          = (comment.created_at == comment.updated_at) ? 'Posted by' : 'Edited by'
           = link_to comment.author.login_name, member_path(comment.author)
-          at
-          = comment.created_at
+          on
+          = (comment.created_at == comment.updated_at) ? comment.created_at : comment.updated_at
 
         .comment-body
           :growstuff_markdown

--- a/app/views/members/_account.html.haml
+++ b/app/views/members/_account.html.haml
@@ -9,3 +9,7 @@
   = member.account_type
   account
 
+%p
+  %strong Last Login:
+  = member.last_sign_in_at
+

--- a/app/views/posts/_single.html.haml
+++ b/app/views/posts/_single.html.haml
@@ -9,13 +9,13 @@
 
         .post-meta
           %p
-            Posted by
+            = (post.created_at == post.updated_at) ? 'Posted by' : 'Edited by'
             = link_to post.author.login_name, member_path(post.author)
             - if post.forum
               in
               = link_to post.forum, post.forum
-            at
-            = post.created_at
+            on
+            = (post.created_at == post.updated_at) ? post.created_at : post.updated_at
 
         .post-body
           :growstuff_markdown

--- a/spec/features/comments/commenting_a_comment_spec.rb
+++ b/spec/features/comments/commenting_a_comment_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+feature 'Commenting on a post' do
+  let(:member)   { FactoryGirl.create(:member) }
+  let(:post)     { FactoryGirl.create(:post, :author => member) }
+  
+  background do
+    login_as(member)
+    visit new_comment_path(:post_id => post.id)
+  end
+
+  scenario "creating a comment" do
+    fill_in "comment_body", :with => "This is a sample test for comment"
+    click_button "Post comment"
+    expect(page).to have_content "Comment was successfully created"
+    expect(page).to have_content "Commented by"
+  end
+
+  context "editing a comment" do
+    let(:existing_comment) { FactoryGirl.create(:comment, :post => post, :author => member) }
+
+    background do
+      visit edit_comment_path(existing_comment)
+    end
+
+    scenario "saving edit" do
+      fill_in "comment_body", :with => "Testing edit for comment"
+      click_button "Post comment"  
+      expect(page).to have_content "Comment was successfully updated"
+      expect(page).to have_content "Edited by"
+    end
+  end
+
+end

--- a/spec/features/comments/commenting_a_comment_spec.rb
+++ b/spec/features/comments/commenting_a_comment_spec.rb
@@ -13,7 +13,7 @@ feature 'Commenting on a post' do
     fill_in "comment_body", :with => "This is a sample test for comment"
     click_button "Post comment"
     expect(page).to have_content "Comment was successfully created"
-    expect(page).to have_content "Commented by"
+    expect(page).to have_content "Posted by"
   end
 
   context "editing a comment" do

--- a/spec/features/posts/posting_a_post_spec.rb
+++ b/spec/features/posts/posting_a_post_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+feature 'Post a post' do
+  let(:member)   { FactoryGirl.create(:member) }
+
+  background do
+    login_as(member)
+    visit new_post_path
+  end
+
+  scenario "creating a post" do
+    fill_in "post_subject", :with => "Testing"
+    fill_in "post_body", :with => "This is a sample test"
+    click_button "Post"
+    expect(page).to have_content "Post was successfully created"
+    expect(page).to have_content "Posted by"
+  end
+
+  context "editing a post" do
+    let(:existing_post) { FactoryGirl.create(:post, :author => member)}
+
+    background do
+      visit edit_post_path(existing_post)
+    end
+
+    scenario "saving edit" do
+      fill_in "post_subject", :with => "Testing Edit"
+      click_button "Post"  
+      expect(page).to have_content "Post was successfully updated"
+      expect(page).to have_content "Edited by"
+    end
+  end
+
+end


### PR DESCRIPTION
@Skud  this PR is for issues #476 and #546 .

The system changes Posted by <name> on <date/time> into Edited by <name> on <date/time> whenever a post/comment is edited.

![screen shot 2015-06-23 at 8 31 00 am](https://cloud.githubusercontent.com/assets/8434127/8296357/3e936da2-1982-11e5-896c-e096aa0b02e1.png)