### PR TITLE
Remove one-off tasks that were run for Release 8.

### DIFF
--- a/script/deploy-tasks.sh
+++ b/script/deploy-tasks.sh
@@ -10,17 +10,5 @@
 # echo "YYYY-MM-DD - do something or other"
 # rake growstuff:oneoff:something
 
-echo "2014-12-01 - load lots of new crops"
-rake growstuff:import_crops file=db/seeds/crops-12-mint.csv
-rake growstuff:import_crops file=db/seeds/crops-13-brassicas.csv
-rake growstuff:import_crops file=db/seeds/crops-14-london-workingbee.csv
-rake growstuff:import_crops file=db/seeds/crops-15-squashes.csv
-
-echo "2014-12-01 - load alternate names for crops"
-rake growstuff:oneoff:add_alternate_names
-
-echo "2015-01-28 - populate the harvest si_weight field"
-rake growstuff:oneoff:populate_si_weight
-
 echo "2015-01-30 - build Elasticsearch index"
 rake growstuff:oneoff:elasticsearch_create_index


### PR DESCRIPTION
The ElasticSearch index task was run, but failed because we didn't have an ElasticSearch instance to run it against.

There's also a potential speed improvement on the `growstuff:import_crops` rake task. Currently we load the cropbot user once per row, but we could load them once at the beginning. I don't know how much of a speedup this would give. Right now it doesn't matter too much, but we'll no doubt want to add crops in the future (and the same code is run by `rake db:seed`).