### PR TITLE
Install *all* gems in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ env:
     - GROWSTUFF_SITE_NAME="Growstuff (travis)" RAILS_SECRET_TOKEN='xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx' GROWSTUFF_ELASTICSEARCH='false'
   global:
     secure: "Z5TpM2jEX4UCvNePnk/LwltQX48U2u9BRc+Iypr1x9QW2o228QJhPIOH39a8RMUrepGnkQIq9q3ZRUn98RfrJz1yThtlNFL3NmzdQ57gKgjGwfpa0e4Dwj/ZJqV2D84tDGjvdVYLP7zzaYZxQcwk/cgNpzKf/jq97HLNP7CYuf4="
-bundler_args: "--without development production staging"
 rvm:
 - 2.1.8
 before_script:


### PR DESCRIPTION
Previously we were only installing the gems needed for testing. This caused our CI to miss an incompatibility problem with a gem that was only needed for another environment:
https://github.com/Growstuff/growstuff/pull/878#discussion_r63745751