### PR TITLE
#718 optional and required fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ custom_plan.rb
 zeus.json
 .bundle
 config/application.yml
+.idea/**

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -63,3 +63,4 @@ submit the change with your pull request.
 - Gabrielle DeWitt / [gabrielle27](https://github.com/gabrielle27)
 - Manmeet Singh / [manmeetsingh](https://github.com/manmeetsingh)
 - Jym Paul Carandang / [jacarandang](https://github.com/jacarandang)
+- Anthony Atkinson / [sha1sum](https://github.com/sha1sum)

--- a/app/assets/stylesheets/overrides.css.less
+++ b/app/assets/stylesheets/overrides.css.less
@@ -325,7 +325,15 @@ html, body {
   display: none;
 }
 
-.form-group.required .control-label:after {
-	content: " *";
+.form-group.required .control-label:before {
+	content: "* ";
+	color: red;
+}
+
+.margin-bottom {
+	margin-bottom: 1em;
+}
+
+.red {
 	color: red;
 }

--- a/app/assets/stylesheets/overrides.css.less
+++ b/app/assets/stylesheets/overrides.css.less
@@ -324,3 +324,8 @@ html, body {
 #add-sci_name-row, #remove-sci_name-row, #add-alt_name-row, #remove-alt_name-row{
   display: none;
 }
+
+.form-group.required .control-label:after {
+	content: " *";
+	color: red;
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -31,5 +31,11 @@ module ApplicationHelper
     "#{klass.name.downcase.pluralize}/#{identifier}-#{count}-#{max_updated_at}"
   end
 
+  def required_field_help_text
+    asterisk = content_tag :span, '*', class: ['red']
+    text = content_tag :em, 'denotes a required field'
+    content_tag :div, asterisk + ' '.html_safe + text, class: ['margin-bottom']
+  end
+
 end
 

--- a/app/views/gardens/_form.html.haml
+++ b/app/views/gardens/_form.html.haml
@@ -1,3 +1,5 @@
+= required_field_help_text
+
 = form_for(@garden, :html => {:class => "form-horizontal", :role => "form"}) do |f|
   - if @garden.errors.any?
     #error_explanation
@@ -6,7 +8,7 @@
         - @garden.errors.full_messages.each do |msg|
           %li= msg
 
-  .form-group
+  .form-group.required
     = f.label :name, :class => 'control-label col-md-2'
     .col-md-8
       = f.text_field :name, :class => 'form-control'
@@ -14,12 +16,12 @@
   .form-group
     = f.label :description, :class => 'control-label col-md-2'
     .col-md-8
-      = f.text_area :description, :rows => 6, :class => 'form-control'
+      = f.text_area :description, :rows => 6, :class => 'form-control', :placeholder => 'optional'
 
   .form-group
     = f.label :location, :class => 'control-label col-md-2'
     .col-md-8
-      = f.text_field :location, :value => @garden.location || current_member.location, :class => 'form-control'
+      = f.text_field :location, :value => @garden.location || current_member.location, :class => 'form-control', :placeholder => 'optional'
       %span.help-block
         If you have a location set in your profile, it will be used when
         you create a new garden.
@@ -31,7 +33,7 @@
   .form-group
     = f.label :area, :class => 'control-label col-md-2'
     .col-md-2
-      = f.number_field :area, :class => 'input-small form-control'
+      = f.number_field :area, :class => 'input-small form-control', :placeholder => 'optional'
     .col-md-2
       = f.select(:area_unit, Garden::AREA_UNITS_VALUES, {:include_blank => false}, :class => 'form-control')
 

--- a/app/views/harvests/_form.html.haml
+++ b/app/views/harvests/_form.html.haml
@@ -1,3 +1,5 @@
+= required_field_help_text
+
 = form_for(@harvest, :html => {:class => "form-horizontal", :role => :form}) do |f|
   - if @harvest.errors.any?
     #error_explanation
@@ -6,7 +8,7 @@
         - @harvest.errors.full_messages.each do |msg|
           %li= msg
 
-  .form-group
+  .form-group.required
     = f.label :crop, 'What did you harvest?', :class => 'control-label col-md-2'
     .col-md-4
       = auto_suggest @harvest, :crop, :class => 'form-control col-md-2', :default => @crop
@@ -17,7 +19,7 @@
       = link_to "Request new crops.", new_crop_path
 
   .form-group
-    = f.label :harvested_at, 'When?', :class => 'control-label col-md-2'
+    = f.label :harvested_at, 'When?', :class => 'control-label col-md-2', :placeholder => 'optional'
     .col-md-2
       = f.text_field :harvested_at, :value => @harvest.harvested_at ? @harvest.harvested_at.to_s(:ymd) : '', :class => 'add-datepicker form-control'
 
@@ -27,20 +29,20 @@
       -# Some browsers (eg Firefox for Android) assume "number" means
       -# "integer" unless you specify step="any":
       -# http://blog.isotoma.com/2012/03/html5-input-typenumber-and-decimalsfloats-in-chrome/
-      = f.number_field :quantity, :class => 'input-small', :step => 'any', :class => 'form-control'
+      = f.number_field :quantity, :class => 'input-small', :step => 'any', :class => 'form-control', :placeholder => 'optional'
     .col-md-2
       = f.select(:unit, Harvest::UNITS_VALUES, {:include_blank => false}, :class => 'input-medium form-control')
 
   .form-group
     = f.label :weight_quantity, 'Weighing (in total):', :class => 'control-label col-md-2'
     .col-md-2
-      = f.number_field :weight_quantity, :class => 'input-small', :step => 'any', :class => 'form-control'
+      = f.number_field :weight_quantity, :class => 'input-small', :step => 'any', :class => 'form-control', :placeholder => 'optional'
     .col-md-2
       = f.select(:weight_unit, Harvest::WEIGHT_UNITS_VALUES, {:include_blank => false}, :class => 'form-control')
   .form-group
     = f.label :description, 'Notes', :class => 'control-label col-md-2'
     .col-md-8
-      = f.text_area :description, :rows => 6, :class => 'form-control'
+      = f.text_area :description, :rows => 6, :class => 'form-control', :placeholder => 'optional'
 
   .form-group
     .form-actions.col-md-offset-2.col-md-8

--- a/app/views/plantings/_form.html.haml
+++ b/app/views/plantings/_form.html.haml
@@ -1,3 +1,7 @@
+.margin-bottom
+  %span.red *
+  %em denotes a required field.
+
 = form_for(@planting, :html => {:class => "form-horizontal", :role => "form"}) do |f|
   - if @planting.errors.any?
     #error_explanation
@@ -6,14 +10,14 @@
         - @planting.errors.full_messages.each do |msg|
           %li= msg
 
-  .form-group
+  .form-group.required
     = f.label :crop, 'What did you plant?', :class => 'control-label col-md-2'
     .col-md-8
       = auto_suggest @planting, :crop, :class => 'form-control', :default => @crop
       %span.help-inline
         Can't find what you're looking for?
         = link_to "Request new crops.", new_crop_path
-  .form-group
+  .form-group.required
     = f.label :garden_id, 'Where did you plant it?', :class => 'control-label col-md-2'
     .col-md-8
       = collection_select(:planting, :garden_id, Garden.active.where(:owner_id => current_member), :id, :name, {:selected => @planting.garden_id || @garden.id}, {:class => 'form-control'})
@@ -21,22 +25,22 @@
         = link_to "Add a garden.", new_garden_path
   .form-group
     = f.label :planted_at, 'When?', :class => 'control-label col-md-2'
-    .col-md-2= f.text_field :planted_at, :value => @planting.planted_at ? @planting.planted_at.to_s(:ymd) : '', :class => 'add-datepicker form-control'
+    .col-md-2= f.text_field :planted_at, :value => @planting.planted_at ? @planting.planted_at.to_s(:ymd) : '', :class => 'add-datepicker form-control', :placeholder => 'optional'
   .form-group
     = f.label :quantity, 'How many?', :class => 'control-label col-md-2'
     .col-md-2
-      = f.number_field :quantity, :class => 'form-control'
+      = f.number_field :quantity, :class => 'form-control', :placeholder => 'optional'
   .form-group
     = f.label :planted_from, 'Planted from:', :class => 'control-label col-md-2'
     .col-md-8
-      = f.select(:planted_from, Planting::PLANTED_FROM_VALUES, {:include_blank => true}, :class => 'form-control')
+      = f.select(:planted_from, Planting::PLANTED_FROM_VALUES, {:include_blank => 'optional'}, :class => 'form-control')
   .form-group
     = f.label :sunniness, 'Sun or shade?', :class => 'control-label col-md-2'
     .col-md-8
-      = f.select(:sunniness, Planting::SUNNINESS_VALUES, {:include_blank => true}, :class => 'form-control')
+      = f.select(:sunniness, Planting::SUNNINESS_VALUES, {:include_blank => 'optional'}, :class => 'form-control')
   .form-group
     = f.label :description, 'Tell us more about it', :class => 'control-label col-md-2'
-    .col-md-8= f.text_area :description, :rows => 6, :class => 'form-control'
+    .col-md-8= f.text_area :description, :rows => 6, :class => 'form-control', :placeholder => 'optional'
   .form-group
     = f.label :finished, 'Mark as finished', :class => 'control-label col-md-2'
     .col-md-8
@@ -44,9 +48,9 @@
       %span.help-block
         A planting is finished when you've harvested all of the crop, or it dies, or it's otherwise no longer growing in your garden.
   .form-group
-    = f.label :finished_at, 'Finished date', { :class => 'control-label col-md-2' }
+    = f.label :finished_at, 'Finished date', { :class => 'control-label col-md-2', :placeholder => 'optional' }
     .col-md-2
-      = f.text_field :finished_at, :value => @planting.finished_at ? @planting.finished_at.to_s(:ymd) : '', :class => 'add-datepicker form-control'
+      = f.text_field :finished_at, :value => @planting.finished_at ? @planting.finished_at.to_s(:ymd) : '', :class => 'add-datepicker form-control', :placeholder => 'optional'
   .form-group
     .form-actions.col-md-offset-2.col-md-8
       = f.submit 'Save', :class => 'btn btn-primary'

--- a/app/views/plantings/_form.html.haml
+++ b/app/views/plantings/_form.html.haml
@@ -1,6 +1,4 @@
-.margin-bottom
-  %span.red *
-  %em denotes a required field.
+= required_field_help_text
 
 = form_for(@planting, :html => {:class => "form-horizontal", :role => "form"}) do |f|
   - if @planting.errors.any?

--- a/app/views/seeds/_form.html.haml
+++ b/app/views/seeds/_form.html.haml
@@ -18,20 +18,20 @@
   .form-group
     = f.label :quantity, 'Quantity:', :class => 'control-label col-md-2', :placeholder => 'optional'
     .col-md-2
-      = f.number_field :quantity, :class => 'form-control'
+      = f.number_field :quantity, :class => 'form-control', placeholder: 'optional'
   .form-group
     = f.label :plant_before, 'Plant before:', :class => 'control-label col-md-2'
     .col-md-2
-      = f.text_field :plant_before, :class => 'add-datepicker form-control', :value => @seed.plant_before ? @seed.plant_before.to_s(:ymd) : ''
+      = f.text_field :plant_before, :class => 'add-datepicker form-control', :value => @seed.plant_before ? @seed.plant_before.to_s(:ymd) : '', placeholder: 'optional'
   .form-group
     = f.label :days_until_maturity_min, 'Days until maturity:', :class => 'control-label col-md-2', :placeholder => 'optional'
     %fieldset
       .col-md-2
-        = f.number_field :days_until_maturity_min, :class => 'form-control'
+        = f.number_field :days_until_maturity_min, :class => 'form-control', placeholder: 'optional'
       .col-md-1
         = f.label :days_until_maturity_max, 'to', :class => 'control-label'
       .col-md-2
-        = f.number_field :days_until_maturity_max, :class => 'form-control'
+        = f.number_field :days_until_maturity_max, :class => 'form-control', placeholder: 'optional'
       .col-md-1
         = f.label :dummy, 'days', :class => 'control-label'
   .form-group.required

--- a/app/views/seeds/_form.html.haml
+++ b/app/views/seeds/_form.html.haml
@@ -1,3 +1,5 @@
+= required_field_help_text
+
 = form_for(@seed, :html => {:class => "form-horizontal", :role => "form"}) do |f|
   - if @seed.errors.any?
     #error_explanation
@@ -6,7 +8,7 @@
         - @seed.errors.full_messages.each do |msg|
           %li= msg
 
-  .form-group
+  .form-group.required
     = f.label :crop, 'Crop:', :class => 'control-label col-md-2'
     .col-md-8
       = auto_suggest @seed, :crop, :class => 'form-control', :default => @crop
@@ -14,7 +16,7 @@
         Can't find what you're looking for?
         = link_to "Request new crops.", new_crop_path
   .form-group
-    = f.label :quantity, 'Quantity:', :class => 'control-label col-md-2'
+    = f.label :quantity, 'Quantity:', :class => 'control-label col-md-2', :placeholder => 'optional'
     .col-md-2
       = f.number_field :quantity, :class => 'form-control'
   .form-group
@@ -22,7 +24,7 @@
     .col-md-2
       = f.text_field :plant_before, :class => 'add-datepicker form-control', :value => @seed.plant_before ? @seed.plant_before.to_s(:ymd) : ''
   .form-group
-    = f.label :days_until_maturity_min, 'Days until maturity:', :class => 'control-label col-md-2'
+    = f.label :days_until_maturity_min, 'Days until maturity:', :class => 'control-label col-md-2', :placeholder => 'optional'
     %fieldset
       .col-md-2
         = f.number_field :days_until_maturity_min, :class => 'form-control'
@@ -32,22 +34,22 @@
         = f.number_field :days_until_maturity_max, :class => 'form-control'
       .col-md-1
         = f.label :dummy, 'days', :class => 'control-label'
-  .form-group
+  .form-group.required
     = f.label :organic, 'Organic?', :class => 'control-label col-md-2'
     .col-md-8
       = f.select(:organic, Seed::ORGANIC_VALUES, {}, :class => 'form-control', :default => 'unknown')
-  .form-group
+  .form-group.required
     = f.label :gmo, 'GMO?', :class => 'control-label col-md-2'
     .col-md-8
       = f.select(:gmo, Seed::GMO_VALUES, {}, :class => 'form-control', :default => 'unknown')
-  .form-group
+  .form-group.required
     = f.label :heirloom, 'Heirloom?', :class => 'control-label col-md-2'
     .col-md-8
       = f.select(:heirloom, Seed::HEIRLOOM_VALUES, {}, :class => 'form-control', :default => 'unknown')
   .form-group
     = f.label :description, 'Description:', :class => 'control-label col-md-2'
     .col-md-8
-      = f.text_area :description, :rows => 6, :class => 'form-control'
+      = f.text_area :description, :rows => 6, :class => 'form-control', :placeholder => 'optional'
   .form-group
     .col-md-offset-2.col-md-8
       %span.help-block
@@ -56,7 +58,7 @@
         list your seeds as available for trade, other members can
         contact you to request seeds.  You can list any conditions or
         other information in the description, above.
-  .form-group
+  .form-group.required
     = f.label :tradable_to, 'Will trade:', :class => 'control-label col-md-2'
     .col-md-8
       = f.select(:tradable_to, Seed::TRADABLE_TO_VALUES, {}, :class => 'form-control')

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -406,7 +406,6 @@ ActiveRecord::Schema.define(version: 20150625224805) do
     t.datetime "updated_at"
     t.string   "slug"
     t.integer  "forum_id"
-    t.integer  "parent_id"
   end
 
   add_index "posts", ["created_at", "author_id"], name: "index_posts_on_created_at_and_author_id", using: :btree

--- a/spec/features/gardens/adding_gardens_spec.rb
+++ b/spec/features/gardens/adding_gardens_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+feature "Gardens", :js do
+  let(:member) { FactoryGirl.create :member }
+
+  background do
+    login_as member
+    visit new_garden_path
+  end
+
+  it "has the required fields help text" do
+    expect(page).to have_content "* denotes a required field"
+  end
+
+  it "displays required and optional fields properly" do
+    expect(page).to have_selector ".form-group.required", text: "Name"
+    expect(page).to have_selector 'textarea#garden_description[placeholder="optional"]'
+    expect(page).to have_selector 'input#garden_location[placeholder="optional"]'
+    expect(page).to have_selector 'input#garden_area[placeholder="optional"]'
+  end
+
+  scenario "Create new garden" do
+    fill_in "Name", with: "New garden"
+    click_button "Save"
+    expect(page).to have_content "Garden was successfully created"
+    expect(page).to have_content "New garden"
+  end
+
+  scenario "Refuse to create new garden with negative area" do
+    visit new_garden_path
+    fill_in "Name", with: "Negative Garden"
+    fill_in "Area", with: -5
+    click_button "Save"
+    expect(page).not_to have_content "Garden was successfully created"
+    expect(page).to have_content "Area must be greater than or equal to 0"
+  end
+end

--- a/spec/features/gardens_spec.rb
+++ b/spec/features/gardens_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 feature "Planting a crop", :js => true do
-  let!(:garden)   { FactoryGirl.create(:garden) }
+  let!(:garden) { FactoryGirl.create(:garden) }
   let!(:planting) { FactoryGirl.create(:planting, garden: garden, planted_at: Date.parse("2013-3-10")) }
   let!(:tomato) { FactoryGirl.create(:tomato) }
   let!(:finished_planting) { FactoryGirl.create(:finished_planting, garden: garden, crop: tomato) }
@@ -26,23 +26,6 @@ feature "Planting a crop", :js => true do
     expect(page).to have_content "This garden is inactive"
     expect(page).to have_content "Mark as active"
     expect(page).not_to have_content "Mark as inactive"
-  end
-
-  scenario "Create new garden" do
-    visit new_garden_path
-    fill_in "Name", :with => "New garden"
-    click_button "Save"
-    expect(page).to have_content "Garden was successfully created"
-    expect(page).to have_content "New garden"
-  end
-
-  scenario "Refuse to create new garden with negative area" do
-    visit new_garden_path
-    fill_in "Name", :with => "Negative Garden"
-    fill_in "Area", :with => -5
-    click_button "Save"
-    expect(page).not_to have_content "Garden was successfully created"
-    expect(page).to have_content "Area must be greater than or equal to 0"
   end
 
   scenario "Edit garden" do

--- a/spec/features/harvests/harvesting_a_crop_spec.rb
+++ b/spec/features/harvests/harvesting_a_crop_spec.rb
@@ -12,6 +12,17 @@ feature "Harvesting a crop", :js => true do
 
   it_behaves_like "crop suggest", "harvest", "crop"
 
+  it "has the required fields help text" do
+    expect(page).to have_content "* denotes a required field"
+  end
+
+  it "displays required and optional fields properly" do
+    expect(page).to have_selector ".form-group.required", text: "What did you harvest?"
+    expect(page).to have_selector 'input#harvest_quantity[placeholder="optional"]'
+    expect(page).to have_selector 'input#harvest_weight_quantity[placeholder="optional"]'
+    expect(page).to have_selector 'textarea#harvest_description[placeholder="optional"]'
+  end
+
   scenario "Creating a new harvest", :js => true do
     fill_autocomplete "crop", :with => "mai"
     select_from_autocomplete "maize"

--- a/spec/features/plantings/planting_a_crop_spec.rb
+++ b/spec/features/plantings/planting_a_crop_spec.rb
@@ -14,6 +14,21 @@ feature "Planting a crop", :js => true do
 
   it_behaves_like "crop suggest", "planting"
 
+  it "has the required fields help text" do
+    expect(page).to have_content "* denotes a required field"
+  end
+
+  it "displays required and optional fields properly" do
+    expect(page).to have_selector ".form-group.required", text: "What did you plant?"
+    expect(page).to have_selector ".form-group.required", text: "Where did you plant it?"
+    expect(page).to have_selector 'input#planting_planted_at[placeholder="optional"]'
+    expect(page).to have_selector 'input#planting_quantity[placeholder="optional"]'
+    expect(page).to have_selector 'select#planting_planted_from option', text: 'optional'
+    expect(page).to have_selector 'select#planting_sunniness option', text: 'optional'
+    expect(page).to have_selector 'textarea#planting_description[placeholder="optional"]'
+    expect(page).to have_selector 'input#planting_finished_at[placeholder="optional"]'
+  end
+
   scenario "Creating a new planting" do
     fill_autocomplete "crop", :with => "mai"
     select_from_autocomplete "maize"

--- a/spec/features/seeds/adding_seeds_spec.rb
+++ b/spec/features/seeds/adding_seeds_spec.rb
@@ -12,6 +12,23 @@ feature "Seeds", :js => true do
 
   it_behaves_like "crop suggest", "seed", "crop"
 
+  it "has the required fields help text" do
+    expect(page).to have_content "* denotes a required field"
+  end
+
+  it "displays required and optional fields properly" do
+    expect(page).to have_selector ".form-group.required", text: "Crop:"
+    expect(page).to have_selector 'input#seed_quantity[placeholder="optional"]'
+    expect(page).to have_selector 'input#seed_plant_before[placeholder="optional"]'
+    expect(page).to have_selector 'input#seed_days_until_maturity_min[placeholder="optional"]'
+    expect(page).to have_selector 'input#seed_days_until_maturity_max[placeholder="optional"]'
+    expect(page).to have_selector '.form-group.required', text: 'Organic?'
+    expect(page).to have_selector '.form-group.required', text: 'GMO?'
+    expect(page).to have_selector '.form-group.required', text: 'Heirloom?'
+    expect(page).to have_selector 'textarea#seed_description[placeholder="optional"]'
+    expect(page).to have_selector '.form-group.required', text: 'Will trade:'
+  end
+
   scenario "Adding a new seed", :js => true do
     fill_autocomplete "crop", :with => "mai"
     select_from_autocomplete "maize"

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -12,4 +12,11 @@ describe ApplicationHelper do
     parse_date('2012-05-12').should eq Date.new(2012, 5, 12)
     parse_date('may 12th 2012').should eq Date.new(2012, 5, 12)
   end
+
+  it "shows required field marker help text with proper formatting" do
+    output = required_field_help_text
+    expect(output).to have_selector '.margin-bottom'
+    expect(output).to have_selector '.red', text: '*'
+    expect(output).to have_selector 'em', text: 'denotes a required field'
+  end
 end


### PR DESCRIPTION
Given that users are torn between marking required fields and marking optional fields, I decided to go with both and mark required fields with a red asterisk and denote optional fields with an "optional" placeholder or or used "include_blank: 'optional'" on select fields that previously had "include_blank: true". issue #718 