### PR TITLE
update paperclip

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,7 +90,7 @@ GEM
     climate_control (0.0.3)
       activesupport (>= 3.0)
     cliver (0.3.2)
-    cocaine (0.5.7)
+    cocaine (0.5.8)
       climate_control (>= 0.0.3, < 1.0)
     codemirror-rails (4.8)
       railties (>= 3.0, < 5)
@@ -119,12 +119,6 @@ GEM
       rails-i18n (>= 4.0.0)
       sass-rails (>= 4.0.3)
     concurrent-ruby (1.0.2)
-    coveralls (0.7.1)
-      multi_json (~> 1.3)
-      rest-client
-      simplecov (>= 0.7)
-      term-ansicolor
-      thor
     coveralls (0.8.13)
       json (~> 1.8)
       simplecov (~> 0.11.0)
@@ -255,7 +249,6 @@ GEM
     leaflet-rails (0.7.4)
     letter_opener (1.3.0)
       launchy (~> 2.2)
-    lumberjack (1.0.9)
     listen (3.1.4)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -294,7 +287,7 @@ GEM
       multi_json (~> 1.3)
       omniauth-oauth (~> 1.0)
     orm_adapter (0.5.0)
-    paperclip (4.3.0)
+    paperclip (4.3.6)
       activemodel (>= 3.2.0)
       activesupport (>= 3.2.0)
       cocaine (~> 0.5.5)

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The wiki is down right now, so here's what you need to do on Mac OS X to get set
 
 ```
 gem install bundle
-gem install pg -v '0.17.1' -- --with-pg-config=/Applications/Postgres.app/Contents/Versions/latest/bin/pg_config
+gem install pg -v '0.18.4' -- --with-pg-config=/Applications/Postgres.app/Contents/Versions/latest/bin/pg_config
 bundle install
 ```
 


### PR DESCRIPTION
security (of the DOS-when-drive-rapidly-fills-up variety) fix https://github.com/thoughtbot/paperclip/releases/tag/v4.3.6