### PR TITLE
Fixes #720 - Places show nearby seeds, members, and plantings.

### DIFF
--- a/app/views/gardens/show.html.haml
+++ b/app/views/gardens/show.html.haml
@@ -47,15 +47,13 @@
     - if @garden.plantings.current.size > 0
       .container
         .row
-          .col-md-1
-            %b #
-          .col-md-3
+          .col-md-4
             %b Photo
           .col-md-6
             %b Planting Details
           .col-md-2
         - @garden.plantings.current.each.with_index do |planting_current, index_current|
-          = render partial: "plantings/thumbnail", locals: {:planting => planting_current, :index => index_current}
+          = render partial: "plantings/thumbnail", locals: {:planting => planting_current}
     - else
       %p
         Nothing is currently planted here.
@@ -64,15 +62,13 @@
     - if @garden.plantings.finished.size > 0
       .container
         .row
-          .col-md-1
-            %b #
-          .col-md-3
+          .col-md-4
             %b Photo
           .col-md-6
             %b Planting Details
           .col-md-2
-        - @garden.plantings.finished.each.with_index do |planting_finished, index_finished|
-          = render partial: "plantings/thumbnail", locals: {:planting => planting_finished, :index => index_finished}
+        - @garden.plantings.finished.each.with_index do |planting_finished|
+          = render partial: "plantings/thumbnail", locals: {:planting => planting_finished}
       
   .col-md-3
     %h4 About this garden

--- a/app/views/gardens/show.html.haml
+++ b/app/views/gardens/show.html.haml
@@ -45,30 +45,16 @@
 
     %h3 What's planted here?
     - if @garden.plantings.current.size > 0
-      .container
-        .row
-          .col-md-4
-            %b Photo
-          .col-md-6
-            %b Planting Details
-          .col-md-2
-        - @garden.plantings.current.each.with_index do |planting_current, index_current|
-          = render partial: "plantings/thumbnail", locals: {:planting => planting_current}
+      - @garden.plantings.current.each.with_index do |planting_current, index_current|
+        = render partial: "plantings/thumbnail", locals: {:planting => planting_current}
     - else
       %p
         Nothing is currently planted here.
 
     %h3 Previously planted in this garden
     - if @garden.plantings.finished.size > 0
-      .container
-        .row
-          .col-md-4
-            %b Photo
-          .col-md-6
-            %b Planting Details
-          .col-md-2
-        - @garden.plantings.finished.each.with_index do |planting_finished|
-          = render partial: "plantings/thumbnail", locals: {:planting => planting_finished}
+      - @garden.plantings.finished.each.with_index do |planting_finished|
+        = render partial: "plantings/thumbnail", locals: {:planting => planting_finished}
       
   .col-md-3
     %h4 About this garden

--- a/app/views/gardens/show.html.haml
+++ b/app/views/gardens/show.html.haml
@@ -44,17 +44,19 @@
                   = link_to "Add photo", new_photo_path(:type => "garden", :id => @garden.id), :class => 'btn btn-primary'
 
     %h3 What's planted here?
-    - if @garden.plantings.current.size > 0
-      - @garden.plantings.current.each.with_index do |planting_current, index_current|
-        = render partial: "plantings/thumbnail", locals: {:planting => planting_current}
+    .row
+      - if @garden.plantings.current.size > 0
+        - @garden.plantings.current.each.with_index do |planting_current, index_current|
+          = render partial: "plantings/thumbnail", locals: {:planting => planting_current}
     - else
       %p
         Nothing is currently planted here.
 
     %h3 Previously planted in this garden
-    - if @garden.plantings.finished.size > 0
-      - @garden.plantings.finished.each.with_index do |planting_finished|
-        = render partial: "plantings/thumbnail", locals: {:planting => planting_finished}
+    .row
+      - if @garden.plantings.finished.size > 0
+        - @garden.plantings.finished.each.with_index do |planting_finished|
+          = render partial: "plantings/thumbnail", locals: {:planting => planting_finished}
       
   .col-md-3
     %h4 About this garden

--- a/app/views/gardens/show.html.haml
+++ b/app/views/gardens/show.html.haml
@@ -44,8 +44,8 @@
                   = link_to "Add photo", new_photo_path(:type => "garden", :id => @garden.id), :class => 'btn btn-primary'
 
     %h3 What's planted here?
