### PR TITLE
set background color on autocomplete dropdown. Fixes #914

### DIFF
--- a/app/assets/stylesheets/overrides.sass
+++ b/app/assets/stylesheets/overrides.sass
@@ -244,7 +244,8 @@ html, body
 
 // Autosuggest
 
-.ui-autocomplete 
+.ui-autocomplete
+  background: white
   z-index: $zindex-tooltip
 
 // Crowdfunding campaign, Sep-Oct 2014


### PR DESCRIPTION
Before:
<img width="510" alt="screen shot 2016-05-25 at 4 04 28 pm" src="https://cloud.githubusercontent.com/assets/401264/15554465/6345ecb4-2292-11e6-9baf-a8ed563565a4.png">

After:
<img width="643" alt="screen shot 2016-05-25 at 4 05 03 pm" src="https://cloud.githubusercontent.com/assets/401264/15554481/7a90e252-2292-11e6-9f7e-95e7a9317417.png">
