### PR TITLE
Stop hard-coding strings for pagination

### DIFF
--- a/app/views/comments/index.html.haml
+++ b/app/views/comments/index.html.haml
@@ -1,7 +1,7 @@
 = content_for :title, "Recent comments"
 
 %div.pagination
-  = page_entries_info @comments, :model => "comments"
+  = page_entries_info @comments
   = will_paginate @comments
 
 - @comments.each do |comment|
@@ -11,7 +11,7 @@
   = render :partial => "single", :locals => { :comment => comment }
 
 %div.pagination
-  = page_entries_info @comments, :model => "comments"
+  = page_entries_info @comments
   = will_paginate @comments
 
 %p

--- a/app/views/crops/show.html.haml
+++ b/app/views/crops/show.html.haml
@@ -54,13 +54,13 @@
           = render :partial => "shared/signin_signup", :locals => { :to => "post your tips and experiences growing #{ @crop.name.pluralize }" }
     - else
       %div.pagination
-        = page_entries_info @posts, :model => "posts"
+        = page_entries_info @posts
         = will_paginate @posts, :params => {:anchor => "posts"}
       - @posts.each do |post|
         = render :partial => "posts/single", :locals => { :post => post, :subject => true }
 
       %div.pagination
-        = page_entries_info @posts, :model => "posts"
+        = page_entries_info @posts
         = will_paginate @posts, :params => {:anchor => "posts"}
 
   .col-md-3

--- a/app/views/crops/wrangle.html.haml
+++ b/app/views/crops/wrangle.html.haml
@@ -34,7 +34,7 @@
 
 
 %div.pagination
-  = page_entries_info @crops, :model => "crops"
+  = page_entries_info @crops
   = will_paginate @crops
 
 %table{:class => "table table-striped", :id => @approval_status.blank? ? 'recently-added-crops' : "#{@approval_status}-crops"}
@@ -64,7 +64,7 @@
         ago.
 
 %div.pagination
-  = page_entries_info @crops, :model => "crops"
+  = page_entries_info @crops
   = will_paginate @crops
 
 

--- a/app/views/gardens/index.html.haml
+++ b/app/views/gardens/index.html.haml
@@ -15,7 +15,7 @@
     = render :partial => 'shared/signin_signup', :locals => { :to => 'add a new garden' }
 
 %div.pagination
-  = page_entries_info @gardens, :model => "gardens"
+  = page_entries_info @gardens
   = will_paginate @gardens
 
 .row
@@ -27,6 +27,6 @@
     %p There are no gardens to display.
 
 %div.pagination
-  = page_entries_info @gardens, :model => "gardens"
+  = page_entries_info @gardens
   = will_paginate @gardens
 

--- a/app/views/harvests/index.html.haml
+++ b/app/views/harvests/index.html.haml
@@ -21,7 +21,7 @@
     = render :partial => 'shared/signin_signup', :locals => { :to => 'track your harvests' }
 
 %div.pagination
-  = page_entries_info @harvests, :model => "harvests"
+  = page_entries_info @harvests
   = will_paginate @harvests
 .row
   - if @harvests.size > 0
@@ -30,7 +30,7 @@
         =render :partial => 'harvests/thumbnail', :locals => {:harvest => harvest}
 
 %div.pagination
-  = page_entries_info @harvests, :model => "harvests"
+  = page_entries_info @harvests
   = will_paginate @harvests
 
   %ul.list-inline

--- a/app/views/members/index.html.haml
+++ b/app/views/members/index.html.haml
@@ -7,7 +7,7 @@
   = submit_tag "Show", :class => 'btn btn-primary'
 
 %div.pagination
-  = page_entries_info @members, :model => "members"
+  = page_entries_info @members
   = will_paginate @members
 
 .member-cards
@@ -15,5 +15,5 @@
     = render :partial => "members/thumbnail", :locals => { :member => m }
 
 %div.pagination
-  = page_entries_info @members, :model => "members"
+  = page_entries_info @members
   = will_paginate @members

--- a/app/views/members/view_followers.html.haml
+++ b/app/views/members/view_followers.html.haml
@@ -1,7 +1,7 @@
 - content_for :title, "#{@member.login_name}'s followers"
 
 %div.pagination
-  = page_entries_info @followers, :model => "members"
+  = page_entries_info @followers
   = will_paginate @followers
 
 .row
@@ -12,5 +12,5 @@
           = render :partial => "members/thumbnail", :locals => { :member => f }
           
 %div.pagination
-  = page_entries_info @followers, :model => "members"
+  = page_entries_info @followers
   = will_paginate @followers

