### PR TITLE
Fix WARNING: Using the `raise_error` matcher without providing a specific error

### DIFF
--- a/spec/controllers/member_controller_spec.rb
+++ b/spec/controllers/member_controller_spec.rb
@@ -62,12 +62,12 @@ describe MembersController do
     end
 
     it "doesn't show completely nonsense members" do
-      lambda { get :show, {:id => 9999} }.should raise_error
+      lambda { get :show, {:id => 9999} }.should raise_error(ActiveRecord::RecordNotFound)
     end
 
     it "doesn't show unconfirmed members" do
       @member2 = FactoryGirl.create(:unconfirmed_member)
-      lambda { get :show, {:id => @member2.id} }.should raise_error
+      lambda { get :show, {:id => @member2.id} }.should raise_error(ActiveRecord::RecordNotFound)
     end
 
   end


### PR DESCRIPTION
```
WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call. Actual error raised was #<ActiveRecord::RecordNotFound: Couldn't find Member with 'id'=9999>. Instead consider providing a specific error class or message. This message can be supressed by setting: `RSpec::Expectations.configuration.warn_about_potential_false_positives = false`. Called from /home/travis/build/Growstuff/growstuff/spec/controllers/member_controller_spec.rb:65:in `block (3 levels) in <top (required)>'

WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call. Actual error raised was #<ActiveRecord::RecordNotFound: Couldn't find Member with 'id'=28 [WHERE (confirmed_at IS NOT NULL)]>. Instead consider providing a specific error class or message. This message can be supressed by setting: `RSpec::Expectations.configuration.warn_about_potential_false_positives = false`. Called from /home/travis/build/Growstuff/growstuff/spec/controllers/member_controller_spec.rb:70:in `block (3 levels) in <top (required)>'.
```