### PR TITLE
Fix #632 Make mailchimp newsletter subscription work again

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -239,7 +239,7 @@ class Member < ActiveRecord::Base
     return true if (Rails.env.test? && !testing)
     gb = Gibbon::API.new
     res = gb.lists.subscribe({
-      :id => Gibbon::API.api_key,
+      :id => config.newsletter_list_id,
       :email => { :email => email },
       :merge_vars => { :login_name => login_name },
       :double_optin => false # they already confirmed their email with us
@@ -250,7 +250,7 @@ class Member < ActiveRecord::Base
     return true if (Rails.env.test? && !testing)
     gb = Gibbon::API.new
     res = gb.lists.unsubscribe({
-      :id => ENV['GROWSTUFF_MAILCHIMP_NEWSLETTER_ID'],
+      :id => config.newsletter_list_id,
       :email => { :email => email }
     })
   end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -239,7 +239,7 @@ class Member < ActiveRecord::Base
     return true if (Rails.env.test? && !testing)
     gb = Gibbon::API.new
     res = gb.lists.subscribe({
-      :id => config.newsletter_list_id,
+      :id => Growstuff::Application.config.newsletter_list_id,
       :email => { :email => email },
       :merge_vars => { :login_name => login_name },
       :double_optin => false # they already confirmed their email with us
@@ -250,7 +250,7 @@ class Member < ActiveRecord::Base
     return true if (Rails.env.test? && !testing)
     gb = Gibbon::API.new
     res = gb.lists.unsubscribe({
-      :id => config.newsletter_list_id,
+      :id => Growstuff::Application.config.newsletter_list_id,
       :email => { :email => email }
     })
   end


### PR DESCRIPTION
Fix #632 . Change app/models/member.rb line 241 to point to correct mailchimp list.

Also, make changes to upgrade to [latest Gibbon v2.x](https://github.com/amro/gibbon).

Currently in process of testing. Not ready for merge just yet.