### PR TITLE
WIP: Fix #632 to use consistent API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,9 @@ gem 'unicorn'                      # http server
 gem 'pg'
 gem 'figaro'                       # for handling config via ENV variables
 gem 'cancancan', '~> 1.9'          # for checking member privileges
-gem 'gibbon'                       # for Mailchimp newsletter subscriptions
+gem 'gibbon', '=0.4.6'             # for Mailchimp newsletter subscriptions
+# Gibbon >0.5.0 targets MailChimp API 2.0, which is substantially different from API 1.3.
+# Please use Gibbon 0.4.6 if you need to use API 1.3.
 gem 'csv_shaper'                   # CSV export
 gem 'ruby-units'                   # for unit conversion
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,7 +173,7 @@ GEM
     formatador (0.2.5)
     friendly_id (5.0.4)
       activerecord (>= 4.0.0)
-    gibbon (1.1.4)
+    gibbon (0.4.6)
       httparty
       multi_json (>= 1.3.4)
     gravatar-ultimate (2.0.0)
@@ -213,7 +213,7 @@ GEM
       haml (>= 4.0.0.rc.1)
       hpricot (~> 0.8.6)
       ruby_parser (~> 3.1.1)
-    httparty (0.13.3)
+    httparty (0.13.5)
       json (~> 1.8)
       multi_xml (>= 0.5.2)
     i18n (0.7.0)
@@ -460,7 +460,7 @@ DEPENDENCIES
   flickraw
   friendly_id (~> 5.0.4)
   geocoder!
-  gibbon
+  gibbon (= 0.4.6)
   gravatar-ultimate
   guard
   guard-rspec


### PR DESCRIPTION
Looking at issue #632 and the comment, either we need to make lots of tricky changes to use the new MailChimp API, or we can lock to the old gibbon version to get it back working for now. I suggest we do this so the newsletter will start working again, and then open a fresh issue to upgrade to latest MailChimp API and gibbon gem together.