-    .row
-      - if @garden.plantings.current.size > 0
+    - if @garden.plantings.current.size > 0
+      .row
         - @garden.plantings.current.each.with_index do |planting_current, index_current|
           = render partial: "plantings/thumbnail", locals: {:planting => planting_current}
     - else
@@ -53,8 +53,8 @@
         Nothing is currently planted here.
 
     %h3 Previously planted in this garden
-    .row
-      - if @garden.plantings.finished.size > 0
+    - if @garden.plantings.finished.size > 0
+      .row
         - @garden.plantings.finished.each.with_index do |planting_finished|
           = render partial: "plantings/thumbnail", locals: {:planting => planting_finished}
       

--- a/app/views/members/_gardens.html.haml
+++ b/app/views/members/_gardens.html.haml
@@ -35,15 +35,8 @@
 
         %h3 What's planted here?
         - if g.featured_plantings.size > 0
-          .container
-            .row
-              .col-md-4
-                %b Photo
-              .col-md-6
-                %b Planting Details
-              .col-md-2
-            - g.featured_plantings.each.with_index do |planting|
-              = render partial: "plantings/thumbnail", locals: {:planting => planting}
+          - g.featured_plantings.each.with_index do |planting|
+            = render partial: "plantings/thumbnail", locals: {:planting => planting}
 
         %p
           = link_to "More about this garden...", url_for(g)

--- a/app/views/members/_gardens.html.haml
+++ b/app/views/members/_gardens.html.haml
@@ -34,9 +34,11 @@
                         = link_to "Add photo", new_photo_path(:type => "garden", :id => g.id), :class => 'btn btn-primary'
 
         %h3 What's planted here?
-        - if g.featured_plantings.size > 0
-          - g.featured_plantings.each.with_index do |planting|
-            = render partial: "plantings/thumbnail", locals: {:planting => planting}
+        .row
+          - if g.featured_plantings.size > 0
+            - g.featured_plantings.each.with_index do |planting|
+              .col-xs-12.col-lg-6
+                = render partial: "plantings/thumbnail", locals: {:planting => planting}
 
         %p
           = link_to "More about this garden...", url_for(g)

--- a/app/views/members/_gardens.html.haml
+++ b/app/views/members/_gardens.html.haml
@@ -37,15 +37,13 @@
         - if g.featured_plantings.size > 0
           .container
             .row
-              .col-md-1
-                %b #
-              .col-md-3
+              .col-md-4
                 %b Photo
               .col-md-6
                 %b Planting Details
               .col-md-2
-            - g.featured_plantings.each.with_index do |planting, index|
-              = render partial: "plantings/thumbnail", locals: {:planting => planting, :index => index}
+            - g.featured_plantings.each.with_index do |planting|
+              = render partial: "plantings/thumbnail", locals: {:planting => planting}
 
         %p
           = link_to "More about this garden...", url_for(g)

--- a/app/views/places/show.html.haml
+++ b/app/views/places/show.html.haml
@@ -36,7 +36,8 @@
         - plantings << planting
     - if !plantings.blank?
       - plantings.first(10).each.with_index do |planting, index|
-        = render partial: "plantings/thumbnail", locals: {:planting => planting, :index => index}
+        .col-xs-12.col-lg-6
+          = render partial: "plantings/thumbnail", locals: {:planting => planting, :index => index}
       = link_to "View all plantings >>", plantings_path
     - else
       %p No nearby plantings found

--- a/app/views/places/show.html.haml
+++ b/app/views/places/show.html.haml
@@ -36,9 +36,7 @@
         - plantings << planting
     - if !plantings.blank?
       .row
-        .col-md-1
-          %b #
-        .col-md-3
+        .col-md-4
           %b Photo
         .col-md-6
           %b Planting Details

--- a/app/views/places/show.html.haml
+++ b/app/views/places/show.html.haml
@@ -11,5 +11,46 @@
     - @nearby_members.first(30).each do |member|
       .col-md-4.three-across
         = render :partial => "members/thumbnail", :locals => { :member => member }
