### PR TITLE
Improve the styling of a planting to be more like the other card-layouts

### DIFF
--- a/app/assets/stylesheets/overrides.sass
+++ b/app/assets/stylesheets/overrides.sass
@@ -93,6 +93,15 @@ p.stats
   padding-left: 1em
   width: 15em
 
+.planting
+  dl.planting-attributes
+    font-size: 85%
+
+    dt
+      text-align: left
+    dd
+      margin-left: auto
+
 .planting-thumbnail 
   padding: .25em
 

--- a/app/assets/stylesheets/overrides.sass
+++ b/app/assets/stylesheets/overrides.sass
@@ -93,6 +93,20 @@ p.stats
   padding-left: 1em
   width: 15em
 
+.planting-thumbnail 
+  padding: .25em
+
+  dl.planting-attributes
+    font-size: 85%
+    width: 100%
+
+    dt
+      text-align: left
+      width: 80px
+    dd
+      padding-left: 80px
+      margin-left: auto
+
 #placesmap, #cropmap 
   height: 500px
 

--- a/app/assets/stylesheets/overrides.sass
+++ b/app/assets/stylesheets/overrides.sass
@@ -103,8 +103,6 @@ p.stats
       margin-left: auto
 
 .planting-thumbnail 
-  padding: .25em
-
   dl.planting-attributes
     font-size: 85%
     width: 100%

--- a/app/assets/stylesheets/overrides.sass
+++ b/app/assets/stylesheets/overrides.sass
@@ -102,17 +102,18 @@ p.stats
     dd
       margin-left: auto
 
-.planting-thumbnail 
-  dl.planting-attributes
-    font-size: 85%
-    width: 100%
+@media (min-width: $screen-md-min)
+  .planting-thumbnail 
+    dl.planting-attributes
+      font-size: 85%
+      width: 100%
 
-    dt
-      text-align: left
-      width: 80px
-    dd
-      padding-left: 80px
-      margin-left: auto
+      dt
+        text-align: left
+        width: 80px
+      dd
+        padding-left: 80px
+        margin-left: auto
 
 #placesmap, #cropmap 
   height: 500px

--- a/app/views/members/_gardens.html.haml
+++ b/app/views/members/_gardens.html.haml
@@ -44,12 +44,12 @@
                 %p
                   = link_to "Add photo", new_photo_path(:type => "garden", :id => g.id), :class => 'btn btn-primary'
 
-        %h3 What's planted here?
-        .row
-          - if g.featured_plantings.size > 0
-            - g.featured_plantings.each.with_index do |planting|
-              .col-xs-12.col-lg-6
-                = render partial: "plantings/thumbnail", locals: {:planting => planting}
+          %h3 What's planted here?
+          .row
+            - if g.featured_plantings.size > 0
+              - g.featured_plantings.each.with_index do |planting|
+                .col-xs-12.col-lg-6
+                  = render partial: "plantings/thumbnail", locals: {:planting => planting}
 
-        %p
-          = link_to "More about this garden...", url_for(g)
+          %p
+            = link_to "More about this garden...", url_for(g)

--- a/app/views/places/show.html.haml
+++ b/app/views/places/show.html.haml
@@ -29,17 +29,20 @@
 
   %h3= "Recent plantings near #{@place}"
   
-  .row
-    - plantings = []
-    - @nearby_members.first(10).each do |member|
-      - member.plantings.first(5).each do |planting|
-        - plantings << planting
-    - if !plantings.blank?
+
+  - plantings = []
+  - @nearby_members.first(10).each do |member|
+    - member.plantings.first(5).each do |planting|
+      - plantings << planting
+  - if !plantings.blank?
+    .row
       - plantings.first(10).each.with_index do |planting, index|
         .col-xs-12.col-lg-6
           = render partial: "plantings/thumbnail", locals: {:planting => planting, :index => index}
+    .row
       = link_to "View all plantings >>", plantings_path
