### PR TITLE
Turn on Phantom JS for all tests

### DIFF
--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -18,7 +18,7 @@
 
     .navbar-collapse.collapse#navbar-collapse
       %ul.nav.navbar-nav.pull-right
-        %li.dropdown<
+        %li.dropdown#crops-menu<
           %a.dropdown-toggle{'data-toggle' => 'dropdown', :href => crops_path}
             Crops
             %b.caret
@@ -27,7 +27,7 @@
             %li= link_to "Seeds", seeds_path
             %li= link_to "Plantings", plantings_path
             %li= link_to "Harvests", harvests_path
-        %li.dropdown<
+        %li.dropdown#community-menu<
           %a.dropdown-toggle{'data-toggle' => 'dropdown', :href => members_path}
             Community
             %b.caret
@@ -39,7 +39,7 @@
             %li= link_to "Support Growstuff", shop_path
 
         - if member_signed_in?
-          %li.dropdown<
+          %li.dropdown#yourstuff-menu<
             %a.dropdown-toggle{'data-toggle' => 'dropdown', :href => root_path}
               - if current_member.notifications.unread_count > 0
                 Your Stuff (#{current_member.notifications.unread_count})

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -18,7 +18,7 @@
 
     .navbar-collapse.collapse#navbar-collapse
       %ul.nav.navbar-nav.pull-right
-        %li.dropdown#crops-menu<
+        %li.dropdown<
           %a.dropdown-toggle{'data-toggle' => 'dropdown', :href => crops_path}
             Crops
             %b.caret
@@ -27,7 +27,7 @@
             %li= link_to "Seeds", seeds_path
             %li= link_to "Plantings", plantings_path
             %li= link_to "Harvests", harvests_path
-        %li.dropdown#community-menu<
+        %li.dropdown<
           %a.dropdown-toggle{'data-toggle' => 'dropdown', :href => members_path}
             Community
             %b.caret
@@ -39,7 +39,7 @@
             %li= link_to "Support Growstuff", shop_path
 
         - if member_signed_in?
-          %li.dropdown#yourstuff-menu<
+          %li.dropdown<
             %a.dropdown-toggle{'data-toggle' => 'dropdown', :href => root_path}
               - if current_member.notifications.unread_count > 0
                 Your Stuff (#{current_member.notifications.unread_count})

--- a/spec/features/admin/account_types_spec.rb
+++ b/spec/features/admin/account_types_spec.rb
@@ -11,6 +11,15 @@ feature "account types", :js => true do
 
     scenario "navigating to account type admin" do
       visit root_path
+      click_link member.login_name
+      click_link "Admin"
+      expect(current_path).to eq admin_path
+      click_link "Account types"
+      expect(current_path).to eq account_types_path
+    end
+
+    scenario "navigating to account type admin without js", :js => false do
+      visit root_path
       click_link "Admin"
       expect(current_path).to eq admin_path
       click_link "Account types"

--- a/spec/features/admin/account_types_spec.rb
+++ b/spec/features/admin/account_types_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature "account types" do
+feature "account types", :js => true do
   context "admin user" do
     let(:member) { create :admin_member }
     let(:account_type) { create :account_type }

--- a/spec/features/admin/forums_spec.rb
+++ b/spec/features/admin/forums_spec.rb
@@ -9,8 +9,20 @@ feature "forums", :js => true do
       login_as member
     end
 
-    scenario "navigating to forum admin" do
+    scenario "navigating to forum admin without js", :js => false do
       visit root_path
+      click_link "Admin"
+      expect(current_path).to eq admin_path
+      within 'ul#admin_links' do
+        click_link "Forums"
+      end
+      expect(current_path).to eq forums_path
+      expect(page).to have_content "New forum"
+    end
+
+    scenario "navigating to forum admin with js" do
+      visit root_path
+      click_link member.login_name
       click_link "Admin"
       expect(current_path).to eq admin_path
       within 'ul#admin_links' do

--- a/spec/features/admin/forums_spec.rb
+++ b/spec/features/admin/forums_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature "forums" do
+feature "forums", :js => true do
   context "as an admin user" do
     let(:member) { create :admin_member }
     let(:forum) { create :forum }

--- a/spec/features/crops/alternate_name_spec.rb
+++ b/spec/features/crops/alternate_name_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature "Alternate names" do
+feature "Alternate names", :js => true do
   let!(:alternate_eggplant) { create :alternate_eggplant }
   let(:crop) { alternate_eggplant.crop }
 

--- a/spec/features/crops/crop_detail_page_spec.rb
+++ b/spec/features/crops/crop_detail_page_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature "crop detail page" do
+feature "crop detail page", :js => true do
   let(:crop) { create :crop }
   
   subject { visit crop_path(crop) }

--- a/spec/features/crops/crop_wranglers_spec.rb
+++ b/spec/features/crops/crop_wranglers_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature "crop wranglers" do
+feature "crop wranglers", :js => true do
   context "signed in wrangler" do
     let!(:crop_wranglers) { create_list :crop_wrangling_member, 3 }
     let(:wrangler) { crop_wranglers.first }

--- a/spec/features/crops/crop_wranglers_spec.rb
+++ b/spec/features/crops/crop_wranglers_spec.rb
@@ -12,7 +12,7 @@ feature "crop wranglers", :js => true do
 
     scenario "sees crop wranglers listed on the crop wrangler page" do
       visit root_path
-      click_link member.login_name
+      click_link wrangler.login_name
       click_link 'Crop Wrangling'
 
       within '.crop_wranglers' do
@@ -25,7 +25,7 @@ feature "crop wranglers", :js => true do
 
     scenario "can see list of crops with extra detail of who created a crop" do
       visit root_path
-      click_link member.login_name
+      click_link wrangler.login_name
       click_link 'Crop Wrangling'
       within '#recently-added-crops' do
         expect(page).to have_content "#{crops.first.creator.login_name}"
@@ -41,7 +41,7 @@ feature "crop wranglers", :js => true do
 
     scenario "can create a new crop" do
       visit root_path
-      click_link member.login_name
+      click_link wrangler.login_name
       click_link 'Crop Wrangling'
       click_link 'Add Crop'
       fill_in 'Name', with: "aubergine"

--- a/spec/features/crops/crop_wranglers_spec.rb
+++ b/spec/features/crops/crop_wranglers_spec.rb
@@ -12,6 +12,7 @@ feature "crop wranglers", :js => true do
 
     scenario "sees crop wranglers listed on the crop wrangler page" do
       visit root_path
+      click_link member.login_name
       click_link 'Crop Wrangling'
 
       within '.crop_wranglers' do
@@ -24,6 +25,7 @@ feature "crop wranglers", :js => true do
 
     scenario "can see list of crops with extra detail of who created a crop" do
       visit root_path
+      click_link member.login_name
       click_link 'Crop Wrangling'
       within '#recently-added-crops' do
         expect(page).to have_content "#{crops.first.creator.login_name}"
@@ -39,6 +41,7 @@ feature "crop wranglers", :js => true do
 
     scenario "can create a new crop" do
       visit root_path
+      click_link member.login_name
       click_link 'Crop Wrangling'
       click_link 'Add Crop'
       fill_in 'Name', with: "aubergine"
@@ -69,8 +72,14 @@ feature "crop wranglers", :js => true do
 
     background { login_as member }
 
-    scenario "can't see wrangling page" do
+    scenario "can't see wrangling page without js", :js => false do
       visit root_path
+      expect(page).not_to have_link "Crop Wrangling"
+    end
+
+    scenario "can't see wrangling page with js" do
+      visit root_path
+      click_link member.login_name
       expect(page).not_to have_link "Crop Wrangling"
     end
   end

--- a/spec/features/footer_spec.rb
+++ b/spec/features/footer_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature "footer" do
+feature "footer", :js => true do
 
   before { visit root_path }
 

--- a/spec/features/locale_spec.rb
+++ b/spec/features/locale_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature "Changing locales" do
+feature "Changing locales", :js => true do
 
   after { I18n.locale = :en }
 

--- a/spec/features/member_profile_spec.rb
+++ b/spec/features/member_profile_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
-feature "member profile" do
+feature "member profile", :js => true do
+
   context "signed out member" do
     let(:member) { create :member }
 

--- a/spec/features/rss/comments_spec.rb
+++ b/spec/features/rss/comments_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Comments RSS feed', :js => true do
+feature 'Comments RSS feed' do
   scenario 'The index feed exists' do
     visit comments_path(format: 'rss')
     expect(page.status_code).to equal 200

--- a/spec/features/rss/comments_spec.rb
+++ b/spec/features/rss/comments_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Comments RSS feed' do
+feature 'Comments RSS feed', :js => true do
   scenario 'The index feed exists' do
     visit comments_path(format: 'rss')
     expect(page.status_code).to equal 200

--- a/spec/features/rss/crops_spec.rb
+++ b/spec/features/rss/crops_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Crops RSS feed', :js => true do
+feature 'Crops RSS feed' do
   scenario 'The index feed exists' do
     visit crops_path(format: 'rss')
     expect(page.status_code).to equal 200

--- a/spec/features/rss/crops_spec.rb
+++ b/spec/features/rss/crops_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Crops RSS feed' do
+feature 'Crops RSS feed', :js => true do
   scenario 'The index feed exists' do
     visit crops_path(format: 'rss')
     expect(page.status_code).to equal 200

--- a/spec/features/rss/members_spec.rb
+++ b/spec/features/rss/members_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Members RSS feed' do
+feature 'Members RSS feed', :js => true do
   let(:member) { create :member }
 
   scenario 'The show action exists' do

--- a/spec/features/rss/members_spec.rb
+++ b/spec/features/rss/members_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Members RSS feed', :js => true do
+feature 'Members RSS feed' do
   let(:member) { create :member }
 
   scenario 'The show action exists' do

--- a/spec/features/rss/plantings_spec.rb
+++ b/spec/features/rss/plantings_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Plantings RSS feed' do
+feature 'Plantings RSS feed', :js => true do
   scenario 'The index feed exists' do
     visit plantings_path(format: 'rss')
     expect(page.status_code).to equal 200

--- a/spec/features/rss/plantings_spec.rb
+++ b/spec/features/rss/plantings_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Plantings RSS feed', :js => true do
+feature 'Plantings RSS feed' do
   scenario 'The index feed exists' do
     visit plantings_path(format: 'rss')
     expect(page.status_code).to equal 200

--- a/spec/features/rss/posts_spec.rb
+++ b/spec/features/rss/posts_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Posts RSS feed', :js => true do
+feature 'Posts RSS feed' do
   scenario 'The index feed exists' do
     visit posts_path(format: 'rss')
     expect(page.status_code).to equal 200

--- a/spec/features/rss/posts_spec.rb
+++ b/spec/features/rss/posts_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Posts RSS feed' do
+feature 'Posts RSS feed', :js => true do
   scenario 'The index feed exists' do
     visit posts_path(format: 'rss')
     expect(page.status_code).to equal 200

--- a/spec/features/rss/seeds_spec.rb
+++ b/spec/features/rss/seeds_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Seeds RSS feed' do
+feature 'Seeds RSS feed', :js => true do
   scenario 'The index feed exists' do
     visit seeds_path(format: 'rss')
     expect(page.status_code).to equal 200

--- a/spec/features/rss/seeds_spec.rb
+++ b/spec/features/rss/seeds_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Seeds RSS feed', :js => true do
+feature 'Seeds RSS feed' do
   scenario 'The index feed exists' do
     visit seeds_path(format: 'rss')
     expect(page.status_code).to equal 200

--- a/spec/features/scientific_name_spec.rb
+++ b/spec/features/scientific_name_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature "Scientific names" do
+feature "Scientific names", :js => true do
   let!(:zea_mays) { create :zea_mays }
   let(:crop) { zea_mays.crop }
 

--- a/spec/features/seeds/misc_seeds_spec.rb
+++ b/spec/features/seeds/misc_seeds_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature "seeds" do
+feature "seeds", :js => true do
   context "signed in user" do
     let(:member) { create :member }
     let(:crop) { create :crop }

--- a/spec/features/signin_spec.rb
+++ b/spec/features/signin_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
-feature "signin" do
+
+feature "signin", :js => true do
   let(:member) { create :member }
   let(:recipient) { create :member }
   let(:notification) { create :notification }

--- a/spec/features/signup_spec.rb
+++ b/spec/features/signup_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
-feature "signup" do
+feature "signup", :js => true do
+
   scenario "sign up for new account from top menubar" do
     visit crops_path # something other than front page, which has multiple signup links
     click_link 'Sign up'


### PR DESCRIPTION
Another attempt at turning on Javascript for more of our tests. Based on #670 by @pozorvlak, with a few further fixes. Ready for merge - all tests passing.