### PR TITLE
Style checkbox for 'remember me' 

### DIFF
--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -15,9 +15,10 @@
 
   - if devise_mapping.rememberable?
     .form-group
-      .col-md-8.col-md-offset-2
-        = f.check_box :remember_me
-        Remember me
+      .col-md-8.col-md-offset-2.checkbox
+        label
+          = f.check_box :remember_me
+          Remember me
 
   .form-group
     .form-actions.col-md-8.col-md-offset-2

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -16,7 +16,7 @@
   - if devise_mapping.rememberable?
     .form-group
       .col-md-8.col-md-offset-2.checkbox
-        label
+        %label
           = f.check_box :remember_me
           Remember me
 


### PR DESCRIPTION
Minor usability/mobile UI annoyance - you can't click the 'remember me' text to tick the checkbox.

This:
 * Applies bootstrap classes around the checkbox
 * Saves my big fat fingers from selecting text when they shouldn't