--- a/app/views/members/view_follows.html.haml
+++ b/app/views/members/view_follows.html.haml
@@ -1,7 +1,7 @@
 - content_for :title, "#{@member.login_name}'s follows"
 
 %div.pagination
-  = page_entries_info @follows, :model => "members"
+  = page_entries_info @follows
   = will_paginate @follows
 
 .row
@@ -12,5 +12,5 @@
           = render :partial => "members/thumbnail", :locals => { :member => f }
 
 %div.pagination
-  = page_entries_info @follows, :model => "members"
+  = page_entries_info @follows
   = will_paginate @follows

--- a/app/views/photos/index.html.haml
+++ b/app/views/photos/index.html.haml
@@ -3,7 +3,7 @@
 %p Most recent photos added to #{ENV['GROWSTUFF_SITE_NAME']}.
 
 %div.pagination
-  = page_entries_info @photos, :model => "photos"
+  = page_entries_info @photos
   = will_paginate @photos
 
 .row
@@ -17,7 +17,7 @@
           = link_to p.owner, p.owner
 
 %div.pagination
-  = page_entries_info @photos, :model => "photos"
+  = page_entries_info @photos
   = will_paginate @photos
 
 

--- a/app/views/photos/new.html.haml
+++ b/app/views/photos/new.html.haml
@@ -20,7 +20,7 @@
         = submit_tag "Search", :class => 'btn btn-primary'
 
   %div.pagination
-    = page_entries_info @photos, :model => "photos"
+    = page_entries_info @photos
     = will_paginate @photos
 
   .row

--- a/app/views/plantings/index.html.haml
+++ b/app/views/plantings/index.html.haml
@@ -17,7 +17,7 @@
     = render :partial => 'shared/signin_signup', :locals => { :to => "track what you've planted" }
 
 %div.pagination
-  = page_entries_info @plantings, :model => "plantings"
+  = page_entries_info @plantings
   = will_paginate @plantings
 
 .row
@@ -27,7 +27,7 @@
         = render partial: "plantings/thumbnail", locals: {:planting => planting}
 
 %div.pagination
-  = page_entries_info @plantings, :model => "plantings"
+  = page_entries_info @plantings
   = will_paginate @plantings
 
   %ul.list-inline

--- a/app/views/posts/index.html.haml
+++ b/app/views/posts/index.html.haml
@@ -15,7 +15,7 @@
     = render :partial => 'shared/signin_signup', :locals => { :to => 'write a post' }
 
 %div.pagination
-  = page_entries_info @posts, :model => "posts"
+  = page_entries_info @posts
   = will_paginate @posts
 
 - unless @posts.empty?
@@ -23,7 +23,7 @@
     = render :partial => "single", :locals => { :post => post, :subject => true }
 
   %div.pagination
-    = page_entries_info @posts, :model => "posts"
+    = page_entries_info @posts
     = will_paginate @posts
 
 %p

--- a/app/views/seeds/index.html.haml
+++ b/app/views/seeds/index.html.haml
@@ -21,7 +21,7 @@
     = render :partial => 'shared/signin_signup', :locals => { :to => 'add seeds to your stash' }
 
 %div.pagination
-  = page_entries_info @seeds, :model => "seeds"
+  = page_entries_info @seeds
   = will_paginate @seeds
 .row
   - if @seeds.size > 0
@@ -30,7 +30,7 @@
         =render :partial => 'seeds/thumbnail', :locals => {:seed => seed}
 
 %div.pagination
-  = page_entries_info @seeds, :model => "seeds"
+  = page_entries_info @seeds
   = will_paginate @seeds
 
 %ul.list-inline

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -151,3 +151,32 @@ en:
       post: "Post"
       edit_profile: "Edit profile"
 
+  activerecord:
+    models:
+      comment:
+        one: "comment"
+        other: "comments"
+      crop:
+        one: "crop"
+        other: "crops"
+      garden:
+        one: "garden"
+        other: "gardens"
+      harvest:
+        one: "harvest"
+        other: "harvests"
+      member:
+        one: "member"
+        other: "members"
+      photo:
+        one: "photo"
+        other: "photos"
+      planting:
+        one: "planting"
+        other: "plantings"
+      post:
+        one: "post"
+        other: "posts"
+      seed:
+        one: "seed"
+        other: "seeds"


### PR DESCRIPTION
Use translation template to set singular/other strings
for .model_name

Fixes #855 

And I'm about to go file bugs regarding us doing things like `pluralize(member.posts.size, "post")` that result in untranslated text