+  = link_to "View all members >>", members_path
+- elsif @place
+  %p No results found
+
+%h3
+  = "Seeds available for trade near #{@place}"
+%br
+- if !@nearby_members.empty?
+  .row
+    - crop_id = []
+    - @nearby_members.first(10).each do |member|
+      - member.seeds.first(5).each do |seed|
+        - crop_id.push seed.crop.id
+    - crop_id.uniq.first(20).each do |crop|
+      .col-md-2.six-across
+        = render :partial => "crops/thumbnail", :locals => { :crop => Crop.find(crop) }
+  = link_to "View all seeds >>", seeds_path
+
+- elsif @place
+  %p No results found
+
+%h3
+  = "Recent plantings near #{@place}"
+%br
+- if !@nearby_members.empty?
+  - plantings = []
+  - @nearby_members.first(10).each do |member|
+    - member.plantings.first(5).each do |planting|
+      - plantings << planting
+  .row
+    .col-md-1
+      %b #
+    .col-md-3
+      %b Photo
+    .col-md-6
+      %b Planting Details
+    .col-md-2
+  - plantings.first(10).each.with_index do |planting, index|
+    = render partial: "plantings/thumbnail", locals: {:planting => planting, :index => index}
+  = link_to "View all plantings >>", plantings_path
+
 - elsif @place
   %p No results found

--- a/app/views/places/show.html.haml
+++ b/app/views/places/show.html.haml
@@ -4,7 +4,7 @@
 
 %div#placesmap{ :style => "height:300px"}
 
-%h3 Nearby members
+%h3= "Nearby members"
 
 - if !@nearby_members.empty?
   .row
@@ -12,45 +12,41 @@
       .col-md-4.three-across
         = render :partial => "members/thumbnail", :locals => { :member => member }
   = link_to "View all members >>", members_path
-- elsif @place
-  %p No results found
 
-%h3
-  = "Seeds available for trade near #{@place}"
-%br
-- if !@nearby_members.empty?
-  .row
-    - crop_id = []
-    - @nearby_members.first(10).each do |member|
-      - member.seeds.first(5).each do |seed|
-        - crop_id.push seed.crop.id
-    - crop_id.uniq.first(20).each do |crop|
-      .col-md-2.six-across
-        = render :partial => "crops/thumbnail", :locals => { :crop => Crop.find(crop) }
-  = link_to "View all seeds >>", seeds_path
-
-- elsif @place
-  %p No results found
-
-%h3
-  = "Recent plantings near #{@place}"
-%br
-- if !@nearby_members.empty?
-  - plantings = []
+  %h3= "Seeds available for trade near #{@place}"
+  - crop_id = []
   - @nearby_members.first(10).each do |member|
-    - member.plantings.first(5).each do |planting|
-      - plantings << planting
-  .row
-    .col-md-1
-      %b #
-    .col-md-3
-      %b Photo
-    .col-md-6
-      %b Planting Details
-    .col-md-2
-  - plantings.first(10).each.with_index do |planting, index|
-    = render partial: "plantings/thumbnail", locals: {:planting => planting, :index => index}
-  = link_to "View all plantings >>", plantings_path
+    - member.seeds.first(5).each do |seed|
+      - crop_id.push seed.crop.id
+  - if !crop_id.blank?
+    .row
+      - crop_id.uniq.first(20).each do |crop|
+        .col-md-2.six-across
+          = render :partial => "crops/thumbnail", :locals => { :crop => Crop.find(crop) }
+    = link_to "View all seeds >>", seeds_path
+  - else
+    %p No nearby seeds found
 
-- elsif @place
+  %h3= "Recent plantings near #{@place}"
+  
+  .row
+    - plantings = []
+    - @nearby_members.first(10).each do |member|
+      - member.plantings.first(5).each do |planting|
+        - plantings << planting
+    - if !plantings.blank?
+      .row
+        .col-md-1
+          %b #
+        .col-md-3
+          %b Photo
+        .col-md-6
+          %b Planting Details
+        .col-md-2
+      - plantings.first(10).each.with_index do |planting, index|
+        = render partial: "plantings/thumbnail", locals: {:planting => planting, :index => index}
+      = link_to "View all plantings >>", plantings_path
+    - else
+      %p No nearby plantings found
+- else
   %p No results found

--- a/app/views/places/show.html.haml
+++ b/app/views/places/show.html.haml
@@ -35,12 +35,6 @@
       - member.plantings.first(5).each do |planting|
         - plantings << planting
     - if !plantings.blank?
-      .row
-        .col-md-4
-          %b Photo
-        .col-md-6
-          %b Planting Details
-        .col-md-2
       - plantings.first(10).each.with_index do |planting, index|
         = render partial: "plantings/thumbnail", locals: {:planting => planting, :index => index}
       = link_to "View all plantings >>", plantings_path

