### PR TITLE
[#568] Signout redirects to last page visited

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,6 +22,10 @@ class ApplicationController < ActionController::Base
     stored_location_for(:member) || root_path
   end
 
+  def after_sign_out_path_for(resource_or_scope)
+    request.referrer
+  end
+
   # tweak CanCan defaults because we don't have a "current_user" method
   # this means that we use current_user in specs but current_member everywhere
   # else in the code.
@@ -33,7 +37,7 @@ class ApplicationController < ActionController::Base
   rescue_from CanCan::AccessDenied do |exception|
     redirect_to request.referer || root_url, :alert => exception.message
   end
-   
+
   def set_locale
     I18n.locale = params[:locale] || extract_locale_from_subdomain || I18n.default_locale
   end
@@ -48,7 +52,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.for(:sign_up) do |member| 
+    devise_parameter_sanitizer.for(:sign_up) do |member|
       member.permit(:login_name, :email, :password, :password_confirmation,
         :remember_me, :login,
         # terms of service

--- a/spec/features/signout_spec.rb
+++ b/spec/features/signout_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+feature "signout" do
+  let(:member){FactoryGirl.create(:member)}
+  
+  scenario "redirect to previous page after signout" do
+    visit crops_path # some random page
+    click_link 'Sign in'
+    fill_in 'Login', with: member.login_name
+    fill_in 'Password', with: member.password
+    click_button 'Sign in'
+    click_link 'Sign out'
+    current_path.should eq crops_path
+  end
+
+  scenario "after signout, redirect to signin page if page needs authentication" do
+    models = %w[plantings harvests posts photos gardens seeds]
+    models.each do |model|
+      visit "/#{model}/new"
+      current_path.should eq new_member_session_path
+      fill_in 'Login', with: member.login_name
+      fill_in 'Password', with: member.password
+      click_button 'Sign in'
+      current_path.should eq "/#{model}/new"
+      click_link 'Sign out'
+      current_path.should eq new_member_session_path
+    end
+  end
+
+end


### PR DESCRIPTION
Sign out redirects to last page visited however, it doesn't redirect to root_path if the page last visited needs authentication (e.g. edit account), instead it is redirected to the login page