### PR TITLE
Resolves #617 - Open Service graphic link in footer

### DIFF
--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -7,3 +7,6 @@
         != cms_snippet_content(:footer2)
       .col-md-4#footer3
         != cms_snippet_content(:footer3)
+        %div(style="float: right;")
+          %a(href="http://opendefinition.org/ossd/")
+            %img(src="http://assets.okfn.org/images/ok_buttons/os_80x15_blue.png" alt="")

--- a/spec/features/footer_spec.rb
+++ b/spec/features/footer_spec.rb
@@ -2,9 +2,14 @@ require 'rails_helper'
 
 feature "footer" do
 
+  before { visit root_path }
+
   scenario "footer is on home page" do
-    visit root_path
     expect(page).to have_css 'footer'
+  end
+
+  it 'has the Open Service link and graphic' do
+    expect(page).to have_selector 'a[href="http://opendefinition.org/ossd/"]'
   end
 
 # NB: not testing specific content in the footer since I'm going to put them


### PR DESCRIPTION
The graphic provided by [Open Definition](http://opendefinition.org/ossd/) is now displayed on the right of the footer.

Resolves #617 