### PR TITLE
Upgrade database cleaner gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -116,7 +116,7 @@ group :development, :test do
   gem 'rspec-rails', '~> 3.1.0'         # unit testing framework
   gem 'rspec-activemodel-mocks'
   gem 'byebug'                          # debugging
-  gem 'database_cleaner', '~> 1.3.0'
+  gem 'database_cleaner', '~> 1.5.0'
   gem 'webrat'                          # provides HTML matchers for view tests
   gem 'factory_girl_rails', '~> 4.5.0'  # for creating test data
   gem 'coveralls', require: false       # coverage analysis

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,7 +127,7 @@ GEM
     csv_shaper (1.1.1)
       activesupport (>= 3.0.0)
     dalli (2.7.2)
-    database_cleaner (1.3.0)
+    database_cleaner (1.5.0)
     debug_inspector (0.0.2)
     debugger-linecache (1.2.0)
     devise (3.4.1)
@@ -461,7 +461,7 @@ DEPENDENCIES
   coveralls
   csv_shaper
   dalli
-  database_cleaner (~> 1.3.0)
+  database_cleaner (~> 1.5.0)
   devise (~> 3.4.1)
   elasticsearch-model
   elasticsearch-rails


### PR DESCRIPTION
https://github.com/DatabaseCleaner/database_cleaner/pull/364 resolves an issue where database_cleaner gets upset by open transactions; often in the way that Capybara keeps a few open on modern rails.

This upgrades us to the latest:
https://rubygems.org/gems/database_cleaner/versions/1.5.0