### PR TITLE
Tweak permissions links

### DIFF
--- a/app/views/alternate_names/show.html.haml
+++ b/app/views/alternate_names/show.html.haml
@@ -11,5 +11,5 @@
 
 - if can? :edit, @alternate_name
   = link_to 'Edit', edit_alternate_name_path(@alternate_name), :class => 'btn btn-default btn-xs'
-\|
+  \|
 = link_to 'Back', alternate_names_path

--- a/app/views/scientific_names/show.html.haml
+++ b/app/views/scientific_names/show.html.haml
@@ -9,6 +9,8 @@
   %b Crop:
   = link_to @scientific_name.crop, @scientific_name.crop
 
-= link_to 'Edit', edit_scientific_name_path(@scientific_name), :class => 'btn btn-default btn-xs'
-\|
+
+- if can? :edit, @scientific_name
+  = link_to 'Edit', edit_scientific_name_path(@scientific_name), :class => 'btn btn-default btn-xs'
+  \|
 = link_to 'Back', scientific_names_path

--- a/spec/views/scientific_names/show.html.haml_spec.rb
+++ b/spec/views/scientific_names/show.html.haml_spec.rb
@@ -28,6 +28,18 @@ describe "scientific_names/show" do
     render
     # Run the generator again with the --webrat flag if you want to use webrat matchers
     rendered.should match(/Zea mays/)
-    rendered.should match(@scientific_name.id.to_s)
+  end
+
+  context 'signed in' do
+
+    before :each do
+      @wrangler = FactoryGirl.create(:crop_wrangling_member)
+      sign_in @wrangler
+      render
+    end
+
+    it 'should have an edit button' do
+      rendered.should have_content 'Edit'
+    end
   end
 end

--- a/spec/views/scientific_names/show.html.haml_spec.rb
+++ b/spec/views/scientific_names/show.html.haml_spec.rb
@@ -35,6 +35,7 @@ describe "scientific_names/show" do
     before :each do
       @wrangler = FactoryGirl.create(:crop_wrangling_member)
       sign_in @wrangler
+      controller.stub(:current_user) { @wrangler }
       render
     end
 


### PR DESCRIPTION
Scientific names:
Only show edit links if we have permission

Alternate names:
Don't show a pipe if we only have one option