--- a/app/views/plantings/_thumbnail.html.haml
+++ b/app/views/plantings/_thumbnail.html.haml
@@ -1,7 +1,5 @@
 .row
-  .col-md-1
-    = "##{index+1}"
-  .col-md-3
+  .col-md-4
     = link_to image_tag((planting.default_photo ?  planting.default_photo.thumbnail_url : 'placeholder_150.png'), :alt => planting.crop_id, :class => 'img'), planting
   .col-md-6
     %dl.dl-horizontal
@@ -29,8 +27,7 @@
       - if can? :destroy, planting
         %li= link_to 'Delete', planting, method: :delete, data: { confirm: 'Are you sure?' }, :class => 'btn btn-default btn-xs'
 .row
-  .col-md-1
-  .col-md-3
+  .col-md-4
     %ul{:style => "list-style-type:none"}
       %li
         %b Crop name:

--- a/app/views/plantings/_thumbnail.html.haml
+++ b/app/views/plantings/_thumbnail.html.haml
@@ -1,7 +1,7 @@
 .row
-  .col-md-4
+  .col-xs-4.col-md-2
     = link_to image_tag((planting.default_photo ?  planting.default_photo.thumbnail_url : 'placeholder_150.png'), :alt => planting.crop_id, :class => 'img'), planting
-  .col-md-6
+  .col-xs-4.col-md-6
     %dl.dl-horizontal
       %dt Owner:
       %dd= link_to planting.owner.login_name, planting.owner
@@ -17,7 +17,7 @@
       %dd= "#{display_sunniness(planting)}"
       %dt Planted from:
       %dd= "#{display_planted_from(planting)}"
-  .col-md-2
+  .col-xs-4.col-md-4
     %ul{:style => "list-style-type:none"}
       %li= link_to 'Details', planting, :class => 'btn btn-default btn-xs'
       - if can? :edit, planting
@@ -27,15 +27,12 @@
       - if can? :destroy, planting
         %li= link_to 'Delete', planting, method: :delete, data: { confirm: 'Are you sure?' }, :class => 'btn btn-default btn-xs'
 .row
-  .col-md-4
-    %ul{:style => "list-style-type:none"}
-      %li
-        %b Crop name:
-        = link_to planting.crop.name, planting.crop
-      %li
-        %b Days until maturity:
-        = "#{display_days_before_maturity(planting)}"
+  .col-xs-3.col-md-4
+    %dl
+      %dt Crop name:
+      %dd= link_to planting.crop.name, planting.crop
+      %dt Days until maturity:
+      %dd= "#{display_days_before_maturity(planting)}"
 
-  .col-md-8
-    %ul{:style => "list-style-type:none"}
-      %li= render partial: 'plantings/planting_progress', locals: {:planting => planting}
+  .col-xs-9.col-md-8
+    = render partial: 'plantings/planting_progress', locals: {:planting => planting}

--- a/app/views/plantings/index.html.haml
+++ b/app/views/plantings/index.html.haml
@@ -20,15 +20,13 @@
 
 - if @plantings.size > 0
   .row
-    .col-md-1
-      %b #
-    .col-md-3
+    .col-md-4
       %b Photo
     .col-md-6
       %b Planting Details
     .col-md-2
-  - @plantings.each.with_index do |planting, index|
-    = render partial: "plantings/thumbnail", locals: {:planting => planting, :index => index}
+  - @plantings.each.with_index do |planting|
+    = render partial: "plantings/thumbnail", locals: {:planting => planting}
 
   %div.pagination
     = page_entries_info @plantings, :model => "plantings"

--- a/app/views/plantings/index.html.haml
+++ b/app/views/plantings/index.html.haml
@@ -19,12 +19,6 @@
     = will_paginate @plantings
 
 - if @plantings.size > 0
-  .row
-    .col-md-4
-      %b Photo
-    .col-md-6
-      %b Planting Details
-    .col-md-2
   - @plantings.each.with_index do |planting|
     = render partial: "plantings/thumbnail", locals: {:planting => planting}
 

--- a/app/views/plantings/index.html.haml
+++ b/app/views/plantings/index.html.haml
@@ -14,18 +14,19 @@
   - else
     = render :partial => 'shared/signin_signup', :locals => { :to => "track what you've planted" }
 
-  %div.pagination
-    = page_entries_info @plantings, :model => "plantings"
-    = will_paginate @plantings
+%div.pagination
+  = page_entries_info @plantings, :model => "plantings"
+  = will_paginate @plantings
 
