### PR TITLE
RFC: Use a "growstuff" database user in dev and test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ env:
 rvm:
 - 2.2.4
 before_script:
-- psql -c 'create database growstuff_test;' -U postgres
+  - psql -c "create user growstuff with createdb password 'growstuff';" -U postgres
+  - psql -c "create database growstuff_test owner growstuff;" -U postgres
 script:
 - bundle exec rake db:migrate --trace
 - bundle exec rspec spec/

--- a/config/database.yml
+++ b/config/database.yml
@@ -2,14 +2,15 @@ development:
   adapter: postgresql
   database: growstuff_dev
   host: localhost
-  user: postgres
-  password: password
+  user: growstuff
+  password: growstuff
 
 test:
   adapter: postgresql
   database: growstuff_test
   host: localhost
-  user: postgres
+  user: growstuff
+  password: growstuff
 
 production:
   adapter: postgresql


### PR DESCRIPTION
Using the default "postgres" user, particularly without a password, makes me nervous.

We'd need to adjust environment-setup instructions to include a "create DB user" step, as soon as we recreate the environment-setup instructions...