### PR TITLE
Correct browser-resize issues with the members section of homepage and make members page match

### DIFF
--- a/app/assets/stylesheets/overrides.css.less
+++ b/app/assets/stylesheets/overrides.css.less
@@ -97,12 +97,25 @@ p.stats {
   font-weight: bold;
 }
 
-.homepage-members {
-  height: 100px;
+.member-cards {
+  display: flex;
+  flex: none;
+  flex-wrap: wrap;
+  justify-content: space-between;
 }
+.member-thumbnail {
+  padding: .25em;
 
-.homepage-members:nth-child(odd) {
-  margin-left: 0px;
+  div {
+    width: 5em;
+    display: inline-block;
+	vertical-align: top;
+  }
+
+  div ~ div {
+    width: 15em;
+	padding-left: 1em;
+  }
 }
 
 #placesmap, #cropmap {

--- a/app/helpers/gardens_helper.rb
+++ b/app/helpers/gardens_helper.rb
@@ -1,7 +1,7 @@
 module GardensHelper
 
   def display_garden_description(garden)
-  	if garden.description.nil?
+    if garden.description.nil?
   		"no description provided."
     else
       truncate(garden.description, length: 130, separator: ' ', omission: '... ') { link_to "Read more", garden_path(garden) }

--- a/app/views/home/_members.html.haml
+++ b/app/views/home/_members.html.haml
@@ -2,12 +2,12 @@
   .hidden-xs
     - members = Member.interesting.first(6)
     - if members.present?
+      %section
       %h2= t('.title')
 
-      .row
+      .member-cards
         - members.each do |m|
-          .col-md-4.homepage-members
-            = render :partial => "members/thumbnail", :locals => { :member => m }
+          = render :partial => "members/thumbnail", :locals => { :member => m }
 
       %p.text-right
         = link_to "#{t('.view_all')} »", members_path

--- a/app/views/members/_thumbnail.html.haml
+++ b/app/views/members/_thumbnail.html.haml
@@ -1,17 +1,16 @@
 - cache member do
-  .row
-    .member-thumbnail
-      .col-md-3
-        = render :partial => "members/image_with_popover", :locals => { :member => member }
-      .col-md-9
-        %p
-          = link_to member.login_name, member
-          - if ! member.location.blank?
-            %small
-              %br/
-              %i= member.location
-          - if ! member.plantings.empty?
-            %small
-              %br/
-              Recently planted:
-              != member.plantings.first(3).map{|p| link_to p.crop_name, p }.join(", ")
+  .member-thumbnail.panel
+    %div
+      = render :partial => "members/image_with_popover", :locals => { :member => member }
+    %div
+      %p
+        = link_to member.login_name, member
+        - if ! member.location.blank?
+          %small
+            %br/
+            %i= member.location
+        - if ! member.plantings.empty?
+          %small
+            %br/
+            Recently planted:
+            != member.plantings.first(3).map{|p| link_to p.crop_name, p }.join(", ")

--- a/app/views/members/index.html.haml
+++ b/app/views/members/index.html.haml
@@ -10,11 +10,9 @@
   = page_entries_info @members, :model => "members"
   = will_paginate @members
 
-.row
+.member-cards
   - @members.each do |m|
-    .col-md-4.three-across
-      .thumbnail
-        = render :partial => "members/thumbnail", :locals => { :member => m }
+    = render :partial => "members/thumbnail", :locals => { :member => m }
 
 %div.pagination
   = page_entries_info @members, :model => "members"


### PR DESCRIPTION
This makes it so the member entries have the same white background as other cards and reflow as the page is resized. In the process, I removed some HTML elements that existed solely for display reasons and not for semantic reasons.

![screen shot 2015-07-23 at 1 52 34 pm](https://cloud.githubusercontent.com/assets/401264/8857967/d4b8dd94-3142-11e5-8021-44124635c540.png)
![screen shot 2015-07-23 at 1 52 47 pm](https://cloud.githubusercontent.com/assets/401264/8857968/d4c0c2d4-3142-11e5-970f-5e1d40ca723d.png)
![screen shot 2015-07-23 at 1 52 56 pm](https://cloud.githubusercontent.com/assets/401264/8857970/d4c469f2-3142-11e5-80b5-9ab2c17ff7e3.png)
![screen shot 2015-07-23 at 1 53 12 pm](https://cloud.githubusercontent.com/assets/401264/8857969/d4c43676-3142-11e5-9ee3-b30861351cc3.png)
![screen shot 2015-07-23 at 1 53 21 pm](https://cloud.githubusercontent.com/assets/401264/8857971/d4c4b222-3142-11e5-9128-25f8d97e279c.png)