-- if @plantings.size > 0
-  - @plantings.each.with_index do |planting|
-    .col-xs-12.col-lg-6
-      = render partial: "plantings/thumbnail", locals: {:planting => planting}
+.row
+  - if @plantings.size > 0
+    - @plantings.each.with_index do |planting|
+      .col-xs-12.col-lg-6
+        = render partial: "plantings/thumbnail", locals: {:planting => planting}
 
-  %div.pagination
-    = page_entries_info @plantings, :model => "plantings"
-    = will_paginate @plantings
+%div.pagination
+  = page_entries_info @plantings, :model => "plantings"
+  = will_paginate @plantings
 
   %ul.list-inline
     %li The data on this page is available in the following formats:

--- a/app/views/plantings/index.html.haml
+++ b/app/views/plantings/index.html.haml
@@ -20,7 +20,8 @@
 
 - if @plantings.size > 0
   - @plantings.each.with_index do |planting|
-    = render partial: "plantings/thumbnail", locals: {:planting => planting}
+    .col-xs-12.col-lg-6
+      = render partial: "plantings/thumbnail", locals: {:planting => planting}
 
   %div.pagination
     = page_entries_info @plantings, :model => "plantings"

--- a/spec/features/places/searching_a_place_spec.rb
+++ b/spec/features/places/searching_a_place_spec.rb
@@ -1,7 +1,12 @@
 require "rails_helper"
 
 RSpec.feature "User searches", :type => :feature do
-	
+	let(:member)   { FactoryGirl.create(:member, location: "Philippines") }
+    let!(:maize)   { FactoryGirl.create(:maize) }
+    let(:garden)   { FactoryGirl.create(:garden, owner: member) }
+    let!(:seed1)    { FactoryGirl.create(:seed, owner: member) }
+    let!(:planting){ FactoryGirl.create(:planting, garden: garden, owner: member, planted_at: Date.parse("2013-3-10")) }
+
 	scenario "with a valid place" do
 		visit places_path
 		search_with("Philippines")
@@ -9,6 +14,7 @@ RSpec.feature "User searches", :type => :feature do
 		expect(page).to have_button "search_button"
 		page.has_content?('placesmap')
 		expect(page).to have_content "Nearby members"
+		expect(page).to_not have_content "No results found"
 	end
 
 	scenario "with a blank search string" do
@@ -19,9 +25,40 @@ RSpec.feature "User searches", :type => :feature do
 		page.has_content?('placesmap')
 	end
 
-	def search_with(search_string)
+  	describe "Nearby plantings, seed, and members" do
+	    before(:each) do
+	      login_as(member)
+	      visit places_path
+		  search_with("Philippines")
+	    end
+
+	    it "should show that there are nearby seeds, plantings, and members" do
+	      expect(page).to have_content "Nearby members"
+      	  expect(page).to have_content "Seeds available for trade near Philippines"
+      	  expect(page).to have_content "Recent plantings near Philippines"
+      	  find_link("View all members").visible?
+      	  find_link("View all seeds").visible?
+      	  find_link("View all plantings").visible?
+      	end
+
+      	it "should go to members' index page" do
+      	  click_link('View all members >>')
+      	  current_path.should == members_path
+      	end
+
+      	it "should go to plantings' index page" do
+      	  click_link('View all plantings >>')
+      	  current_path.should == plantings_path
+      	end
+
+      	it "should go to seeds' index page" do
+      	  click_link('View all seeds >>')
+      	  current_path.should == seeds_path
+      	end
+	end
+
+  	def search_with(search_string)
 		fill_in "new_place", :with => search_string
 		click_button "search_button"
 	end
-
 end


### PR DESCRIPTION
OLD places page:
![screen shot 2015-07-07 at 1 26 34 pm](https://cloud.githubusercontent.com/assets/6015897/8539263/e55faafe-24ab-11e5-9c22-0ae5e5854294.png)

NEW places page:
![screen shot 2015-07-07 at 1 34 46 pm](https://cloud.githubusercontent.com/assets/6015897/8539355/ff62500e-24ac-11e5-9845-ed9080c3bff6.png)


Hi @pozorvlak and @maco ,

I added nearby seeds and plantings in addition to nearby members as a result when searching for a place (see image above). I also created the feature tests on this.

I'll be waiting for your response.

Gabriel Sandoval,
AELOGICA Intern