### PR TITLE
Fix #721 : Escape quick crop link in markdown

### DIFF
--- a/lib/haml/filters/growstuff_markdown.rb
+++ b/lib/haml/filters/growstuff_markdown.rb
@@ -2,7 +2,7 @@ require 'bluecloth'
 
 module Haml::Filters
   module GrowstuffMarkdown
-    CROP_REGEX = /\[([^\[\]]+?)\]\(crop\)/
+    CROP_REGEX = /(?<!\\)\[([^\[\]]+?)\]\(crop\)/
     include Haml::Filters::Base
 
     def render(text)

--- a/spec/lib/haml/filters/growstuff_markdown_spec.rb
+++ b/spec/lib/haml/filters/growstuff_markdown_spec.rb
@@ -32,6 +32,12 @@ describe 'Haml::Filters::Growstuff_Markdown' do
     rendered.should match /not a crop/
   end
 
+  it "doesn't convert escaped crop links" do
+    @crop = FactoryGirl.create(:crop)
+    rendered = Haml::Filters::GrowstuffMarkdown.render( "\\" << input_link(@crop.name))
+    rendered.should match /\[#{@crop.name}\]\(crop\)/
+  end
+
   it "handles multiple crop links" do
     tomato = FactoryGirl.create(:tomato)
     maize = FactoryGirl.create(:maize)


### PR DESCRIPTION
Lookahead in markdown to verify \ is not present

Test for escaping crop link

Fixes #721 