### PR TITLE
Set staging secret key from environment

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -8,10 +8,13 @@
 development:
   secret_key_base: 'b1b67abb399261478f4721e704eb3851466daf60d9cd2b53a1839b056d641c4c1c2a476bcaf7addc6d6548926cfd32fa5a00a8de258880257ebb5a6fd86cb08f'
   # run 'rake secret' to generate your own
- 
+
 test:
   secret_key_base: 'be557aa019b181f201c9906663dbf8f22efb1b70b11f78035bfeda86aa7dcfd1efb184e2ee894a0ae0dc37fe67d311f38e7731fa16d8d595f2e1ef5447bae020'
   # run 'rake secret' to generate your own
- 
+
+staging:
+  secret_key_base: <%= ENV["RAILS_SECRET_TOKEN"] %>
+
 production:
   secret_key_base: <%= ENV["RAILS_SECRET_TOKEN"] %>


### PR DESCRIPTION
Currently the staging server is down because it can't find the secret key needed to sign cookies. This is related to the changes in #710.