### PR TITLE
Fixing #790 properly - caching posts on homepage

### DIFF
--- a/app/views/posts/_summary.html.haml
+++ b/app/views/posts/_summary.html.haml
@@ -15,7 +15,8 @@
           %td.hidden-xs
             =link_to post.author, post.author
           %td
-            = distance_of_time_in_words(post.recent_activity, Time.zone.now)
-            ago
+            = post.recent_activity.to_date.to_formatted_s(:short)
+            // once the site gets more active, can change this to include time as well
+            // can't make it relative (distance_of_time_in_words) as it's cached
           %td.hidden-xs
             = post.comments.size.to_s

--- a/spec/views/forums/index.html.haml_spec.rb
+++ b/spec/views/forums/index.html.haml_spec.rb
@@ -45,7 +45,7 @@ describe "forums/index" do
     it "displays posts" do
       assert_select "table"
       rendered.should have_content @post.subject
-      rendered.should have_content "less than a minute ago"
+      rendered.should have_content Date.today.to_s(:short)
     end
 
     it "displays comment count" do


### PR DESCRIPTION
Reverts Growstuff/growstuff#793 that reverted #790. This one should now validly give the right fix, and since #775 is now sorted, Travis should be happy. So this now needs review from someone who is not me, particularly that we're happy with the UX of dates being absolute rather than relative.