### PR TITLE
darken navbar item text when it opens (and the background turns light)

### DIFF
--- a/app/assets/stylesheets/custom_bootstrap/variables.sass
+++ b/app/assets/stylesheets/custom_bootstrap/variables.sass
@@ -42,7 +42,7 @@ $navbar-default-bg-highlight: $brown
 $navbar-default-color: $beige
 $navbar-default-link-color: darken($beige, 20%)
 $navbar-default-link-hover-color: $beige
-$navbar-default-link-active-color: $beige
+$navbar-default-link-active-color: darken($beige,80%)
 $navbar-default-brand-color: lighten($green, 20%)
 
 // Top nav collapse threshold


### PR DESCRIPTION
Fixes #896 

And Lea Verou's contrast checker says this is WCAG 2.0 compliant.