### PR TITLE
Remove warnings and debugging puts from rspec output

### DIFF
--- a/spec/features/crops/crop_detail_page_spec.rb
+++ b/spec/features/crops/crop_detail_page_spec.rb
@@ -133,7 +133,7 @@ feature "crop detail page", js: true do
 
       scenario "has a link to Wikipedia with SEO" do
         expect(page).to have_content "Learn more about #{ crop.name }"
-        expect(page).to have_link "Wikipedia (English)", crop.en_wikipedia_url
+        expect(page).to have_link "Wikipedia (English)", href: crop.en_wikipedia_url
       end
 
     end

--- a/spec/features/gardens_spec.rb
+++ b/spec/features/gardens_spec.rb
@@ -12,7 +12,6 @@ feature "Planting a crop", js: true do
 
   scenario "View gardens" do
     visit gardens_path
-    puts page.body
     expect(page).to have_content "Everyone's gardens"
     click_link "View your gardens"
     expect(page).to have_content "#{garden.owner.login_name}'s gardens"

--- a/spec/features/planting_reminder_spec.rb
+++ b/spec/features/planting_reminder_spec.rb
@@ -33,8 +33,8 @@ feature "Planting reminder email", :js do
 
     scenario "lists plantings" do
       expect(mail).to have_content "most recent plantings you've told us about"
-      expect(mail).to have_link p1.to_s, planting_url(p1)
-      expect(mail).to have_link p2.to_s, planting_url(p2)
+      expect(mail).to have_link p1.to_s, href: planting_url(p1)
+      expect(mail).to have_link p2.to_s, href: planting_url(p2)
       expect(mail).to have_content "keep your garden records up to date"
     end
   end
@@ -57,8 +57,8 @@ feature "Planting reminder email", :js do
 
     scenario "lists harvests" do
       expect(mail).to have_content "the last few things you harvested were"
-      expect(mail).to have_link h1.to_s, harvest_url(h1)
-      expect(mail).to have_link h2.to_s, harvest_url(h2)
+      expect(mail).to have_link h1.to_s, href: harvest_url(h1)
+      expect(mail).to have_link h2.to_s, href: harvest_url(h2)
       expect(mail).to have_content "Harvested anything else lately?"
     end
   end


### PR DESCRIPTION
Fixes the "rspec output includes an HTML page dump" issue noted at
https://github.com/Growstuff/growstuff/commit/2089866756f8c42c8c582f33ceccbeb0585df141#diff-6464240396bc745d7e89a408c200fd3aR15