-    - else
+  - else
+    .row
       %p No nearby plantings found
 - else
   %p No results found

--- a/app/views/plantings/_thumbnail.html.haml
+++ b/app/views/plantings/_thumbnail.html.haml
@@ -1,41 +1,41 @@
-.row
-  .col-xs-4.col-md-2
-    = link_to image_tag((planting.default_photo ?  planting.default_photo.thumbnail_url : 'placeholder_150.png'), :alt => planting.crop_id, :class => 'img'), planting
-  .col-xs-4.col-md-6
-    %dl.dl-horizontal
-      %dt Owner:
-      %dd= link_to planting.owner.login_name, planting.owner
-      %dt Garden:
-      %dd= link_to planting.garden.name, planting.garden
-      %dt Planted on:
-      %dd= planting.planted_at
-      %dt Quantity: 
-      %dd= "#{display_planting_quantity(planting)}"
-      %dt Finished on:
-      %dd= "#{display_finished(planting)}"
-      %dt Sun/shade?:
-      %dd
-        - sunniness = planting.sunniness.blank? ? "not specified" : planting.sunniness
-        = image_tag("sunniness_#{sunniness}.png", :size => "25x25", :alt => "#{sunniness}", :title => "#{sunniness}")
-        = " (#{sunniness})"
-      %dt Planted from:
-      %dd= "#{display_planted_from(planting)}"
-  .col-xs-4.col-md-4
-    %ul{:style => "list-style-type:none"}
-      %li= link_to 'Details', planting, :class => 'btn btn-default btn-xs'
-      - if can? :edit, planting
-        %li= link_to 'Edit', edit_planting_path(planting), :class => 'btn btn-default btn-xs'
-        - if ! planting.finished
-          %li= link_to "Mark as finished", planting_path(planting, :planting => {:finished => 1}),  :method => :put, :class => 'btn btn-default btn-xs append-date'
-      - if can? :destroy, planting
-        %li= link_to 'Delete', planting, method: :delete, data: { confirm: 'Are you sure?' }, :class => 'btn btn-default btn-xs'
-.row
-  .col-xs-3.col-md-4
-    %dl
-      %dt Crop name:
-      %dd= link_to planting.crop.name, planting.crop
-      %dt Days until maturity:
-      %dd= "#{display_days_before_maturity(planting)}"
+.panel.planting-thumbnail
+  .row
+    .col-xs-4.col-md-4
+      = link_to image_tag((planting.default_photo ?  planting.default_photo.thumbnail_url : 'placeholder_150.png'), :alt => planting.crop_id, :class => 'img'), planting
+    .col-xs-4.col-md-5
+      %h4= link_to planting.crop.name, planting.crop
+      %dl.dl-horizontal.planting-attributes
+        %dt Owner:
+        %dd= link_to planting.owner.login_name, planting.owner
+        %dt Garden:
+        %dd= link_to planting.garden.name, planting.garden
+        %dt Planted on:
+        %dd= planting.planted_at
+        %dt Quantity: 
+        %dd= "#{display_planting_quantity(planting)}"
+        %dt Finished on:
+        %dd= "#{display_finished(planting)}"
+        %dt Sun/shade?:
+        %dd
+          - sunniness = planting.sunniness.blank? ? "not specified" : planting.sunniness
+          = image_tag("sunniness_#{sunniness}.png", :size => "25x25", :alt => "#{sunniness}", :title => "#{sunniness}")
+          = " (#{sunniness})"
+        %dt Planted from:
+        %dd= "#{display_planted_from(planting)}"
+    .col-xs-4.col-md-3
+      %ul{:style => "list-style-type:none; text-align:right"}
+        %li= link_to 'Details', planting, :class => 'btn btn-default btn-xs'
+        - if can? :edit, planting
+          %li= link_to 'Edit', edit_planting_path(planting), :class => 'btn btn-default btn-xs'
+          - if ! planting.finished
+            %li= link_to "Mark as finished", planting_path(planting, :planting => {:finished => 1}),  :method => :put, :class => 'btn btn-default btn-xs append-date'
+        - if can? :destroy, planting
+          %li= link_to 'Delete', planting, method: :delete, data: { confirm: 'Are you sure?' }, :class => 'btn btn-default btn-xs'
+  .row
+    .col-xs-3.col-md-4
+      %dl
+        %dt Days until maturity:
+        %dd= "#{display_days_before_maturity(planting)}"
 
