### PR TITLE
Add additional capyabara driver options

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -124,6 +124,7 @@ group :development, :test do
   gem 'capybara-email'                  # integration tests for email
   gem 'poltergeist', '~> 1.6'           # for headless JS testing
   gem 'i18n-tasks'                      # adds tests for finding missing and unused translations
+  gem 'selenium-webdriver'
 end
 
 group :travis do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,8 @@ GEM
     capybara-email (2.4.0)
       capybara (~> 2.4)
       mail
+    childprocess (0.5.6)
+      ffi (~> 1.0, >= 1.0.11)
     climate_control (0.0.3)
       activesupport (>= 3.0)
     cliver (0.3.2)
@@ -380,12 +382,18 @@ GEM
     ruby-units (1.4.5)
     ruby_parser (3.1.3)
       sexp_processor (~> 4.1)
+    rubyzip (1.1.7)
     sass (3.2.19)
     sass-rails (4.0.5)
       railties (>= 4.0.0, < 5.0)
       sass (~> 3.2.2)
       sprockets (~> 2.8, < 3.0)
       sprockets-rails (~> 2.0)
+    selenium-webdriver (2.47.1)
+      childprocess (~> 0.5)
+      multi_json (~> 1.0)
+      rubyzip (~> 1.0)
+      websocket (~> 1.0)
     sexp_processor (4.4.4)
     shellany (0.0.1)
     simplecov (0.9.1)
@@ -432,6 +440,7 @@ GEM
       nokogiri (>= 1.2.0)
       rack (>= 1.0)
       rack-test (>= 0.5.3)
+    websocket (1.2.2)
     websocket-driver (0.5.4)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
@@ -505,6 +514,7 @@ DEPENDENCIES
   rspec-rails (~> 3.1.0)
   ruby-units
   sass-rails (~> 4.0.4)
+  selenium-webdriver
   therubyracer (~> 0.12)
   uglifier (~> 2.5.3)
   unicorn

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -78,6 +78,7 @@ GROWSTUFF_ELASTICSEARCH: "false"
 
 test:
   GROWSTUFF_SITE_NAME: Growstuff (test)
+  GROWSTUFF_CAPYBARA_DRIVER: poltergeist
 
 # Note: there is no good way to deploy settings from Figaro to
 # Travis-CI.  If you need env vars set there in order for tests to pass,

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -23,7 +23,15 @@ end
 
 require 'capybara'
 require 'capybara/poltergeist'
+
 Capybara.javascript_driver = :poltergeist
+if ENV['GROWSTUFF_CAPYBARA_DRIVER'].present?
+  case ENV['GROWSTUFF_CAPYBARA_DRIVER']
+  when 'selenium'
+    require 'selenium-webdriver'
+  end
+  Capybara.javascript_driver = ENV['GROWSTUFF_CAPYBARA_DRIVER'].to_sym
+end
 Capybara.app_host = 'http://localhost'
 Capybara.server_port = 8081
 


### PR DESCRIPTION
Adds the ability to run feature tests via selenium if you configure it;
or run specs with ```GROWSTUFF_CAPYBARA_DRIVER=selenium bundle exec rake spec:features/```

I find this really useful because:
 * You can actually see what's going on
 * Combined with pry; you can interactively debug the current browser window and resolve issues with visibility
 * Its possible to test against multiple browsers with a bit of configuration

Defaults to poltergeist still for CI, normal use