### PR TITLE
Fix more checkbox labels in registration and email editing

### DIFF
--- a/app/views/devise/registrations/_edit_email.html.haml
+++ b/app/views/devise/registrations/_edit_email.html.haml
@@ -9,24 +9,28 @@
       %span.help-block If you change your email address you will have to reconfirm.
 
   .form-group
-    .col-md-offset-2.col-md-8
-      = f.check_box :show_email
-      Show email publicly on your profile page.
+    .col-md-offset-2.col-md-8.checkbox
+      %label
+        = f.check_box :show_email
+        Show email publicly on your profile page.
 
   .form-group
-    .col-md-offset-2.col-md-8
-      = f.check_box :send_notification_email
-      Receive emailed copies of Inbox notifications (eg. private messages).
+    .col-md-offset-2.col-md-8.checkbox
+      %label
+        = f.check_box :send_notification_email
+        Receive emailed copies of Inbox notifications (eg. private messages).
 
   .form-group
-    .col-md-offset-2.col-md-8
-      = f.check_box :send_planting_reminder
-      Receive regular reminders to track your planting and harvesting.
+    .col-md-offset-2.col-md-8.checkbox
+      %label
+        = f.check_box :send_planting_reminder
+        Receive regular reminders to track your planting and harvesting.
 
   .form-group
-    .col-md-offset-2.col-md-8
-      = f.check_box :newsletter
-      Subscribe to the #{ENV['GROWSTUFF_SITE_NAME']} newsletter
+    .col-md-offset-2.col-md-8.checkbox
+      %label
+        = f.check_box :newsletter
+        Subscribe to the #{ENV['GROWSTUFF_SITE_NAME']} newsletter
       .help-block
         = render :partial => 'newsletter_blurb'
 

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -26,15 +26,17 @@
     .col-md-8= f.password_field :password_confirmation, :class => 'form-control'
 
   .form-group
-    .col-md-offset-2.col-md-8
-      = f.check_box :tos_agreement
-      I agree to the
-      = succeed "." do
-        = link_to 'Terms of Service', url_for(:action => 'tos', :controller => '/policy')
+    .col-md-offset-2.col-md-8.checkbox
+      %label
+        = f.check_box :tos_agreement
+        I agree to the
+        = succeed "." do
+          = link_to 'Terms of Service', url_for(:action => 'tos', :controller => '/policy')
   .form-group
-    .col-md-offset-2.col-md-8
-      = f.check_box :newsletter, :checked => true
-      Subscribe to the #{ENV['GROWSTUFF_SITE_NAME']} newsletter
+    .col-md-offset-2.col-md-8.checkbox
+      %label
+        = f.check_box :newsletter, :checked => true
+        Subscribe to the #{ENV['GROWSTUFF_SITE_NAME']} newsletter
       .help-inline
         = render :partial => 'newsletter_blurb'
 


### PR DESCRIPTION
Continues #797

The only other ones are in form partials, and don't really have the same kind of label - decided to leave them well enough alone.