### PR TITLE
Add member preferred image

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -37,5 +37,18 @@ module ApplicationHelper
     content_tag :div, asterisk + ' '.html_safe + text, class: ['margin-bottom']
   end
 
+  #
+  # Returns an image uri for a given member.
+  #
+  # Falls back to Gravatar
+  #
+  def avatar_uri(member, size = 150)
+    return member.preferred_avatar_uri if member.preferred_avatar_uri.present?
+
+    Gravatar.new(member.email).image_url({
+      :size => size,
+      :default => :identicon
+    })
+  end
 end
 

--- a/app/views/members/_avatar.html.haml
+++ b/app/views/members/_avatar.html.haml
@@ -1,9 +1,5 @@
 = link_to                                      |
-  image_tag(                                   |
-    Gravatar.new(member.email).image_url(      |
-      options = {                              |
-        :size => defined?(size) ?  size : 150, |
-        :default => :identicon }),             |
+  image_tag(avatar_uri(member, 150),           |
     :alt => '',                                |
     :class => 'img img-responsive avatar' ),   |
   member_path(member)

--- a/app/views/members/_image_with_popover.html.haml
+++ b/app/views/members/_image_with_popover.html.haml
@@ -1,9 +1,6 @@
 = link_to |
   image_tag( |
-      Gravatar.new(member.email).image_url( |
-        options = { |
-          :size => defined?(size) ?  size : 150, |
-          :default => :identicon }), |
+      avatar_uri(member, 150), |
         :alt => member.login_name, |
         :class => 'img-responsive member-image' |
   ), |

--- a/db/migrate/20150824145414_add_member_preferred_image.rb
+++ b/db/migrate/20150824145414_add_member_preferred_image.rb
@@ -1,0 +1,5 @@
+class AddMemberPreferredImage < ActiveRecord::Migration
+  def change
+    add_column :members, :preferred_avatar_uri, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150625224805) do
+ActiveRecord::Schema.define(version: 20150824145414) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -306,6 +306,7 @@ ActiveRecord::Schema.define(version: 20150625224805) do
     t.integer  "plantings_count"
     t.boolean  "newsletter"
     t.boolean  "send_planting_reminder",  default: true
+    t.string   "preferred_avatar_uri"
   end
 
   add_index "members", ["confirmation_token"], name: "index_members_on_confirmation_token", unique: true, using: :btree

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -26,11 +26,11 @@ describe ApplicationHelper do
         @member = FactoryGirl.build(:member, email: 'example@example.com', preferred_avatar_uri: nil)
       end
       it 'should render a gravatar uri' do
-        expect(avatar_uri(@member)).to eq 'https://s.gravatar.com/avatar/23463b99b62a72f26ed677cc556c44e8?s=150'
+        expect(avatar_uri(@member)).to eq 'http://www.gravatar.com/avatar/23463b99b62a72f26ed677cc556c44e8?size=150&default=identicon'
       end
 
       it 'should render a gravatar uri for a given size' do
-        expect(avatar_uri(@member, 456)).to eq 'https://s.gravatar.com/avatar/23463b99b62a72f26ed677cc556c44e8?s=456'
+        expect(avatar_uri(@member, 456)).to eq 'http://www.gravatar.com/avatar/23463b99b62a72f26ed677cc556c44e8?size=456&default=identicon'
       end
     end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -19,4 +19,28 @@ describe ApplicationHelper do
     expect(output).to have_selector '.red', text: '*'
     expect(output).to have_selector 'em', text: 'denotes a required field'
   end
+
+  describe '#avatar_uri' do
+    context 'with a normal user' do
+      before :each do
+        @member = FactoryGirl.build(:member, email: 'example@example.com', preferred_avatar_uri: nil)
+      end
+      it 'should render a gravatar uri' do
+        expect(avatar_uri(@member)).to eq 'https://s.gravatar.com/avatar/23463b99b62a72f26ed677cc556c44e8?s=150'
+      end
+
+      it 'should render a gravatar uri for a given size' do
+        expect(avatar_uri(@member, 456)).to eq 'https://s.gravatar.com/avatar/23463b99b62a72f26ed677cc556c44e8?s=456'
+      end
+    end
+
+    context 'with a user who specified a preferred avatar uri' do
+      before :each do
+        @member = FactoryGirl.build(:member, email: 'example@example.com', preferred_avatar_uri: 'http://media.catmoji.com/post/ujg/cat-in-hat.jpg')
+      end
+      it 'should render a the specified uri' do
+        expect(avatar_uri(@member)).to eq 'http://media.catmoji.com/post/ujg/cat-in-hat.jpg'
+      end
+    end
+  end
 end


### PR DESCRIPTION
Partially addresses #509 - since most of the oauth providers give you an avatar URI, it'll be trivial to refactor #811 a bit further to set it to your $whatever login pic.

![gravatar](https://cloud.githubusercontent.com/assets/365751/9443675/7e55e314-4ac1-11e5-92a9-9c9bd0fe6568.png)

and we simulate the oauth login setting this:
```
irb(main):003:0* m = Member.first; m.preferred_avatar_uri = 'http://media.catmoji.com/post/ujg/cat-in-hat.jpg'; m.save!
  Member Load (47.1ms)  SELECT  "members".* FROM "members"   ORDER BY lower(login_name) asc LIMIT 1
  Member Load (46.4ms)  SELECT  "members".* FROM "members"   ORDER BY lower(login_name) asc LIMIT 1
   (41.5ms)  BEGIN
  Member Exists (47.1ms)  SELECT  1 AS one FROM "members"  WHERE (LOWER("members"."login_name") = LOWER('daniel_oconnor') AND "members"."id" != 8) LIMIT 1
  SQL (43.5ms)  UPDATE "members" SET "preferred_avatar_uri" = $1, "updated_at" = $2 WHERE "members"."id" = 8  [["preferred_avatar_uri", "http://media.catmoji.com/post/ujg/cat-in-hat.jpg"], ["updated_at", "2015-08-25 00:34:20.680746"]]
   (46.4ms)  COMMIT
```

and a simple refresh; hey presto

![custom_image](https://cloud.githubusercontent.com/assets/365751/9443676/7e5cf9a6-4ac1-11e5-81d7-a50b8e2f5818.png)


... a pleased cat.