### PR TITLE
Add correct prefix to fix facebook share icon

### DIFF
--- a/app/views/layouts/_meta.html.haml
+++ b/app/views/layouts/_meta.html.haml
@@ -1,8 +1,7 @@
 %head
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta property="og:image" content="images/growstuff-apple-touch-icon-precomposed.png"/>
-  <meta property="og:image:secure_url" content="images/growstuff-apple-touch-icon-precomposed.png"/>
+  <meta property="og:image" content="#{image_url 'growstuff-apple-touch-icon-precomposed.png'}"/>
 
 
   - if (content_for?(:member_rss_login_name) && content_for(:member_rss_slug))

--- a/app/views/layouts/_meta.html.haml
+++ b/app/views/layouts/_meta.html.haml
@@ -2,7 +2,10 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta property="og:image" content="#{image_url 'growstuff-apple-touch-icon-precomposed.png'}"/>
-
+  <meta property="og:title" content="#{content_for?(:title) ? yield(:title) + " - #{ ENV['GROWSTUFF_SITE_NAME']} " : ENV['GROWSTUFF_SITE_NAME']}" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="#{root_url}" />
+  <meta property="og:site_name" content="#{ENV['GROWSTUFF_SITE_NAME']}" />
 
   - if (content_for?(:member_rss_login_name) && content_for(:member_rss_slug))
     = auto_discovery_link_tag(:rss, { :controller => "/members", :action => 'show', :format => "rss", :id => yield(:member_rss_slug) }, { :title => "#{ ENV['GROWSTUFF_SITE_NAME'] }- #{yield(:member_rss_login_name)}'s posts" })

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,5 +1,5 @@
 !!! 5
-%html(lang="en")
+%html(lang="en" prefix="og: http://ogp.me/ns#")
   = render :partial => "layouts/meta"
   %body
     = render :partial => "layouts/header"


### PR DESCRIPTION
#733 Add the correct RDFa prefix

I think this will work OK, but don't have a way to test my localhost properly.

http://www.w3.org/2012/pyRdfa/extract tells me it's valid RDFa, producing:

```
@prefix ns1: <http://ogp.me/ns#image:> .
@prefix ns2: <http://www.w3.org/1999/xhtml/vocab#> .
@prefix og: <http://ogp.me/ns#> .

<> og:image "http://localhost:3000/assets/growstuff-apple-touch-icon-precomposed-8e3c5998fc73bde728cfc3a2ea8fb69f.png"@en;
    ns1:secure_url "images/growstuff-apple-touch-icon-precomposed.png"@en .

[] ns2:role ns2:navigation .
```

Or in other words, <> (this page) has an og:image of "http://localhost:3000/assets/growstuff-apple-touch-icon-precomposed-8e3c5998fc73bde728cfc3a2ea8fb69f.png"

If this doesn't work, probably need to make it <http://localhost:3000/assets/growstuff-apple-touch-icon-precomposed-8e3c5998fc73bde728cfc3a2ea8fb69f.png> 