-  .col-xs-9.col-md-8
-    = render partial: 'plantings/planting_progress', locals: {planting: planting}
+    .col-xs-9.col-md-8
+      = render partial: 'plantings/planting_progress', locals: {planting: planting}

--- a/app/views/plantings/_thumbnail.html.haml
+++ b/app/views/plantings/_thumbnail.html.haml
@@ -3,9 +3,9 @@
     %h3.panel-title= link_to planting.crop.name, planting.crop
   .panel-body
     .row
-      .col-xs-4.col-md-4
+      .col-xs-12.col-md-4
         = link_to image_tag((planting.default_photo ?  planting.default_photo.thumbnail_url : 'placeholder_150.png'), :alt => planting.crop_id, :class => 'img'), planting
-      .col-xs-4.col-md-5
+      .col-xs-7.col-md-5
         %dl.dl-horizontal.planting-attributes
           %dt Owner:
           %dd= link_to planting.owner.login_name, planting.owner
@@ -24,7 +24,7 @@
             = " (#{sunniness})"
           %dt Planted from:
           %dd= "#{display_planted_from(planting)}"
-      .col-xs-4.col-md-3
+      .col-xs-1.col-md-3
         %ul{:style => "list-style-type:none; text-align:right"}
           %li= link_to 'Details', planting, :class => 'btn btn-default btn-xs'
           - if can? :edit, planting
@@ -33,11 +33,12 @@
               %li= link_to "Mark as finished", planting_path(planting, :planting => {:finished => 1}),  :method => :put, :class => 'btn btn-default btn-xs append-date'
           - if can? :destroy, planting
             %li= link_to 'Delete', planting, method: :delete, data: { confirm: 'Are you sure?' }, :class => 'btn btn-default btn-xs'
+
     .row
-      .col-xs-3.col-md-4
+      .col-xs-12.col-md-4
         %dl
           %dt Days until maturity:
           %dd= "#{display_days_before_maturity(planting)}"
 
-      .col-xs-9.col-md-8
+      .col-xs-12.col-md-8
         = render partial: 'plantings/planting_progress', locals: {planting: planting}

