### PR TITLE
Check existence of secret token before using it.

### DIFF
--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -2,12 +2,19 @@ class Notifier < ActionMailer::Base
   include NotificationsHelper
   default from: "Growstuff <noreply@growstuff.org>"
 
+  def verifier()
+    if ENV['RAILS_SECRET_TOKEN']
+      return ActiveSupport::MessageVerifier.new(ENV['RAILS_SECRET_TOKEN'])
+    else
+      raise "RAILS_SECRET_TOKEN environment variable not set - have you created config/application.yml?"
+    end
+  end
+
   def notify(notification)
     @notification = notification
     @reply_link = reply_link(@notification)
 
     # Encrypting 
-    verifier = ActiveSupport::MessageVerifier.new(ENV['RAILS_SECRET_TOKEN'])
     @signed_message = verifier.generate ({ member_id: @notification.recipient.id, type: :send_notification_email })
 
     mail(:to => @notification.recipient.email,
@@ -21,7 +28,6 @@ class Notifier < ActionMailer::Base
     @harvests = @member.harvests.first(5)
 
     # Encrypting 
-    verifier = ActiveSupport::MessageVerifier.new(ENV['RAILS_SECRET_TOKEN'])
     @signed_message = verifier.generate ({ member_id: @member.id, type: :send_planting_reminder })
 
     if @member.send_planting_reminder


### PR DESCRIPTION
People were forgetting to create config/application.yml, which meant that RAILS_SECRET_TOKEN wasn't being set, which meant that all tests involving notifications failed. Unfortunately, the resulting wall of error messages (https://gist.github.com/sha1sum/5debae6b700ff8fc0c76) did not make the root cause remotely clear, leading to much confusion and head-scratching all round.

This commit checks for the existence of RAILS_SECRET_TOKEN and fails with an informative error message if it's missing.