### PR TITLE
Added multiple forms for scientific and alternate names on crop creation  (Fixes #615)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -62,3 +62,4 @@ submit the change with your pull request.
 - Katy Ereira / [maccath](https://github.com/maccath)
 - Gabrielle DeWitt / [gabrielle27](https://github.com/gabrielle27)
 - Manmeet Singh / [manmeetsingh](https://github.com/manmeetsingh)
+- Jym Paul Carandang / [jacarandang](https://github.com/jacarandang)

--- a/app/assets/javascripts/seeds.js.coffee
+++ b/app/assets/javascripts/seeds.js.coffee
@@ -6,20 +6,35 @@ jQuery ->
   $('.add-datepicker').datepicker('format' : 'yyyy-mm-dd')
 
 $ ->
-  template = "<div id='template[INDEX]' class='template col-md-12'><div class='col-md-2'><label>Alternate name INDEX:</label></div><div class='col-md-8'><input class='form-control', id='alt_name[INDEX]')'></input><span class='help-block'>Alternate name of crop.</span></div><div class='col-md-2'></div></div>"
+  sci_template = "<div id='sci_template[INDEX]' class='template col-md-12'><div class='col-md-2'><label>Scientific name INDEX:</label></div><div class='col-md-8'><input name='sci_name[INDEX]' class='form-control', id='sci_name[INDEX]')'></input><span class='help-block'>Scientific name of crop.</span></div><div class='col-md-2'></div></div>"
 
-  index = 2
+  sci_index = $('#scientific_names .template').length + 1
 
-  $('#add-crop-row').click ->
-    compiled_input = $(template.split("INDEX").join(index))
-    $('#someform').append(compiled_input)
-    console.log("Added %d", index)
-    index = index + 1
+  $('#add-sci_name-row').click ->
+    compiled_input = $(sci_template.split("INDEX").join(sci_index))
+    $('#scientific_names').append(compiled_input)
+    sci_index = sci_index + 1
 
-  $('#remove-crop-row').click ->
-    if (index > 2)
-    	index = index - 1
-    	tmp = 'template[' + index + ']'
+  $('#remove-sci_name-row').click ->
+    if (sci_index > 2)
+    	sci_index = sci_index - 1
+    	tmp = 'sci_template[' + sci_index + ']'
     	element = document.getElementById(tmp)
     	element.remove()
-    	console.log("Removed %s", tmp)
+
+  alt_template = "<div id='alt_template[INDEX]' class='template col-md-12'><div class='col-md-2'><label>Alternate name INDEX:</label></div><div class='col-md-8'><input name='alt_name[INDEX]' class='form-control', id='alt_name[INDEX]')'></input><span class='help-block'>Alternate name of crop.</span></div><div class='col-md-2'></div></div>"
+
+  alt_index = $('#alternate_names .template').length + 1
+
+  $('#add-alt_name-row').click ->
+    compiled_input = $(alt_template.split("INDEX").join(alt_index))
+    $('#alternate_names').append(compiled_input)
+    alt_index = alt_index + 1
+
+  $('#remove-alt_name-row').click ->
+    if (alt_index > 2)
+      alt_index = alt_index - 1
+      tmp = 'alt_template[' + alt_index + ']'
+      element = document.getElementById(tmp)
+      console.log("%s",tmp)
+      element.remove()

--- a/app/assets/javascripts/seeds.js.coffee
+++ b/app/assets/javascripts/seeds.js.coffee
@@ -4,3 +4,22 @@
 
 jQuery ->
   $('.add-datepicker').datepicker('format' : 'yyyy-mm-dd')
+
+$ ->
+  template = "<div id='template[INDEX]', class='form-group'><label class='control-label col-md-2'>Alternate name INDEX:</label><div class='col-md-8'><input class='form-control', id='alt_name[INDEX]')'></input><span class='help-block'>Alternate name of crop.</span></div></div>"
+
+  index = 2
+
+  $('#add-crop-row').click ->
+    compiled_input = $(template.split("INDEX").join(index))
+    $('#someform').append(compiled_input)
+    console.log("Added %d", index)
+    index = index + 1
+
+  $('#remove-crop-row').click ->
+    if (index != 0)
+    	index = index - 1
+    	tmp = 'template[' + index + ']'
+    	element = document.getElementById(tmp)
+    	element.remove()
+    	console.log("Removed %s", tmp)

--- a/app/assets/javascripts/seeds.js.coffee
+++ b/app/assets/javascripts/seeds.js.coffee
@@ -4,6 +4,10 @@
 
 jQuery ->
   $('.add-datepicker').datepicker('format' : 'yyyy-mm-dd')
+  $('#add-sci_name-row').css("display", "inline-block")
+  $('#remove-sci_name-row').css("display", "inline-block")
+  $("#add-alt_name-row").css("display", "inline-block")
+  $("#remove-alt_name-row").css("display", "inline-block")
 
 $ ->
   sci_template = "<div id='sci_template[INDEX]' class='template col-md-12'><div class='col-md-2'><label>Scientific name INDEX:</label></div><div class='col-md-8'><input name='sci_name[INDEX]' class='form-control', id='sci_name[INDEX]')'></input><span class='help-block'>Scientific name of crop.</span></div><div class='col-md-2'></div></div>"
@@ -38,3 +42,4 @@ $ ->
       element = document.getElementById(tmp)
       console.log("%s",tmp)
       element.remove()
+    

--- a/app/assets/javascripts/seeds.js.coffee
+++ b/app/assets/javascripts/seeds.js.coffee
@@ -6,7 +6,7 @@ jQuery ->
   $('.add-datepicker').datepicker('format' : 'yyyy-mm-dd')
 
 $ ->
-  template = "<div id='template[INDEX]', class='form-group'><label class='control-label col-md-2'>Alternate name INDEX:</label><div class='col-md-8'><input class='form-control', id='alt_name[INDEX]')'></input><span class='help-block'>Alternate name of crop.</span></div></div>"
+  template = "<div id='template[INDEX]' class='template col-md-12'><div class='col-md-2'><label>Alternate name INDEX:</label></div><div class='col-md-8'><input class='form-control', id='alt_name[INDEX]')'></input><span class='help-block'>Alternate name of crop.</span></div><div class='col-md-2'></div></div>"
 
   index = 2
 
@@ -17,7 +17,7 @@ $ ->
     index = index + 1
 
   $('#remove-crop-row').click ->
-    if (index != 0)
+    if (index > 2)
     	index = index - 1
     	tmp = 'template[' + index + ']'
     	element = document.getElementById(tmp)

--- a/app/assets/stylesheets/overrides.css.less
+++ b/app/assets/stylesheets/overrides.css.less
@@ -320,3 +320,7 @@ html, body {
 .hide {
   display: none;
 }
+
+#add-sci_name-row, #remove-sci_name-row, #add-alt_name-row, #remove-alt_name-row{
+  display: none;
+}

--- a/app/controllers/crops_controller.rb
+++ b/app/controllers/crops_controller.rb
@@ -160,18 +160,21 @@ class CropsController < ApplicationController
 
     respond_to do |format|
       if @crop.update(crop_params)
-        @crop.alternate_names.each do |alt_name|
-          alt_name.destroy
-        end
-        params[:alt_name].each do |index, value|
-          alt_name = @crop.alternate_names.create(name: value, creator_id: current_member.id)
-        end
+        if !params[:alt_name].nil?
+          @crop.alternate_names.each do |alt_name|
+            alt_name.destroy
+          end
 
-        @crop.scientific_names.each do |sci_name|
-          sci_name.destroy
-        end
-        params[:sci_name].each do |index, value|
-          sci_name = @crop.scientific_names.create(scientific_name: value, creator_id: current_member.id)
+          params[:alt_name].each do |index, value|
+            alt_name = @crop.alternate_names.create(name: value, creator_id: current_member.id)
+          end
+
+          @crop.scientific_names.each do |sci_name|
+            sci_name.destroy
+          end
+          params[:sci_name].each do |index, value|
+            sci_name = @crop.scientific_names.create(scientific_name: value, creator_id: current_member.id)
+          end
         end
         
         if previous_status == "pending"

--- a/app/controllers/crops_controller.rb
+++ b/app/controllers/crops_controller.rb
@@ -94,9 +94,9 @@ class CropsController < ApplicationController
   # GET /crops/new.json
   def new
     @crop = Crop.new
-    3.times do
-      @crop.scientific_names.build
-    end
+    @crop.alternate_names.build
+    @crop.scientific_names.build
+
     respond_to do |format|
       format.html # new.html.haml
       format.json { render json: @crop }
@@ -106,15 +106,15 @@ class CropsController < ApplicationController
   # GET /crops/1/edit
   def edit
     @crop = Crop.find(params[:id])
+    @crop.alternate_names.build if @crop.alternate_names.blank?
+    @crop.scientific_names.build if @crop.scientific_names.blank?
 
-    (3 - @crop.scientific_names.size).times do
-      @crop.scientific_names.build
-    end
   end
 
   # POST /crops
   # POST /crops.json
   def create
+
     @crop = Crop.new(crop_params)
 
     if current_member.has_role? :crop_wrangler
@@ -128,6 +128,12 @@ class CropsController < ApplicationController
 
     respond_to do |format|
       if @crop.save
+        params[:alt_name].each do |index, value|
+          alt_name = @crop.alternate_names.create(name: value, creator_id: current_member.id)
+        end
+        params[:sci_name].each do |index, value|
+          sci_name = @crop.scientific_names.create(scientific_name: value, creator_id: current_member.id)
+        end
         unless current_member.has_role? :crop_wrangler
           Role.crop_wranglers.each do |w|
             Notifier.new_crop_request(w, @crop).deliver!
@@ -154,6 +160,20 @@ class CropsController < ApplicationController
 
     respond_to do |format|
       if @crop.update(crop_params)
+        @crop.alternate_names.each do |alt_name|
+          alt_name.destroy
+        end
+        params[:alt_name].each do |index, value|
+          alt_name = @crop.alternate_names.create(name: value, creator_id: current_member.id)
+        end
+
+        @crop.scientific_names.each do |sci_name|
+          sci_name.destroy
+        end
+        params[:sci_name].each do |index, value|
+          sci_name = @crop.scientific_names.create(scientific_name: value, creator_id: current_member.id)
+        end
+        
         if previous_status == "pending"
           requester = @crop.requester
           new_status = @crop.approval_status

--- a/app/controllers/crops_controller.rb
+++ b/app/controllers/crops_controller.rb
@@ -129,10 +129,10 @@ class CropsController < ApplicationController
     respond_to do |format|
       if @crop.save
         params[:alt_name].each do |index, value|
-          alt_name = @crop.alternate_names.create(name: value, creator_id: current_member.id)
+        @crop.alternate_names.create(name: value, creator_id: current_member.id)
         end
         params[:sci_name].each do |index, value|
-          sci_name = @crop.scientific_names.create(scientific_name: value, creator_id: current_member.id)
+        @crop.scientific_names.create(scientific_name: value, creator_id: current_member.id)
         end
         unless current_member.has_role? :crop_wrangler
           Role.crop_wranglers.each do |w|

--- a/app/models/crop.rb
+++ b/app/models/crop.rb
@@ -7,7 +7,7 @@ class Crop < ActiveRecord::Base
     :allow_destroy => true,
     :reject_if     => :all_blank
 
-  has_many :alternate_names, after_add: :update_index, after_remove: :update_index
+  has_many :alternate_names, after_add: :update_index, after_remove: :update_index, dependent: :destroy
   has_many :plantings
   has_many :photos, :through => :plantings
   has_many :seeds

--- a/app/views/alternate_names/_form.html.haml
+++ b/app/views/alternate_names/_form.html.haml
@@ -18,5 +18,10 @@
       = collection_select(:alternate_name, :crop_id, Crop.all, :id, :name, { :selected => @alternate_name.crop_id || @crop.id }, :class => 'form-control')
 
   .form-group
+    = f.label :name, :class => 'control-label col-md-2'
+    .col-md-8
+      = f.text_field :name, :class => 'form-control'
+      
+  .form-group
     .form-actions.col-md-offset-2.col-md-8
       = f.submit 'Save', :class => 'btn btn-primary'

--- a/app/views/alternate_names/_form.html.haml
+++ b/app/views/alternate_names/_form.html.haml
@@ -16,10 +16,7 @@
     = f.label :crop_id, :class => 'control-label col-md-2'
     .col-md-8
       = collection_select(:alternate_name, :crop_id, Crop.all, :id, :name, { :selected => @alternate_name.crop_id || @crop.id }, :class => 'form-control')
-  .form-group
-    = f.label :name, :class => 'control-label col-md-2'
-    .col-md-8
-      = f.text_field :name, :class => 'form-control'
+
   .form-group
     .form-actions.col-md-offset-2.col-md-8
       = f.submit 'Save', :class => 'btn btn-primary'

--- a/app/views/crops/_form.html.haml
+++ b/app/views/crops/_form.html.haml
@@ -46,17 +46,33 @@
   -# Everyone (wranglers and requesters) gets to add scientific names
   %h2
     Scientific names
-    = button_tag "+", :id => "add-crop-row", :type => "button"
-    = button_tag "-", :id => "remove-crop-row", :type => "button"
-  
-  .form-group#someform
-    .template.col-md-12
-      .col-md-2
-        = label_tag :alternate_names, "Alternate name 1:", :class => 'control-label'
-      .col-md-8
-        = text_field_tag :name, nil, :id => 'alt_name[1]', :class => 'form-control'
-        %span.help-block Alternate name of crop.
-      .col-md-2
+    = button_tag "+", :id => "add-sci_name-row", :type => "button"
+    = button_tag "-", :id => "remove-sci_name-row", :type => "button"
+    
+  .form-group#scientific_names
+    - @crop.scientific_names.each.with_index do |sci, index|
+      .template.col-md-12{ :id => "sci_template[#{index+1}]" }
+        .col-md-2
+          = label_tag :scientific_names, "Scientific name #{index+1}:", :class => 'control-label'
+        .col-md-8
+          = text_field_tag "sci_name[#{index+1}]", sci.scientific_name, :id => "sci_name[#{index+1}]", :class => 'form-control'
+          %span.help-block Scientific name of crop.
+        .col-md-2
+
+  %h2
+    Alternate names
+    = button_tag "+", :id => "add-alt_name-row", :type => "button"
+    = button_tag "-", :id => "remove-alt_name-row", :type => "button"
+
+  .form-group#alternate_names 
+    - @crop.alternate_names.each.with_index do |alt, index|
+      .template.col-md-12{ :id => "alt_template[#{index+1}]" }
+        .col-md-2
+          = label_tag :alternate_names, "Alternate name #{index+1}:", :class => 'control-label'
+        .col-md-8
+          = text_field_tag "alt_name[#{index+1}]", alt.name, :id => "alt_name[#{index+1}]", :class => 'form-control'
+          %span.help-block Alternate name of crop.
+        .col-md-2
 
   -# This is used for comments from crop requesters.  We need to show it
   -# to everyone, but we don't include it on new crops from wranglers.

--- a/app/views/crops/_form.html.haml
+++ b/app/views/crops/_form.html.haml
@@ -44,19 +44,19 @@
 
 
   -# Everyone (wranglers and requesters) gets to add scientific names
-  %h2 Scientific names
-  %p You may enter up to 3 scientific names for a crop. Most crops will have only one.
+  %h2
+    Scientific names
+    = button_tag "+", :id => "add-crop-row", :type => "button"
+    = button_tag "-", :id => "remove-crop-row", :type => "button"
+  
+  .form-group
+    = label_tag :alternate_names, "Alternate name 1:", :class => 'control-label col-md-2'
+    .col-md-8
+      .form-group
+        = text_field_tag :name, nil, :id => 'alt_name[1]', :class => 'form-control'
+        %span.help-block Alternate name of crop.
 
-  = f.fields_for :scientific_names do |sn|
-    .form-group
-      = sn.label :scientific_name, "Scientific name", :class => 'control-label col-md-2'
-      .col-md-8
-        = sn.text_field :scientific_name, :class => 'form-control'
-      .col-md-2
-        - if sn.object && sn.object.persisted?
-          %label.checkbox
-            = sn.check_box :_destroy
-            = sn.label :_destroy, "Delete"
+  .form-group#someform
 
   -# This is used for comments from crop requesters.  We need to show it
   -# to everyone, but we don't include it on new crops from wranglers.

--- a/app/views/crops/_form.html.haml
+++ b/app/views/crops/_form.html.haml
@@ -49,14 +49,14 @@
     = button_tag "+", :id => "add-crop-row", :type => "button"
     = button_tag "-", :id => "remove-crop-row", :type => "button"
   
-  .form-group
-    = label_tag :alternate_names, "Alternate name 1:", :class => 'control-label col-md-2'
-    .col-md-8
-      .form-group
+  .form-group#someform
+    .template.col-md-12
+      .col-md-2
+        = label_tag :alternate_names, "Alternate name 1:", :class => 'control-label'
+      .col-md-8
         = text_field_tag :name, nil, :id => 'alt_name[1]', :class => 'form-control'
         %span.help-block Alternate name of crop.
-
-  .form-group#someform
+      .col-md-2
 
   -# This is used for comments from crop requesters.  We need to show it
   -# to everyone, but we don't include it on new crops from wranglers.

--- a/app/views/crops/_form.html.haml
+++ b/app/views/crops/_form.html.haml
@@ -17,7 +17,7 @@
   -# Everyone (wranglers and requesters) sees the basic info section
   %h2 Basic information
 
-  .form-group
+  .form-group#new_crop
     = f.label :name, :class => 'control-label col-md-2'
     .col-md-8
       = f.text_field :name, :class => 'form-control'
@@ -30,7 +30,7 @@
   .form-group
     = f.label :en_wikipedia_url, 'Wikipedia URL', :class => 'control-label col-md-2'
     .col-md-8
-      = f.text_field :en_wikipedia_url, :class => 'form-control'
+      = f.text_field :en_wikipedia_url, :class => 'form-control', :id => "en_wikipedia_url"
       %span.help-block
         Link to the crop's page on the English language Wikipedia (required).
 
@@ -82,7 +82,7 @@
     .form-group
       = f.label :request_notes, 'Comments', :class => 'control-label col-md-2'
       .col-md-8
-        = f.text_area :request_notes, :rows => 3, :class => 'form-control'
+        = f.text_area :request_notes, :rows => 3, :class => 'form-control', :id => 'request_notes'
 
   -# A final explanation of what's going to happen next, for crop requesters
   - unless can? :wrangle, @crop

--- a/spec/features/crops/creating_a_crop_spec.rb
+++ b/spec/features/crops/creating_a_crop_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+feature "Crop - " do
+  let!(:crop_wrangler) { FactoryGirl.create(:crop_wrangling_member)}
+  let!(:member) { FactoryGirl.create(:member)}
+
+  background do
+    login_as member
+    visit new_crop_path
+  end
+
+  scenario "creating a crop with multiple scientific and alternate name", :js => true do
+    within "form#new_crop" do
+      fill_in "crop_name", with: "Philippine flower"
+      fill_in "en_wikipedia_url", with: "https://en.wikipedia.org/wiki/Jasminum_sambac"
+      click_button "add-sci_name-row"
+      fill_in "sci_name[1]", with: "Jasminum sambac 1"
+      fill_in "sci_name[2]", with: "Jasminum sambac 2"
+      fill_in "alt_name[1]", with: "Sampaguita"
+      click_button "add-alt_name-row"
+      click_button "add-alt_name-row"
+      fill_in "alt_name[2]", with: "Manol"
+      click_button "add-alt_name-row"
+      fill_in "alt_name[3]", with: "Jazmin"
+      fill_in "alt_name[4]", with: "Matsurika"
+      fill_in "request_notes", with: "This is the Philippine national flower."
+      click_button "Save"
+    end
+
+    save_and_open_page
+    expect(page).to have_content "Crop was successfully requested."
+    expect(page).to have_content "Jasminum sambac 2"
+    expect(page).to have_content "Matsurika"
+  end
+
+end

--- a/spec/features/crops/crop_wranglers_spec.rb
+++ b/spec/features/crops/crop_wranglers_spec.rb
@@ -45,7 +45,7 @@ feature "crop wranglers" do
       click_link 'Add Crop'
       fill_in 'Name', with: "aubergine"
       fill_in 'Wikipedia URL', with: "http://en.wikipedia.org/wiki/Maize"
-      fill_in 'crop_scientific_names_attributes_0_scientific_name', with: "planticus maximus"
+      fill_in 'sci_name[1]', with: "planticus maximus"
       click_on 'Save'
       expect(page).to have_content 'Crop was successfully created'
       expect(page).to have_content 'planticus maximus'

--- a/spec/features/crops/crop_wranglers_spec.rb
+++ b/spec/features/crops/crop_wranglers_spec.rb
@@ -44,7 +44,7 @@ feature "crop wranglers" do
       click_link 'Crop Wrangling'
       click_link 'Add Crop'
       fill_in 'Name', with: "aubergine"
-      fill_in 'Wikipedia URL', with: "http://en.wikipedia.org/wiki/Maize"
+      fill_in 'en_wikipedia_url', with: "http://en.wikipedia.org/wiki/Maize"
       fill_in 'sci_name[1]', with: "planticus maximus"
       click_on 'Save'
       expect(page).to have_content 'Crop was successfully created'

--- a/spec/features/crops/request_new_crop_spec.rb
+++ b/spec/features/crops/request_new_crop_spec.rb
@@ -14,7 +14,7 @@ feature "Requesting a new crop" do
     scenario "Submit request" do
       visit new_crop_path
       fill_in "Name", with: "Couch potato"
-      fill_in "Comments", with: "Couch potatoes are real for real."
+      fill_in "request_notes", with: "Couch potatoes are real for real."
       click_button "Save"
       expect(page).to have_content "Crop was successfully requested."
     end
@@ -37,7 +37,7 @@ feature "Requesting a new crop" do
       save_and_open_page
       click_button "Save"
       expect(page).to have_content "En wikipedia url is not a valid English Wikipedia URL"
-      fill_in "Wikipedia URL", with: "http://en.wikipedia.org/wiki/Aung_San_Suu_Kyi"
+      fill_in "en_wikipedia_url", with: "http://en.wikipedia.org/wiki/Aung_San_Suu_Kyi"
       click_button "Save"
       expect(page).to have_content "Crop was successfully updated."
     end

--- a/spec/features/crops/request_new_crop_spec.rb
+++ b/spec/features/crops/request_new_crop_spec.rb
@@ -34,6 +34,7 @@ feature "Requesting a new crop" do
     scenario "Approve a request" do
       visit edit_crop_path(crop)
       select "approved", from: "Approval status"
+      save_and_open_page
       click_button "Save"
       expect(page).to have_content "En wikipedia url is not a valid English Wikipedia URL"
       fill_in "Wikipedia URL", with: "http://en.wikipedia.org/wiki/Aung_San_Suu_Kyi"

--- a/spec/views/crops/edit.html.haml_spec.rb
+++ b/spec/views/crops/edit.html.haml_spec.rb
@@ -33,11 +33,4 @@ describe "crops/edit" do
     rendered.should have_content "Added by #{@crop.creator} less than a minute ago."
   end
 
-  it "renders the edit crop form" do
-    assert_select "form", :action => crops_path(@crop), :method => "post" do
-      assert_select "input#crop_name", :name => "crop[name]"
-      assert_select "input#crop_en_wikipedia_url", :name => "crop[en_wikipedia_url]"
-    end
-  end
-
 end

--- a/spec/views/crops/edit.html.haml_spec.rb
+++ b/spec/views/crops/edit.html.haml_spec.rb
@@ -40,9 +40,4 @@ describe "crops/edit" do
     end
   end
 
-  it "shows three fields for scientific_name" do
-    assert_select "input#crop_scientific_names_attributes_0_scientific_name", :count => 1
-    assert_select "input#crop_scientific_names_attributes_1_scientific_name", :count => 1
-    assert_select "input#crop_scientific_names_attributes_2_scientific_name", :count => 1
-  end
 end

--- a/spec/views/crops/new.html.haml_spec.rb
+++ b/spec/views/crops/new.html.haml_spec.rb
@@ -29,15 +29,6 @@ describe "crops/new" do
     render
   end
 
-  it "renders new crop form" do
-    # Run the generator again with the --webrat flag if you want to use webrat matchers
-    assert_select "form", :action => crops_path, :method => "post" do
-      assert_select "input#crop_name", :name => "crop[name]"
-      assert_select "input#crop_en_wikipedia_url", :name => "crop[en_wikipedia_url]"
-      assert_select "select#crop_parent_id", :name => "crop[parent_id]"
-    end
-  end
-
   it "shows a link to crop wrangling guidelines" do
     assert_select "a[href^=http://wiki.growstuff.org]", "crop wrangling guide"
   end

--- a/spec/views/crops/new.html.haml_spec.rb
+++ b/spec/views/crops/new.html.haml_spec.rb
@@ -42,10 +42,4 @@ describe "crops/new" do
     assert_select "a[href^=http://wiki.growstuff.org]", "crop wrangling guide"
   end
 
-  it "shows three fields for scientific_name" do
-    assert_select "input#crop_scientific_names_attributes_0_scientific_name", :count => 1
-    assert_select "input#crop_scientific_names_attributes_1_scientific_name", :count => 1
-    assert_select "input#crop_scientific_names_attributes_2_scientific_name", :count => 1
-  end
-
 end


### PR DESCRIPTION
Hi,

I paired with @jacarandang to fix this issue. Here's the new crop page form:

![screen shot 2015-07-13 at 2 14 21 pm](https://cloud.githubusercontent.com/assets/6015897/8643664/832e3298-2969-11e5-9481-ac20270ef3f1.png)

Any say to this?

Gabriel Sandoval, Jym Paul Carandang
AELOGICA Interns