--- a/app/views/plantings/_thumbnail.html.haml
+++ b/app/views/plantings/_thumbnail.html.haml
@@ -1,41 +1,43 @@
-.panel.planting-thumbnail
-  .row
-    .col-xs-4.col-md-4
-      = link_to image_tag((planting.default_photo ?  planting.default_photo.thumbnail_url : 'placeholder_150.png'), :alt => planting.crop_id, :class => 'img'), planting
-    .col-xs-4.col-md-5
-      %h4= link_to planting.crop.name, planting.crop
-      %dl.dl-horizontal.planting-attributes
-        %dt Owner:
-        %dd= link_to planting.owner.login_name, planting.owner
-        %dt Garden:
-        %dd= link_to planting.garden.name, planting.garden
-        %dt Planted on:
-        %dd= planting.planted_at
-        %dt Quantity: 
-        %dd= "#{display_planting_quantity(planting)}"
-        %dt Finished on:
-        %dd= "#{display_finished(planting)}"
-        %dt Sun/shade?:
-        %dd
-          - sunniness = planting.sunniness.blank? ? "not specified" : planting.sunniness
-          = image_tag("sunniness_#{sunniness}.png", :size => "25x25", :alt => "#{sunniness}", :title => "#{sunniness}")
-          = " (#{sunniness})"
-        %dt Planted from:
-        %dd= "#{display_planted_from(planting)}"
-    .col-xs-4.col-md-3
-      %ul{:style => "list-style-type:none; text-align:right"}
-        %li= link_to 'Details', planting, :class => 'btn btn-default btn-xs'
-        - if can? :edit, planting
-          %li= link_to 'Edit', edit_planting_path(planting), :class => 'btn btn-default btn-xs'
-          - if ! planting.finished
-            %li= link_to "Mark as finished", planting_path(planting, :planting => {:finished => 1}),  :method => :put, :class => 'btn btn-default btn-xs append-date'
-        - if can? :destroy, planting
-          %li= link_to 'Delete', planting, method: :delete, data: { confirm: 'Are you sure?' }, :class => 'btn btn-default btn-xs'
-  .row
-    .col-xs-3.col-md-4
-      %dl
-        %dt Days until maturity:
-        %dd= "#{display_days_before_maturity(planting)}"
+.panel.panel-success.planting-thumbnail
+  .panel-heading
+    %h3.panel-title= link_to planting.crop.name, planting.crop
+  .panel-body
+    .row
+      .col-xs-4.col-md-4
+        = link_to image_tag((planting.default_photo ?  planting.default_photo.thumbnail_url : 'placeholder_150.png'), :alt => planting.crop_id, :class => 'img'), planting
+      .col-xs-4.col-md-5
+        %dl.dl-horizontal.planting-attributes
+          %dt Owner:
+          %dd= link_to planting.owner.login_name, planting.owner
+          %dt Garden:
+          %dd= link_to planting.garden.name, planting.garden
+          %dt Planted on:
+          %dd= planting.planted_at
+          %dt Quantity: 
+          %dd= "#{display_planting_quantity(planting)}"
+          %dt Finished on:
+          %dd= "#{display_finished(planting)}"
+          %dt Sun/shade?:
+          %dd
+            - sunniness = planting.sunniness.blank? ? "not specified" : planting.sunniness
+            = image_tag("sunniness_#{sunniness}.png", :size => "25x25", :alt => "#{sunniness}", :title => "#{sunniness}")
+            = " (#{sunniness})"
+          %dt Planted from:
+          %dd= "#{display_planted_from(planting)}"
+      .col-xs-4.col-md-3
+        %ul{:style => "list-style-type:none; text-align:right"}
+          %li= link_to 'Details', planting, :class => 'btn btn-default btn-xs'
+          - if can? :edit, planting
+            %li= link_to 'Edit', edit_planting_path(planting), :class => 'btn btn-default btn-xs'
+            - if ! planting.finished
+              %li= link_to "Mark as finished", planting_path(planting, :planting => {:finished => 1}),  :method => :put, :class => 'btn btn-default btn-xs append-date'
+          - if can? :destroy, planting
+            %li= link_to 'Delete', planting, method: :delete, data: { confirm: 'Are you sure?' }, :class => 'btn btn-default btn-xs'
+    .row
+      .col-xs-3.col-md-4
+        %dl
+          %dt Days until maturity:
+          %dd= "#{display_days_before_maturity(planting)}"
 
-    .col-xs-9.col-md-8
-      = render partial: 'plantings/planting_progress', locals: {planting: planting}
+      .col-xs-9.col-md-8
+        = render partial: 'plantings/planting_progress', locals: {planting: planting}

--- a/app/views/plantings/show.html.haml
+++ b/app/views/plantings/show.html.haml
@@ -59,10 +59,11 @@
   .col-md-6
     = render :partial => "crops/index_card", :locals => { :crop => @planting.crop}
 
-%h2 Notes
+- if @planting.description
+  %h2 Notes
 
