### PR TITLE
#852 Harvest description headings rendered when there's no description

### DIFF
--- a/app/helpers/harvests_helper.rb
+++ b/app/helpers/harvests_helper.rb
@@ -38,8 +38,8 @@ module HarvestsHelper
   end
 
   def display_harvest_description(harvest)
-    if harvest.description.nil?
-      "no description provided."
+    if harvest.description.empty?
+      "No description provided."
     else
       truncate(harvest.description, length: 130, separator: ' ', omission: '... ') { link_to "Read more", harvest_path(harvest) }
     end


### PR DESCRIPTION
Harvest description headings: Issue [#852](https://github.com/Growstuff/growstuff/issues/852) 

I checked out the harvest index view, and it was using the display_harvest_description method in harvests_helper.rb, which looked like this: 
```  
def display_harvest_description(harvest)
    if harvest.description.nil?
      "No description provided."
  end
```
But the view wasn't displaying "No description provided", it just displayed the heading. There were two options with this, I could remove the panel and heading entirely when there's no description, or fix the method that was already there. I went with the latter because I noticed the individual harvest view pages also render "No description provided" for no description, and so I changed the method to ```if harvest.description.empty?``` since when there’s no description, it shows up as an empty string (“”) instead of nil.

Here’s a screenshot of what it looks like with this edit: ![](https://lh3.googleusercontent.com/GUWZt6K-u7LMack9dBwzCZMVDNrKYmb6GEA8GtgzpM9zDCAsWkhPLrghFGqWAbsIeuM3db5OvPpVhnOmZHfKVe6eKre1HK2WABwXbYmPI8JmxDkUbKkpf5DzdKJMLTBfEAcvCDDBicMPRSGmY-ERpW0Z0C6qfgG01z1pXBe3BjgxiKsIDsRo8KsTqxVzL2GCQbfxRltNkPEd5dqJec4HmO2z-UWKweGgUIf2YQHDY0KpxLRNDsRomUCDaIkL_FiNcyKXOXrwc4OvyujsPtHQk3tx4D1OW0KtY2GEUeFKvYvOOWGYIm6J-p3FUvfwMiDhZiYcQ-O44MqNDIS1sMIy26XpkkKvH82ESYkyNoHIG4NPhLm1LPemFVcIeYrQ9-hbSVlPFb6PjbXbUZIBl4e14N8cCAKF8ea2ZCekQlDdHwjUfpkjzIFrC1ZFuiZH1T0REnUmTsfr1iuhM8_bjw7KH0pTseeWIjf7nHOkLOgmhqwe3ZUPsUP0x-vluGx9DG9aoGUn5ghSJB3vNLcBGqWCTcHYazAVXaiM0DcL6Ly3Q0fKMW7M9FU4McMQ7q_FNH5jP_vA=w1162-h701-no)
If you want the heading gone for no description, please let me know! I'm more than happy to do that instead. 