-:growstuff_markdown
-  #{ @planting.description != "" ? @planting.description : "No description given." }
+  :growstuff_markdown
+    #{ @planting.description != "" ? @planting.description : "No description given." }
 
 - if @planting.photos.size > 0 or (can? :edit, @planting and can? :create, Photo)
   %h2 Pictures

--- a/app/views/plantings/show.html.haml
+++ b/app/views/plantings/show.html.haml
@@ -1,51 +1,46 @@
 =content_for :title, "#{@planting.crop} in #{@planting.location}"
 
-.row
+.row.planting
   .col-md-6
-    %p
-      %b Owner:
-      = link_to @planting.owner, @planting.owner
-      &mdash;
-      = link_to "view all #{@planting.owner}'s plantings", plantings_by_owner_path(:owner => @planting.owner.slug)
-    %p
-      %b Planted on:
-      = @planting.planted_at ? @planting.planted_at : "not specified"
+    %dl.dl-horizontal.planting-attributes
+      %dt Owner:
+      %dd
+        = link_to @planting.owner, @planting.owner
+        &mdash;
+        = link_to "view all #{@planting.owner}'s plantings", plantings_by_owner_path(:owner => @planting.owner.slug)
 
-    %p
-      %b Where:
-      =link_to "#{@planting.owner}'s", @planting.owner
-      =link_to @planting.garden, @planting.garden
-      - if ! @planting.owner.location.blank?
-        = "(#{@planting.owner.location})"
-    %p
-      %b 
-        = "Quantity: "
-      = "#{display_planting_quantity(@planting)}"
+      %dt Planted on:
+      %dd= @planting.planted_at ? @planting.planted_at : "not specified"
+
+      %dt Where:
+      %dd
+        =link_to "#{@planting.owner}'s", @planting.owner
+        =link_to @planting.garden, @planting.garden
+        - if ! @planting.owner.location.blank?
+          = "(#{@planting.owner.location})"
+
+      %dt Quantity:
+      %dd
+        ="#{display_planting_quantity(@planting)}"
     
-    - if !@planting.planted_from.blank?
-      %p
-        %b 
-          = "Planted from: "
-        = "#{display_planted_from(@planting)}"
+      - if !@planting.planted_from.blank?
+        %dt Planted from:
+        %dd= "#{display_planted_from(@planting)}"
     
-    %p
-      %b 
-        = "Sun or shade?: "
-      - sunniness = @planting.sunniness.blank? ? "not specified" : @planting.sunniness
-      = image_tag("sunniness_#{sunniness}.png", :size => "25x25", :alt => "#{sunniness}", :title => "#{sunniness}")
-      = " (#{sunniness})"
+      %dt Sun or shade?
+      %dd
+        - sunniness = @planting.sunniness.blank? ? "not specified" : @planting.sunniness
+        = image_tag("sunniness_#{sunniness}.png", :size => "25x25", :alt => "#{sunniness}", :title => "#{sunniness}")
+        = " (#{sunniness})"
+
+      %dt Days until maturity:
+      %dd= "#{display_days_before_maturity(@planting)}"
+
+      %dt Finished:
+      %dd= "#{display_finished(@planting)}"
 
     %p
-      %b 
-        = "Days until maturity: "
-      = "#{display_days_before_maturity(@planting)}"
-    %p
-      %b 
-        = "Finished: "
-      = "#{display_finished(@planting)}"
-
-    %p
-      %b= render 'planting_progress', planting: @planting
+      = render 'planting_progress', planting: @planting
 
     - if can? :edit, @planting or can? :destroy, @planting
       %p


### PR DESCRIPTION
Fixes #870

Before:
http://growstuff.org/plantings/

After:
![image](https://cloud.githubusercontent.com/assets/365751/15458030/1c7ec270-20d4-11e6-89a3-5983185c93a8.png)

I haven't checked this on mobile yet, and the fixed-width behaviour I used to style the definition list feels wrong (on the other hand, the previous styling also used fixed widths)
