### PR TITLE
WIP: Add haml-lint gem, and fix the problems it finds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -117,6 +117,7 @@ group :development, :test do
   gem 'i18n-tasks'                      # adds tests for finding missing and unused translations
   gem 'selenium-webdriver'
   gem "codeclimate-test-reporter", group: :test, require: nil
+  gem 'haml-lint'
 end
 
 group :travis do

--- a/Gemfile
+++ b/Gemfile
@@ -39,10 +39,10 @@ gem 'bootstrap-kaminari-views'     # bootstrap views for kaminari
 # vendored activemerchant for testing- needed for bogus paypal
 # gateway monkeypatch
 gem 'activemerchant', '1.33.0',
-  :path    => 'vendor/gems/activemerchant-1.33.0',
-  :require => 'active_merchant'
+  path: 'vendor/gems/activemerchant-1.33.0',
+  require: 'active_merchant'
 gem 'active_utils', '1.0.5',
-  :path    => 'vendor/gems/active_utils-1.0.5'
+  path: 'vendor/gems/active_utils-1.0.5'
 
 # Markdown formatting for updates etc
 gem 'bluecloth'
@@ -61,8 +61,8 @@ gem 'gravatar-ultimate'
 
 # For geolocation
 gem 'geocoder',
-  :git => 'https://github.com/alexreisner/geocoder.git',
-  :ref => '104d46'
+  git: 'https://github.com/alexreisner/geocoder.git',
+  ref: '104d46'
 
 # For easy calendar selection
 gem 'bootstrap-datepicker-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,12 +200,19 @@ GEM
       rspec (>= 2.99.0, < 4.0)
     haml (4.0.7)
       tilt
+    haml-lint (0.999.999)
+      haml_lint
     haml-rails (0.9.0)
       actionpack (>= 4.0.1)
       activesupport (>= 4.0.1)
       haml (>= 4.0.6, < 5.0)
       html2haml (>= 1.0.1)
       railties (>= 4.0.1)
+    haml_lint (0.17.1)
+      haml (~> 4.0)
+      rake (>= 10, < 12)
+      rubocop (>= 0.36.0)
+      sysexits (~> 1.1)
     hashie (3.4.4)
     heroku-api (0.4.2)
       excon (~> 0.45)
@@ -306,6 +313,7 @@ GEM
       cliver (~> 0.3.1)
       multi_json (~> 1.0)
       websocket-driver (>= 0.2.0)
+    powerpack (0.1.1)
     pry (0.10.3)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -338,6 +346,7 @@ GEM
       activesupport (= 4.1.15)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
+    rainbow (2.1.0)
     raindrops (0.16.0)
     rake (11.1.2)
     rb-fsevent (0.9.7)
@@ -370,6 +379,13 @@ GEM
       rspec-mocks (~> 3.4.0)
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
+    rubocop (0.40.0)
+      parser (>= 2.3.1.0, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-progressbar (1.8.1)
     ruby-units (2.0.0)
     ruby_dep (1.3.1)
     ruby_parser (3.8.2)
@@ -401,6 +417,7 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
+    sysexits (1.2.0)
     term-ansicolor (1.3.2)
       tins (~> 1.0)
     terminal-table (1.5.2)
@@ -414,6 +431,7 @@ GEM
     uglifier (2.7.2)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
+    unicode-display_width (1.0.5)
     unicorn (5.1.0)
       kgio (~> 2.6)
       raindrops (~> 0.7)
@@ -471,6 +489,7 @@ DEPENDENCIES
   guard
   guard-rspec
   haml
+  haml-lint
   haml-rails
   heroku-api
   i18n-tasks

--- a/app/views/account_types/edit.html.haml
+++ b/app/views/account_types/edit.html.haml
@@ -1,4 +1,4 @@
--content_for :title, "Editing account type"
+-content_for :title, 'Editing account type'
 
 = render 'form'
 

--- a/app/views/account_types/index.html.haml
+++ b/app/views/account_types/index.html.haml
@@ -16,7 +16,7 @@
       %td= account_type.is_permanent_paid
       %td= link_to 'Show', account_type
       %td= link_to 'Edit', edit_account_type_path(account_type)
-      %td= link_to 'Destroy', account_type, :method => :delete, :data => { :confirm => 'Are you sure?' }
+      %td= link_to 'Destroy', account_type, method: :delete, data: { confirm: 'Are you sure?' }
 
 %br
 

--- a/app/views/account_types/index.html.haml
+++ b/app/views/account_types/index.html.haml
@@ -1,4 +1,4 @@
-- content_for :title, "Listing account types"
+- content_for :title, 'Listing account types'
 
 %table
   %tr

--- a/app/views/account_types/new.html.haml
+++ b/app/views/account_types/new.html.haml
@@ -1,4 +1,4 @@
-- content_for :title, "New account type"
+- content_for :title, 'New account type'
 
 = render 'form'
 

--- a/app/views/account_types/show.html.haml
+++ b/app/views/account_types/show.html.haml
@@ -12,6 +12,6 @@
 
 = link_to 'Edit', edit_account_type_path(@account_type)
 \|
-= link_to 'Delete', @account_type, :method => :delete, :data => { :confirm => 'Are you sure?' }
+= link_to 'Delete', @account_type, method: :delete, data: { confirm: 'Are you sure?' }
 \|
 = link_to 'Back', account_types_path

--- a/app/views/accounts/edit.html.haml
+++ b/app/views/accounts/edit.html.haml
@@ -1,4 +1,4 @@
-- content_for :title, "Editing account"
+- content_for :title, 'Editing account'
 
 = render 'form'
 

--- a/app/views/accounts/index.html.haml
+++ b/app/views/accounts/index.html.haml
@@ -16,7 +16,7 @@
       %td= account.paid_until
       %td= link_to 'Show', account
       %td= link_to 'Edit', edit_account_path(account)
-      %td= link_to 'Destroy', account, :method => :delete, :data => { :confirm => 'Are you sure?' }
+      %td= link_to 'Destroy', account, method: :delete, data: { confirm: 'Are you sure?' }
 
 %br
 

--- a/app/views/accounts/index.html.haml
+++ b/app/views/accounts/index.html.haml
@@ -1,4 +1,4 @@
-- content_for :title, "Listing accounts"
+- content_for :title, 'Listing accounts'
 
 %table
   %tr

--- a/app/views/accounts/new.html.haml
+++ b/app/views/accounts/new.html.haml
@@ -1,4 +1,4 @@
-- content_for :title, "New account"
+- content_for :title, 'New account'
 
 = render 'form'
 

--- a/app/views/admin/index.html.haml
+++ b/app/views/admin/index.html.haml
@@ -3,13 +3,13 @@
 %h2 Manage
 
 %ul#admin_links
-  %li= link_to "Account types", account_types_path
-  %li= link_to "Products", products_path
-  %li= link_to "Roles", roles_path
-  %li= link_to "Forums", forums_path
-  %li= link_to "Newsletter subscribers", admin_newsletter_path
-  %li= link_to "CMS", comfy_admin_cms_path
+  %li= link_to 'Account types', account_types_path
+  %li= link_to 'Products', products_path
+  %li= link_to 'Roles', roles_path
+  %li= link_to 'Forums', forums_path
+  %li= link_to 'Newsletter subscribers', admin_newsletter_path
+  %li= link_to 'CMS', comfy_admin_cms_path
 
 %h2 Orders
 
-=render "admin/orders/searchform"
+=render 'admin/orders/searchform'

--- a/app/views/admin/orders/_searchform.html.haml
+++ b/app/views/admin/orders/_searchform.html.haml
@@ -1,5 +1,5 @@
 = form_tag(url_for(controller: 'admin/orders', action: 'search'), method: :get, class: 'form-inline') do
-  = label_tag :distance, "Search orders:", class: 'control-label'
+  = label_tag :distance, 'Search orders:', class: 'control-label'
   = text_field_tag :search_text
   = select_tag :search_by, options_for_select({'Member' => 'member', 'Referral code' => 'referral_code', 'Order ID' => 'order_id', 'Paypal Token' => 'paypal_token', 'Paypal Payer ID' => 'paypal_payer_id' })
-  = submit_tag "Search", class: 'btn btn-primary'
+  = submit_tag 'Search', class: 'btn btn-primary'

--- a/app/views/admin/orders/_searchform.html.haml
+++ b/app/views/admin/orders/_searchform.html.haml
@@ -1,5 +1,5 @@
-= form_tag(url_for(:controller => 'admin/orders', :action => 'search'), :method => :get, :class => 'form-inline') do
-  = label_tag :distance, "Search orders:", :class => 'control-label'
+= form_tag(url_for(controller: 'admin/orders', action: 'search'), method: :get, class: 'form-inline') do
+  = label_tag :distance, "Search orders:", class: 'control-label'
   = text_field_tag :search_text
   = select_tag :search_by, options_for_select({'Member' => 'member', 'Referral code' => 'referral_code', 'Order ID' => 'order_id', 'Paypal Token' => 'paypal_token', 'Paypal Payer ID' => 'paypal_payer_id' })
-  = submit_tag "Search", :class => 'btn btn-primary'
+  = submit_tag "Search", class: 'btn btn-primary'

--- a/app/views/admin/orders/index.html.haml
+++ b/app/views/admin/orders/index.html.haml
@@ -1,3 +1,3 @@
 -content_for :title, 'Admin Orders'
 
-=render "admin/orders/searchform"
+=render 'admin/orders/searchform'

--- a/app/views/admin/orders/search.html.haml
+++ b/app/views/admin/orders/search.html.haml
@@ -1,11 +1,11 @@
 -content_for :title, 'Search Orders'
 
-=render "admin/orders/searchform"
+=render 'admin/orders/searchform'
 
 - unless @orders.empty?
   %h2
     Found
-    = pluralize(@orders.size, "result")
+    = pluralize(@orders.size, 'result')
 
   %table.table.table-striped
     %tr

--- a/app/views/admin/orders/search.html.haml
+++ b/app/views/admin/orders/search.html.haml
@@ -36,4 +36,4 @@
               @
               = price_with_currency(o.price)
               %br/
-        %td= link_to 'Details', order, :class => 'btn btn-default btn-xs'
+        %td= link_to 'Details', order, class: 'btn btn-default btn-xs'

--- a/app/views/alternate_names/_form.html.haml
+++ b/app/views/alternate_names/_form.html.haml
@@ -1,4 +1,4 @@
-= form_for @alternate_name, :html => {:class => 'form-horizontal', :role => "form"} do |f|
+= form_for @alternate_name, html: {class: 'form-horizontal', role: "form"} do |f|
   - if @alternate_name.errors.any?
     #error_explanation
       %h2= "#{pluralize(@alternate_name.errors.size, "error")} prohibited this alternate_name from being saved:"
@@ -13,15 +13,15 @@
       on the Growstuff wiki.
 
   .form-group
-    = f.label :crop_id, :class => 'control-label col-md-2'
+    = f.label :crop_id, class: 'control-label col-md-2'
     .col-md-8
-      = collection_select(:alternate_name, :crop_id, Crop.all, :id, :name, { :selected => @alternate_name.crop_id || @crop.id }, :class => 'form-control')
+      = collection_select(:alternate_name, :crop_id, Crop.all, :id, :name, { selected: @alternate_name.crop_id || @crop.id }, class: 'form-control')
 
   .form-group
-    = f.label :name, :class => 'control-label col-md-2'
+    = f.label :name, class: 'control-label col-md-2'
     .col-md-8
-      = f.text_field :name, :class => 'form-control'
+      = f.text_field :name, class: 'form-control'
       
   .form-group
     .form-actions.col-md-offset-2.col-md-8
-      = f.submit 'Save', :class => 'btn btn-primary'
+      = f.submit 'Save', class: 'btn btn-primary'

--- a/app/views/alternate_names/_form.html.haml
+++ b/app/views/alternate_names/_form.html.haml
@@ -1,4 +1,4 @@
-= form_for @alternate_name, html: {class: 'form-horizontal', role: "form"} do |f|
+= form_for @alternate_name, html: {class: 'form-horizontal', role: 'form'} do |f|
   - if @alternate_name.errors.any?
     #error_explanation
       %h2= "#{pluralize(@alternate_name.errors.size, "error")} prohibited this alternate_name from being saved:"

--- a/app/views/alternate_names/_form.html.haml
+++ b/app/views/alternate_names/_form.html.haml
@@ -9,7 +9,7 @@
   %p
     %span.help-block
       For detailed crop wrangling guidelines, please consult the
-      =link_to "crop wrangling guide", "http://wiki.growstuff.org/index.php/Crop_wrangling"
+      =link_to 'crop wrangling guide', 'http://wiki.growstuff.org/index.php/Crop_wrangling'
       on the Growstuff wiki.
 
   .form-group

--- a/app/views/alternate_names/edit.html.haml
+++ b/app/views/alternate_names/edit.html.haml
@@ -1,4 +1,4 @@
-- content_for :title, "Edit alternate name"
+- content_for :title, 'Edit alternate name'
 
 %p
   Added by

--- a/app/views/alternate_names/index.html.haml
+++ b/app/views/alternate_names/index.html.haml
@@ -1,4 +1,4 @@
-- content_for :title, "Listing alternate names"
+- content_for :title, 'Listing alternate names'
 
 - if can? :create, AlternateName
   %p= link_to 'New alternate name', new_alternate_name_path, class: 'btn btn-primary'

--- a/app/views/alternate_names/index.html.haml
+++ b/app/views/alternate_names/index.html.haml
@@ -1,7 +1,7 @@
 - content_for :title, "Listing alternate names"
 
 - if can? :create, AlternateName
-  %p= link_to 'New alternate name', new_alternate_name_path, :class => 'btn btn-primary'
+  %p= link_to 'New alternate name', new_alternate_name_path, class: 'btn btn-primary'
 
 %table
   %tr
@@ -17,7 +17,7 @@
       %td= link_to 'Show', alternate_name
       %td
         - if can? :edit, alternate_name
-          = link_to 'Edit', edit_alternate_name_path(alternate_name), :class => 'btn btn-default btn-xs'
+          = link_to 'Edit', edit_alternate_name_path(alternate_name), class: 'btn btn-default btn-xs'
       %td
         - if can? :destroy, alternate_name
-          = link_to 'Delete', alternate_name, method: :delete, data: { confirm: 'Are you sure?' }, :class => 'btn btn-default btn-xs'
+          = link_to 'Delete', alternate_name, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-default btn-xs'

--- a/app/views/alternate_names/new.html.haml
+++ b/app/views/alternate_names/new.html.haml
@@ -1,3 +1,3 @@
-- content_for :title, "New alternate name"
+- content_for :title, 'New alternate name'
 
 = render 'form'

--- a/app/views/alternate_names/show.html.haml
+++ b/app/views/alternate_names/show.html.haml
@@ -1,6 +1,6 @@
 %p#notice= notice
 
-= render :partial => 'crops/approval_status_message', :locals => { :crop => @alternate_name.crop }
+= render partial: 'crops/approval_status_message', locals: { crop: @alternate_name.crop }
 
 %p
   %b Alternate name:
@@ -10,6 +10,6 @@
   = link_to @alternate_name.crop, @alternate_name.crop
 
 - if can? :edit, @alternate_name
-  = link_to 'Edit', edit_alternate_name_path(@alternate_name), :class => 'btn btn-default btn-xs'
+  = link_to 'Edit', edit_alternate_name_path(@alternate_name), class: 'btn btn-default btn-xs'
   \|
 = link_to 'Back', alternate_names_path

--- a/app/views/comments/_form.html.haml
+++ b/app/views/comments/_form.html.haml
@@ -1,4 +1,4 @@
-= form_for(@comment, :html => {:class => "form-horizontal", :role => "form"}) do |f|
+= form_for(@comment, html: {class: "form-horizontal", role: "form"}) do |f|
   - if @comment.errors.any?
     #error_explanation
       %h2= "#{pluralize(@comment.errors.size, "error")} prohibited this comment from being saved:"
@@ -8,11 +8,11 @@
 
   .form-group
     = f.label :body, "Your comment:"
-    = f.text_area :body, :rows => 6, :class => 'form-control', :autofocus => 'autofocus'
+    = f.text_area :body, rows: 6, class: 'form-control', autofocus: 'autofocus'
   %span.help-block
-    = render :partial => "shared/markdown_help"
+    = render partial: "shared/markdown_help"
   .actions
-    = f.submit 'Post comment', :class => 'btn btn-primary'
+    = f.submit 'Post comment', class: 'btn btn-primary'
   - if defined?(@post)
     .field
-      = f.hidden_field :post_id, :value => @post.id
+      = f.hidden_field :post_id, value: @post.id

--- a/app/views/comments/_form.html.haml
+++ b/app/views/comments/_form.html.haml
@@ -7,10 +7,10 @@
           %li= msg
 
   .form-group
-    = f.label :body, "Your comment:"
+    = f.label :body, 'Your comment:'
     = f.text_area :body, rows: 6, class: 'form-control', autofocus: 'autofocus'
   %span.help-block
-    = render partial: "shared/markdown_help"
+    = render partial: 'shared/markdown_help'
   .actions
     = f.submit 'Post comment', class: 'btn btn-primary'
   - if defined?(@post)

--- a/app/views/comments/_form.html.haml
+++ b/app/views/comments/_form.html.haml
@@ -1,4 +1,4 @@
-= form_for(@comment, html: {class: "form-horizontal", role: "form"}) do |f|
+= form_for(@comment, html: {class: 'form-horizontal', role: 'form'}) do |f|
   - if @comment.errors.any?
     #error_explanation
       %h2= "#{pluralize(@comment.errors.size, "error")} prohibited this comment from being saved:"

--- a/app/views/comments/_single.html.haml
+++ b/app/views/comments/_single.html.haml
@@ -2,7 +2,7 @@
   .comment
     .row
       .col-md-1
-        = render :partial => "members/avatar", :locals => { :member => comment.author }
+        = render partial: "members/avatar", locals: { member: comment.author }
       .col-md-11
         .comment-meta
           = (comment.created_at == comment.updated_at) ? 'Posted by' : 'Edited by'
@@ -17,8 +17,8 @@
         - if can? :edit, comment or can? :destroy, comment
           .comment-actions
             - if can? :edit, comment
-              = link_to 'Edit', edit_comment_path(comment), :class => 'btn btn-default btn-xs'
+              = link_to 'Edit', edit_comment_path(comment), class: 'btn btn-default btn-xs'
             - if can? :destroy, comment
               = link_to 'Delete', comment, method: :delete, |
-                data: { confirm: 'Are you sure?' }, :class => 'btn btn-default btn-xs'
+                data: { confirm: 'Are you sure?' }, class: 'btn btn-default btn-xs'
 

--- a/app/views/comments/_single.html.haml
+++ b/app/views/comments/_single.html.haml
@@ -2,7 +2,7 @@
   .comment
     .row
       .col-md-1
-        = render partial: "members/avatar", locals: { member: comment.author }
+        = render partial: 'members/avatar', locals: { member: comment.author }
       .col-md-11
         .comment-meta
           = (comment.created_at == comment.updated_at) ? 'Posted by' : 'Edited by'

--- a/app/views/comments/edit.html.haml
+++ b/app/views/comments/edit.html.haml
@@ -1,4 +1,4 @@
-= content_for :title, "Editing comment"
+= content_for :title, 'Editing comment'
 
 %p
   Editing comment on

--- a/app/views/comments/index.html.haml
+++ b/app/views/comments/index.html.haml
@@ -8,7 +8,7 @@
   %h2
     Comment on
     = link_to comment.post.subject, comment.post
-  = render :partial => "single", :locals => { :comment => comment }
+  = render partial: "single", locals: { comment: comment }
 
 %div.pagination
   = page_entries_info @comments
@@ -17,4 +17,4 @@
 %p
   Subscribe to the #{ENV['GROWSTUFF_SITE_NAME']}
   = succeed "." do
-    = link_to "comments RSS feed", comments_path(:format => 'rss')
+    = link_to "comments RSS feed", comments_path(format: 'rss')

--- a/app/views/comments/index.html.haml
+++ b/app/views/comments/index.html.haml
@@ -1,4 +1,4 @@
-= content_for :title, "Recent comments"
+= content_for :title, 'Recent comments'
 
 %div.pagination
   = page_entries_info @comments
@@ -8,7 +8,7 @@
   %h2
     Comment on
     = link_to comment.post.subject, comment.post
-  = render partial: "single", locals: { comment: comment }
+  = render partial: 'single', locals: { comment: comment }
 
 %div.pagination
   = page_entries_info @comments
@@ -16,5 +16,5 @@
 
 %p
   Subscribe to the #{ENV['GROWSTUFF_SITE_NAME']}
-  = succeed "." do
-    = link_to "comments RSS feed", comments_path(format: 'rss')
+  = succeed '.' do
+    = link_to 'comments RSS feed', comments_path(format: 'rss')

--- a/app/views/comments/index.rss.haml
+++ b/app/views/comments/index.rss.haml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-%rss{:version => 2.0}
+%rss{version: 2.0}
   %channel
     %title Recent comments on all posts (#{ENV['GROWSTUFF_SITE_NAME']})
     %link= comments_url

--- a/app/views/comments/new.html.haml
+++ b/app/views/comments/new.html.haml
@@ -1,7 +1,7 @@
-= content_for :title, "New comment"
+= content_for :title, 'New comment'
 
-= render partial: "posts/single", locals: { post: @post || @comment.post, subject: true }
+= render partial: 'posts/single', locals: { post: @post || @comment.post, subject: true }
 
-= render partial: "posts/comments", locals: {post: @post || @comment.post}
+= render partial: 'posts/comments', locals: {post: @post || @comment.post}
 
 = render 'form'

--- a/app/views/comments/new.html.haml
+++ b/app/views/comments/new.html.haml
@@ -1,7 +1,7 @@
 = content_for :title, "New comment"
 
-= render :partial => "posts/single", :locals => { :post => @post || @comment.post, :subject => true }
+= render partial: "posts/single", locals: { post: @post || @comment.post, subject: true }
 
-= render :partial => "posts/comments", :locals => {:post => @post || @comment.post}
+= render partial: "posts/comments", locals: {post: @post || @comment.post}
 
 = render 'form'

--- a/app/views/comments/show.html.haml
+++ b/app/views/comments/show.html.haml
@@ -1,9 +1,9 @@
 = content_for :title, @comment.post.subject
 
-= render partial: "posts/single", locals: { post: @comment.post }
+= render partial: 'posts/single', locals: { post: @comment.post }
 
 %h2 Showing 1 comment
 
-= render partial: "single", locals: { comment: @comment }
+= render partial: 'single', locals: { comment: @comment }
 
-=link_to "View all comments", post_path(@comment.post)
+=link_to 'View all comments', post_path(@comment.post)

--- a/app/views/comments/show.html.haml
+++ b/app/views/comments/show.html.haml
@@ -1,9 +1,9 @@
 = content_for :title, @comment.post.subject
 
-= render :partial => "posts/single", :locals => { :post => @comment.post }
+= render partial: "posts/single", locals: { post: @comment.post }
 
 %h2 Showing 1 comment
 
-= render :partial => "single", :locals => { :comment => @comment }
+= render partial: "single", locals: { comment: @comment }
 
 =link_to "View all comments", post_path(@comment.post)

--- a/app/views/crops/_alternate_names.html.haml
+++ b/app/views/crops/_alternate_names.html.haml
@@ -8,9 +8,9 @@
         %li
           = an.name
           - if can? :edit, an
-            = link_to 'Edit', edit_alternate_name_path(an), { :class => 'btn btn-default btn-xs' }
+            = link_to 'Edit', edit_alternate_name_path(an), { class: 'btn btn-default btn-xs' }
           - if can? :destroy, an
-            = link_to 'Delete', an, method: :delete, data: { confirm: 'Are you sure?' }, :class => 'btn btn-default btn-xs'
+            = link_to 'Delete', an, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-default btn-xs'
   %p
   - if can? :edit, crop
-    = link_to 'Add', new_alternate_name_path( :crop_id => crop.id ), { :class => 'btn btn-default btn-xs' }
+    = link_to 'Add', new_alternate_name_path( crop_id: crop.id ), { class: 'btn btn-default btn-xs' }

--- a/app/views/crops/_find_seeds.html.haml
+++ b/app/views/crops/_find_seeds.html.haml
@@ -7,11 +7,11 @@
     - crop.seeds.tradable.each do |seed|
       %li
         = link_to "#{seed.owner} will trade #{seed.tradable_to}.", seed_path(seed)
-        = render :partial => 'members/location', :locals => { :member => seed.owner }
+        = render partial: 'members/location', locals: { member: seed.owner }
   %p
     = link_to "View all #{crop.name} seeds", seeds_by_crop_path(crop)
 - if crop.approved?
   - if current_member
-    %p= link_to "List #{crop.name} seeds to trade", new_seed_path(:crop_id => crop.id)
+    %p= link_to "List #{crop.name} seeds to trade", new_seed_path(crop_id: crop.id)
   - else
-    = render :partial => 'shared/signin_signup', :locals => { :to => 'list your seeds to trade' }
+    = render partial: 'shared/signin_signup', locals: { to: 'list your seeds to trade' }

--- a/app/views/crops/_form.html.haml
+++ b/app/views/crops/_form.html.haml
@@ -92,7 +92,7 @@
   - if can? :wrangle, @crop and @crop.requester
     %h2 Approve or reject pending crops
     .form-group
-      = f.label :approval_status, 'Approval status', :class=> 'control-label col-md-2'
+      = f.label :approval_status, 'Approval status', class: 'control-label col-md-2'
       .col-md-8
         = f.select(:approval_status, @crop.approval_statuses, {}, {class: 'form-control'})
 

--- a/app/views/crops/_form.html.haml
+++ b/app/views/crops/_form.html.haml
@@ -11,7 +11,7 @@
     %p
       %span.help-block
         For detailed crop wrangling guidelines, please consult the
-        =link_to "crop wrangling guide", "http://wiki.growstuff.org/index.php/Crop_wrangling"
+        =link_to 'crop wrangling guide', 'http://wiki.growstuff.org/index.php/Crop_wrangling'
         on the Growstuff wiki.
 
   -# Everyone (wranglers and requesters) sees the basic info section
@@ -46,8 +46,8 @@
   -# Everyone (wranglers and requesters) gets to add scientific names
   %h2
     Scientific names
-    = button_tag "+", id: "add-sci_name-row", type: "button"
-    = button_tag "-", id: "remove-sci_name-row", type: "button"
+    = button_tag '+', id: 'add-sci_name-row', type: 'button'
+    = button_tag '-', id: 'remove-sci_name-row', type: 'button'
     
   .form-group#scientific_names
     - @crop.scientific_names.each.with_index do |sci, index|
@@ -61,8 +61,8 @@
 
   %h2
     Alternate names
-    = button_tag "+", id: "add-alt_name-row", type: "button"
-    = button_tag "-", id: "remove-alt_name-row", type: "button"
+    = button_tag '+', id: 'add-alt_name-row', type: 'button'
+    = button_tag '-', id: 'remove-alt_name-row', type: 'button'
 
   .form-group#alternate_names 
     - @crop.alternate_names.each.with_index do |alt, index|

--- a/app/views/crops/_form.html.haml
+++ b/app/views/crops/_form.html.haml
@@ -1,4 +1,4 @@
-= form_for @crop, html: {class: 'form-horizontal', role: "form"} do |f|
+= form_for @crop, html: {class: 'form-horizontal', role: 'form'} do |f|
   - if @crop.errors.any?
     #error_explanation
       %h3= "#{pluralize(@crop.errors.size, "error")} prohibited this crop from being saved:"
@@ -30,7 +30,7 @@
   .form-group
     = f.label :en_wikipedia_url, 'Wikipedia URL', class: 'control-label col-md-2'
     .col-md-8
-      = f.text_field :en_wikipedia_url, class: 'form-control', id: "en_wikipedia_url"
+      = f.text_field :en_wikipedia_url, class: 'form-control', id: 'en_wikipedia_url'
       %span.help-block
         Link to the crop's page on the English language Wikipedia (required).
 

--- a/app/views/crops/_form.html.haml
+++ b/app/views/crops/_form.html.haml
@@ -1,4 +1,4 @@
-= form_for @crop, :html => {:class => 'form-horizontal', :role => "form"} do |f|
+= form_for @crop, html: {class: 'form-horizontal', role: "form"} do |f|
   - if @crop.errors.any?
     #error_explanation
       %h3= "#{pluralize(@crop.errors.size, "error")} prohibited this crop from being saved:"
@@ -18,9 +18,9 @@
   %h2 Basic information
 
   .form-group#new_crop
-    = f.label :name, :class => 'control-label col-md-2'
+    = f.label :name, class: 'control-label col-md-2'
     .col-md-8
-      = f.text_field :name, :class => 'form-control'
+      = f.text_field :name, class: 'form-control'
       %span.help-block
         The common name for the crop, in English (required).
         - if can? :wrangle, @crop
@@ -28,49 +28,49 @@
           proper nouns only.
 
   .form-group
-    = f.label :en_wikipedia_url, 'Wikipedia URL', :class => 'control-label col-md-2'
+    = f.label :en_wikipedia_url, 'Wikipedia URL', class: 'control-label col-md-2'
     .col-md-8
-      = f.text_field :en_wikipedia_url, :class => 'form-control', :id => "en_wikipedia_url"
+      = f.text_field :en_wikipedia_url, class: 'form-control', id: "en_wikipedia_url"
       %span.help-block
         Link to the crop's page on the English language Wikipedia (required).
 
   -# Only crop wranglers see the crop hierarchy (for now)
   - if can? :wrangle, @crop
     .form-group
-      = f.label :parent_id, 'Parent crop', :class => 'control-label col-md-2'
+      = f.label :parent_id, 'Parent crop', class: 'control-label col-md-2'
       .col-md-8
-        = collection_select(:crop, :parent_id, Crop.all, :id, :name, {:include_blank => true}, :class => 'form-control')
+        = collection_select(:crop, :parent_id, Crop.all, :id, :name, {include_blank: true}, class: 'form-control')
         %span.help-block Optional. For setting up crop hierarchies for varieties etc.
 
 
   -# Everyone (wranglers and requesters) gets to add scientific names
   %h2
     Scientific names
-    = button_tag "+", :id => "add-sci_name-row", :type => "button"
-    = button_tag "-", :id => "remove-sci_name-row", :type => "button"
+    = button_tag "+", id: "add-sci_name-row", type: "button"
+    = button_tag "-", id: "remove-sci_name-row", type: "button"
     
   .form-group#scientific_names
     - @crop.scientific_names.each.with_index do |sci, index|
-      .template.col-md-12{ :id => "sci_template[#{index+1}]" }
+      .template.col-md-12{ id: "sci_template[#{index+1}]" }
         .col-md-2
-          = label_tag :scientific_names, "Scientific name #{index+1}:", :class => 'control-label'
+          = label_tag :scientific_names, "Scientific name #{index+1}:", class: 'control-label'
         .col-md-8
-          = text_field_tag "sci_name[#{index+1}]", sci.scientific_name, :id => "sci_name[#{index+1}]", :class => 'form-control'
+          = text_field_tag "sci_name[#{index+1}]", sci.scientific_name, id: "sci_name[#{index+1}]", class: 'form-control'
           %span.help-block Scientific name of crop.
         .col-md-2
 
   %h2
     Alternate names
-    = button_tag "+", :id => "add-alt_name-row", :type => "button"
-    = button_tag "-", :id => "remove-alt_name-row", :type => "button"
+    = button_tag "+", id: "add-alt_name-row", type: "button"
+    = button_tag "-", id: "remove-alt_name-row", type: "button"
 
   .form-group#alternate_names 
     - @crop.alternate_names.each.with_index do |alt, index|
-      .template.col-md-12{ :id => "alt_template[#{index+1}]" }
+      .template.col-md-12{ id: "alt_template[#{index+1}]" }
         .col-md-2
-          = label_tag :alternate_names, "Alternate name #{index+1}:", :class => 'control-label'
+          = label_tag :alternate_names, "Alternate name #{index+1}:", class: 'control-label'
         .col-md-8
-          = text_field_tag "alt_name[#{index+1}]", alt.name, :id => "alt_name[#{index+1}]", :class => 'form-control'
+          = text_field_tag "alt_name[#{index+1}]", alt.name, id: "alt_name[#{index+1}]", class: 'form-control'
           %span.help-block Alternate name of crop.
         .col-md-2
 
@@ -80,9 +80,9 @@
   - if (can? :wrangle, @crop and @crop.requester) or (cannot? :wrangle, @crop and @crop.new_record?)
     %h2 Crop request notes
     .form-group
-      = f.label :request_notes, 'Comments', :class => 'control-label col-md-2'
+      = f.label :request_notes, 'Comments', class: 'control-label col-md-2'
       .col-md-8
-        = f.text_area :request_notes, :rows => 3, :class => 'form-control', :id => 'request_notes'
+        = f.text_area :request_notes, rows: 3, class: 'form-control', id: 'request_notes'
 
   -# A final explanation of what's going to happen next, for crop requesters
   - unless can? :wrangle, @crop
@@ -94,21 +94,21 @@
     .form-group
       = f.label :approval_status, 'Approval status', :class=> 'control-label col-md-2'
       .col-md-8
-        = f.select(:approval_status, @crop.approval_statuses, {}, {:class => 'form-control'})
+        = f.select(:approval_status, @crop.approval_statuses, {}, {class: 'form-control'})
 
     .form-group
-      = f.label :reason_for_rejection, 'Reason for rejection', :class => 'control-label col-md-2'
+      = f.label :reason_for_rejection, 'Reason for rejection', class: 'control-label col-md-2'
       .col-md-8
-        = f.select(:reason_for_rejection, @crop.reasons_for_rejection, {:include_blank => true}, {:class => 'form-control'})
+        = f.select(:reason_for_rejection, @crop.reasons_for_rejection, {include_blank: true}, {class: 'form-control'})
 
     .form-group
-      = f.label :rejection_notes, 'Rejection notes', :class => 'control-label col-md-2'
+      = f.label :rejection_notes, 'Rejection notes', class: 'control-label col-md-2'
       .col-md-8
-        = f.text_area :rejection_notes, :rows => 3, :class => 'form-control'
+        = f.text_area :rejection_notes, rows: 3, class: 'form-control'
         %span.help-block
           Please provide additional notes why this crop request was rejected if the above reasons do not apply.
 
 
   .form-group
     .form-actions.col-md-offset-2.col-md-8
-      = f.submit 'Save', :class => 'btn btn-primary'
+      = f.submit 'Save', class: 'btn btn-primary'

--- a/app/views/crops/_grown_for.html.haml
+++ b/app/views/crops/_grown_for.html.haml
@@ -4,4 +4,4 @@
     not known.
   - else
     - popular_plant_parts = crop.popular_plant_parts.sort_by {|s, freq| freq }.reverse
-    != popular_plant_parts.map {|p, freq| link_to(p, p) + " (#{freq})" }.join(", ")
+    != popular_plant_parts.map {|p, freq| link_to(p, p) + " (#{freq})" }.join(', ')

--- a/app/views/crops/_harvests.html.haml
+++ b/app/views/crops/_harvests.html.haml
@@ -7,7 +7,7 @@
     - crop.harvests.take(3).each do |harvest|
       %li
         = link_to "#{harvest.owner} harvested #{display_quantity(harvest)}.", harvest_path(harvest)
-        = render :partial => 'members/location', :locals => { :member => harvest.owner }
+        = render partial: 'members/location', locals: { member: harvest.owner }
         %small
           = distance_of_time_in_words(harvest.created_at, Time.zone.now)
           ago.
@@ -15,7 +15,7 @@
     = link_to "View all #{crop.name} harvests", harvests_by_crop_path(crop)
 - if crop.approved?
   - if current_member
-    %p= link_to "Harvest #{crop.name}", new_harvest_path(:crop_id => crop.id)
+    %p= link_to "Harvest #{crop.name}", new_harvest_path(crop_id: crop.id)
   - else
-    = render :partial => 'shared/signin_signup', :locals => { :to => "track your #{crop.name} harvests" }
+    = render partial: 'shared/signin_signup', locals: { to: "track your #{crop.name} harvests" }
 

--- a/app/views/crops/_hierarchy.html.haml
+++ b/app/views/crops/_hierarchy.html.haml
@@ -3,9 +3,9 @@
   - unless defined? max
     - max = 0 # list all without "show all" toggle button
   - display_crops.each do |c|
-    %li.crop-hierarchy{:class => max != 0 && @count >= max ? ['hide', 'toggle'] : []}
+    %li.crop-hierarchy{class: max != 0 && @count >= max ? ['hide', 'toggle'] : []}
       = link_to c, c
       - @count += 1
       - if c.varieties.present?
         - c.varieties.each do |v|
-          = render :partial => 'hierarchy', :locals => { :display_crops => [ v ], :max => max }
+          = render partial: 'hierarchy', locals: { display_crops: [ v ], max: max }

--- a/app/views/crops/_image_with_popover.html.haml
+++ b/app/views/crops/_image_with_popover.html.haml
@@ -2,12 +2,12 @@
   = link_to |
     image_tag( |
       crop.default_photo ?  crop.default_photo.thumbnail_url : 'placeholder_150.png', |
-      :alt => crop.name, |
-      :class => 'image-responsive crop-image' |
+      alt: crop.name, |
+      class: 'image-responsive crop-image' |
     ), |
     crop, |
-    :rel => "popover", |
+    rel: "popover", |
     'data-trigger' => 'hover', |
     'data-title' => crop.name, |
-    'data-content' => "#{ render :partial => 'crops/popover', :locals => { :crop => crop } }", |
+    'data-content' => "#{ render partial: 'crops/popover', locals: { crop: crop } }", |
     'data-html' => true |

--- a/app/views/crops/_image_with_popover.html.haml
+++ b/app/views/crops/_image_with_popover.html.haml
@@ -6,7 +6,7 @@
       class: 'image-responsive crop-image' |
     ), |
     crop, |
-    rel: "popover", |
+    rel: 'popover', |
     'data-trigger' => 'hover', |
     'data-title' => crop.name, |
     'data-content' => "#{ render partial: 'crops/popover', locals: { crop: crop } }", |

--- a/app/views/crops/_index_card.html.haml
+++ b/app/views/crops/_index_card.html.haml
@@ -1,9 +1,9 @@
 .well
   .row
     .col-md-4
-      = link_to image_tag((crop.default_photo ? crop.default_photo.thumbnail_url : 'placeholder_150.png'), :alt => '', :class => 'img crop-image'), crop
+      = link_to image_tag((crop.default_photo ? crop.default_photo.thumbnail_url : 'placeholder_150.png'), alt: '', class: 'img crop-image'), crop
     .col-md-8
-      %h3{:style => 'padding-top: 0px; margin-top: 0px'}
+      %h3{style: 'padding-top: 0px; margin-top: 0px'}
         = link_to crop, crop
 
       %p
@@ -16,6 +16,6 @@
         by #{ENV['GROWSTUFF_SITE_NAME']} members
 
       - if can? :create, Planting
-        = link_to 'Plant this', new_planting_path(:params => { :crop_id => crop.id }), :class => 'btn btn-primary'
+        = link_to 'Plant this', new_planting_path(params: { crop_id: crop.id }), class: 'btn btn-primary'
       - if can? :create, Seed
-        = link_to 'Add seeds to stash', new_seed_path(:params => { :crop_id => crop.id }), :class => 'btn btn-primary'
+        = link_to 'Add seeds to stash', new_seed_path(params: { crop_id: crop.id }), class: 'btn btn-primary'

--- a/app/views/crops/_index_card.html.haml
+++ b/app/views/crops/_index_card.html.haml
@@ -12,7 +12,7 @@
       %p
         %b
           Planted
-          = pluralize(crop.plantings.size, "time")
+          = pluralize(crop.plantings.size, 'time')
         by #{ENV['GROWSTUFF_SITE_NAME']} members
 
       - if can? :create, Planting

--- a/app/views/crops/_photos.html.haml
+++ b/app/views/crops/_photos.html.haml
@@ -2,4 +2,4 @@
   - if !crop.photos.empty?
     - crop.photos.first(3).each do |p|
       .col-md-4
-        = render :partial => "photos/thumbnail", :locals => { :photo => p }
+        = render partial: "photos/thumbnail", locals: { photo: p }

--- a/app/views/crops/_photos.html.haml
+++ b/app/views/crops/_photos.html.haml
@@ -2,4 +2,4 @@
   - if !crop.photos.empty?
     - crop.photos.first(3).each do |p|
       .col-md-4
-        = render partial: "photos/thumbnail", locals: { photo: p }
+        = render partial: 'photos/thumbnail', locals: { photo: p }

--- a/app/views/crops/_planting_advice.html.haml
+++ b/app/views/crops/_planting_advice.html.haml
@@ -4,7 +4,7 @@
     not known.
   - else
     - planted_from = crop.planted_from.sort_by {|s, freq| freq }.reverse
-    = planted_from.map {|s, freq| "#{s} (#{freq})" }.join(", ")
+    = planted_from.map {|s, freq| "#{s} (#{freq})" }.join(', ')
 
 %p
   %strong Plant in:
@@ -12,4 +12,4 @@
     not known.
   - else
     - sunniness = crop.sunniness.sort_by {|s, freq| freq }.reverse
-    = sunniness.map {|s, freq| "#{s} (#{freq})" }.join(", ")
+    = sunniness.map {|s, freq| "#{s} (#{freq})" }.join(', ')

--- a/app/views/crops/_plantings.html.haml
+++ b/app/views/crops/_plantings.html.haml
@@ -7,7 +7,7 @@
     - crop.plantings.take(3).each do |planting|
       %li
         = link_to display_planting(planting), planting_path(planting)
-        = render :partial => 'members/location', :locals => { :member => planting.owner }
+        = render partial: 'members/location', locals: { member: planting.owner }
         %small
           = distance_of_time_in_words(planting.created_at, Time.zone.now)
           ago.
@@ -15,7 +15,7 @@
     = link_to "View all #{crop.name} plantings", plantings_by_crop_path(crop)
 - if crop.approved?
   - if current_member
-    %p= link_to "Plant #{crop.name}", new_planting_path(:crop_id => crop.id)
+    %p= link_to "Plant #{crop.name}", new_planting_path(crop_id: crop.id)
   - else
-    = render :partial => 'shared/signin_signup', :locals => { :to => "track your #{crop.name} plantings" }
+    = render partial: 'shared/signin_signup', locals: { to: "track your #{crop.name} plantings" }
 

--- a/app/views/crops/_popover.html.haml
+++ b/app/views/crops/_popover.html.haml
@@ -5,4 +5,4 @@
         = crop.scientific_names.first.scientific_name
     %br/
     Planted
-    = pluralize(crop.plantings.size, "time")
+    = pluralize(crop.plantings.size, 'time')

--- a/app/views/crops/_scientific_names.html.haml
+++ b/app/views/crops/_scientific_names.html.haml
@@ -8,9 +8,9 @@
         %li
           = sn.scientific_name
           - if can? :edit, sn
-            = link_to 'Edit', edit_scientific_name_path(sn), { :class => 'btn btn-default btn-xs' }
+            = link_to 'Edit', edit_scientific_name_path(sn), { class: 'btn btn-default btn-xs' }
           - if can? :destroy, sn
-            = link_to 'Delete', sn, method: :delete, data: { confirm: 'Are you sure?' }, :class => 'btn btn-default btn-xs'
+            = link_to 'Delete', sn, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-default btn-xs'
   %p
   - if can? :edit, crop
-    = link_to 'Add', new_scientific_name_path( :crop_id => crop.id ), { :class => 'btn btn-default btn-xs' }
+    = link_to 'Add', new_scientific_name_path( crop_id: crop.id ), { class: 'btn btn-default btn-xs' }

--- a/app/views/crops/_thumbnail.html.haml
+++ b/app/views/crops/_thumbnail.html.haml
@@ -2,7 +2,7 @@
   .crop-thumbnail
     - if crop
       - cache cache_key_for(Crop, crop.id) do
-        = link_to image_tag((crop.default_photo ?  crop.default_photo.thumbnail_url : 'placeholder_150.png'), :alt => crop.name, :class => 'img'), crop
+        = link_to image_tag((crop.default_photo ?  crop.default_photo.thumbnail_url : 'placeholder_150.png'), alt: crop.name, class: 'img'), crop
         .cropinfo
           .cropname
             = link_to crop.name, crop

--- a/app/views/crops/_thumbnail.html.haml
+++ b/app/views/crops/_thumbnail.html.haml
@@ -11,4 +11,4 @@
               = crop.scientific_names.first.scientific_name
           .plantingcount
             Planted
-            = pluralize(crop.plantings.size, "time")
+            = pluralize(crop.plantings.size, 'time')

--- a/app/views/crops/_varieties.html.haml
+++ b/app/views/crops/_varieties.html.haml
@@ -11,10 +11,10 @@
       Varieties of #{crop.name}:
 
     - max = 5
-    = render :partial => 'hierarchy', :locals => { :display_crops => [ crop ], :max => max }
+    = render partial: 'hierarchy', locals: { display_crops: [ crop ], max: max }
     - if max != 0 && @count > max
-      = button_tag "Show all #{@count-1} varieties", :class => 'btn btn-link toggle crop-hierarchy'
-      = button_tag "Show less varieties", :class => 'btn btn-link toggle crop-hierarchy hide'
+      = button_tag "Show all #{@count-1} varieties", class: 'btn btn-link toggle crop-hierarchy'
+      = button_tag "Show less varieties", class: 'btn btn-link toggle crop-hierarchy hide'
 
   - if ! crop.parent and crop.varieties.empty?
     %p None known.

--- a/app/views/crops/_varieties.html.haml
+++ b/app/views/crops/_varieties.html.haml
@@ -3,7 +3,7 @@
     %p
       = crop.name
       is a variety of
-      = succeed "." do
+      = succeed '.' do
         = link_to crop.parent, crop.parent
 
   - unless crop.varieties.empty?
@@ -14,7 +14,7 @@
     = render partial: 'hierarchy', locals: { display_crops: [ crop ], max: max }
     - if max != 0 && @count > max
       = button_tag "Show all #{@count-1} varieties", class: 'btn btn-link toggle crop-hierarchy'
-      = button_tag "Show less varieties", class: 'btn btn-link toggle crop-hierarchy hide'
+      = button_tag 'Show less varieties', class: 'btn btn-link toggle crop-hierarchy hide'
 
   - if ! crop.parent and crop.varieties.empty?
     %p None known.

--- a/app/views/crops/_wrangle.html.haml
+++ b/app/views/crops/_wrangle.html.haml
@@ -6,6 +6,6 @@
       %strong CROP WRANGLER
   %p
     - if can? :edit, crop
-      = link_to 'Edit crop', edit_crop_path(crop), { :class => 'btn btn-default btn-xs' }
+      = link_to 'Edit crop', edit_crop_path(crop), { class: 'btn btn-default btn-xs' }
     - if can? :destroy, crop
-      = link_to 'Delete crop', crop, method: :delete, data: { confirm: 'Are you sure?' }, :class => 'btn btn-default btn-xs'
+      = link_to 'Delete crop', crop, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-default btn-xs'

--- a/app/views/crops/_wrangle.html.haml
+++ b/app/views/crops/_wrangle.html.haml
@@ -2,7 +2,7 @@
   %h4 Crop wrangling
   %p
     You are a
-    = succeed "." do
+    = succeed '.' do
       %strong CROP WRANGLER
   %p
     - if can? :edit, crop

--- a/app/views/crops/edit.html.haml
+++ b/app/views/crops/edit.html.haml
@@ -1,16 +1,16 @@
 - content_for :title, "Edit crop: #{@crop.name}"
 
-- if @crop.approval_status == "approved"
+- if @crop.approval_status == 'approved'
   - if @crop.requester
     %p Requested by #{link_to @crop.requester, @crop.requester} #{distance_of_time_in_words(@crop.created_at, Time.zone.now)} ago.
     %p Approved by #{link_to @crop.creator, @crop.creator}.
   - else
     %p Added by #{link_to @crop.creator, @crop.creator} #{distance_of_time_in_words(@crop.created_at, Time.zone.now)} ago.
-- elsif @crop.approval_status == "pending"
+- elsif @crop.approval_status == 'pending'
   .alert.alert-danger
     %p Requested by #{link_to @crop.requester, @crop.requester} #{distance_of_time_in_words(@crop.created_at, Time.zone.now)} ago.
     %p Status: #{@crop.approval_status}.
-- elsif @crop.approval_status == "rejected"
+- elsif @crop.approval_status == 'rejected'
   .alert.alert-danger
     %p Requested by #{link_to @crop.requester, @crop.requester} #{distance_of_time_in_words(@crop.created_at, Time.zone.now)} ago.
     %p Status: #{@crop.approval_status} by #{link_to @crop.creator, @crop.creator}.

--- a/app/views/crops/hierarchy.html.haml
+++ b/app/views/crops/hierarchy.html.haml
@@ -6,4 +6,4 @@
     = link_to "crops database", crops_path
 
 - cache cache_key_for(Crop) do
-  = render :partial => "hierarchy", :locals => { :display_crops => @crops }
+  = render partial: "hierarchy", locals: { display_crops: @crops }

--- a/app/views/crops/hierarchy.html.haml
+++ b/app/views/crops/hierarchy.html.haml
@@ -1,9 +1,9 @@
-- content_for :title, "Crop Hierarchy"
+- content_for :title, 'Crop Hierarchy'
 
 %p
   This page shows the hierarchical tree of all crops in our
-  = succeed "." do
-    = link_to "crops database", crops_path
+  = succeed '.' do
+    = link_to 'crops database', crops_path
 
 - cache cache_key_for(Crop) do
-  = render partial: "hierarchy", locals: { display_crops: @crops }
+  = render partial: 'hierarchy', locals: { display_crops: @crops }

--- a/app/views/crops/index.html.haml
+++ b/app/views/crops/index.html.haml
@@ -11,7 +11,7 @@
 = form_tag(crops_path, method: :get, class: 'form-inline', role: 'form') do
   .form-group
     = label_tag :sort, 'Sort by:', class: 'sr-only'
-    = select_tag "sort", options_for_select({"Sort by popularity" => 'popular', "Sort alphabetically" => 'alpha'}, @sort || 'popular'), class: 'form-control'
+    = select_tag 'sort', options_for_select({'Sort by popularity' => 'popular', 'Sort alphabetically' => 'alpha'}, @sort || 'popular'), class: 'form-control'
   = submit_tag 'Show', class: 'btn btn-primary'
 
 %div.pagination

--- a/app/views/crops/index.html.haml
+++ b/app/views/crops/index.html.haml
@@ -2,17 +2,17 @@
 - content_for :subtitle, t('.subtitle', crops_size: @crops.size)
 
 - if can? :wrangle, Crop
-  = link_to 'Wrangle Crops', wrangle_crops_path, :class => 'btn btn-primary'
+  = link_to 'Wrangle Crops', wrangle_crops_path, class: 'btn btn-primary'
 %p
   #{ENV['GROWSTUFF_SITE_NAME']} tracks who's growing what, where.
   View any crop page to see which of our members have planted it and find
   information on how to grow it yourself.
 
-= form_tag(crops_path, :method => :get, :class => 'form-inline', :role => 'form') do
+= form_tag(crops_path, method: :get, class: 'form-inline', role: 'form') do
   .form-group
-    = label_tag :sort, "Sort by:", :class => 'sr-only'
-    = select_tag "sort", options_for_select({"Sort by popularity" => 'popular', "Sort alphabetically" => 'alpha'}, @sort || 'popular'), :class => 'form-control'
-  = submit_tag "Show", :class => 'btn btn-primary'
+    = label_tag :sort, "Sort by:", class: 'sr-only'
+    = select_tag "sort", options_for_select({"Sort by popularity" => 'popular', "Sort alphabetically" => 'alpha'}, @sort || 'popular'), class: 'form-control'
+  = submit_tag "Show", class: 'btn btn-primary'
 
 %div.pagination
   = will_paginate @paginated_crops
@@ -20,11 +20,11 @@
 .row
   - @paginated_crops.each do |crop|
     .col-md-2.six-across
-      = render :partial => "thumbnail", :locals => { :crop => crop }
+      = render partial: "thumbnail", locals: { crop: crop }
 
 - if can? :create, Crop
   %div
-    = link_to 'New Crop', new_crop_path, {:class => 'btn btn-primary'}
+    = link_to 'New Crop', new_crop_path, {class: 'btn btn-primary'}
 
 %div.pagination
   = will_paginate @paginated_crops
@@ -32,6 +32,6 @@
 
 %ul.list-inline
   %li The data on this page is available in the following formats:
-  %li= link_to "CSV", crops_path(:format => 'csv')
-  %li= link_to "JSON", crops_path(:format => 'json')
-  %li= link_to "RSS", crops_path(:format => 'rss')
+  %li= link_to "CSV", crops_path(format: 'csv')
+  %li= link_to "JSON", crops_path(format: 'json')
+  %li= link_to "RSS", crops_path(format: 'rss')

--- a/app/views/crops/index.html.haml
+++ b/app/views/crops/index.html.haml
@@ -10,9 +10,9 @@
 
 = form_tag(crops_path, method: :get, class: 'form-inline', role: 'form') do
   .form-group
-    = label_tag :sort, "Sort by:", class: 'sr-only'
+    = label_tag :sort, 'Sort by:', class: 'sr-only'
     = select_tag "sort", options_for_select({"Sort by popularity" => 'popular', "Sort alphabetically" => 'alpha'}, @sort || 'popular'), class: 'form-control'
-  = submit_tag "Show", class: 'btn btn-primary'
+  = submit_tag 'Show', class: 'btn btn-primary'
 
 %div.pagination
   = will_paginate @paginated_crops
@@ -20,7 +20,7 @@
 .row
   - @paginated_crops.each do |crop|
     .col-md-2.six-across
-      = render partial: "thumbnail", locals: { crop: crop }
+      = render partial: 'thumbnail', locals: { crop: crop }
 
 - if can? :create, Crop
   %div
@@ -32,6 +32,6 @@
 
 %ul.list-inline
   %li The data on this page is available in the following formats:
-  %li= link_to "CSV", crops_path(format: 'csv')
-  %li= link_to "JSON", crops_path(format: 'json')
-  %li= link_to "RSS", crops_path(format: 'rss')
+  %li= link_to 'CSV', crops_path(format: 'csv')
+  %li= link_to 'JSON', crops_path(format: 'json')
+  %li= link_to 'RSS', crops_path(format: 'rss')

--- a/app/views/crops/index.rss.haml
+++ b/app/views/crops/index.rss.haml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-%rss{:version => 2.0}
+%rss{version: 2.0}
   %channel
     %title Recently added crops (#{ENV['GROWSTUFF_SITE_NAME']})
     %link= crops_url

--- a/app/views/crops/new.html.haml
+++ b/app/views/crops/new.html.haml
@@ -1,4 +1,4 @@
-- content_for :title, (can?(:wrangle, @crop) ? "New crop" : "Suggest a crop") 
+- content_for :title, (can?(:wrangle, @crop) ? 'New crop' : 'Suggest a crop')
 
 - unless can? :wrangler, @crop
   

--- a/app/views/crops/search.html.haml
+++ b/app/views/crops/search.html.haml
@@ -6,11 +6,11 @@
   - content_for :title, "Crop search"
 
 %div
-  = form_tag crops_search_path, :method => :get, :id => 'crop-search', :class => 'form-inline' do
+  = form_tag crops_search_path, method: :get, id: 'crop-search', class: 'form-inline' do
     .form-group
-      = label_tag :term, "Search crops:", :class => 'sr-only'
-      = text_field_tag 'term', nil, :class => 'search-query input-medium form-control', :placeholder => 'Search crops', :value => @term
-    = submit_tag "Search", :class => 'btn btn-primary'
+      = label_tag :term, "Search crops:", class: 'sr-only'
+      = text_field_tag 'term', nil, class: 'search-query input-medium form-control', placeholder: 'Search crops', value: @term
+    = submit_tag "Search", class: 'btn btn-primary'
 
 - if @matches.empty?
   %h2 No results found
@@ -29,7 +29,7 @@
     .row
       - @paginated_matches.each do |c|
         .col-md-2.six-across
-          = render :partial => "thumbnail", :locals => { :crop => c }
+          = render partial: "thumbnail", locals: { crop: c }
 
   %div.pagination
     = will_paginate @paginated_matches

--- a/app/views/crops/search.html.haml
+++ b/app/views/crops/search.html.haml
@@ -3,14 +3,14 @@
   - if @matches
     - content_for :subtitle, "#{@matches.size} total"
 - else
-  - content_for :title, "Crop search"
+  - content_for :title, 'Crop search'
 
 %div
   = form_tag crops_search_path, method: :get, id: 'crop-search', class: 'form-inline' do
     .form-group
-      = label_tag :term, "Search crops:", class: 'sr-only'
+      = label_tag :term, 'Search crops:', class: 'sr-only'
       = text_field_tag 'term', nil, class: 'search-query input-medium form-control', placeholder: 'Search crops', value: @term
-    = submit_tag "Search", class: 'btn btn-primary'
+    = submit_tag 'Search', class: 'btn btn-primary'
 
 - if @matches.empty?
   %h2 No results found
@@ -18,7 +18,7 @@
     Sorry, we couldn't find any crops that matched your search for "#{@term}".
   %p
     Try
-    = link_to "browsing our crop database", crops_path
+    = link_to 'browsing our crop database', crops_path
     instead.
 
 - else
@@ -29,7 +29,7 @@
     .row
       - @paginated_matches.each do |c|
         .col-md-2.six-across
-          = render partial: "thumbnail", locals: { crop: c }
+          = render partial: 'thumbnail', locals: { crop: c }
 
   %div.pagination
     = will_paginate @paginated_matches

--- a/app/views/crops/show.html.haml
+++ b/app/views/crops/show.html.haml
@@ -51,7 +51,7 @@
         - if can? :create, Post
           = link_to 'Post something', new_post_path, class: 'btn btn-default'
         - else
-          = render partial: "shared/signin_signup", locals: { to: "post your tips and experiences growing #{ @crop.name.pluralize }" }
+          = render partial: 'shared/signin_signup', locals: { to: "post your tips and experiences growing #{ @crop.name.pluralize }" }
     - else
       %div.pagination
         = page_entries_info @posts

--- a/app/views/crops/show.html.haml
+++ b/app/views/crops/show.html.haml
@@ -6,16 +6,16 @@
 - if @crop.approved?
   - content_for :buttonbar do
     - if can? :create, Planting
-      = link_to "Plant this", new_planting_path(crop_id: @crop.id), class: 'btn btn-default'
+      = link_to 'Plant this', new_planting_path(crop_id: @crop.id), class: 'btn btn-default'
 
     - if can? :create, Harvest
-      = link_to "Harvest this", new_harvest_path(crop_id: @crop.id), class: 'btn btn-default'
+      = link_to 'Harvest this', new_harvest_path(crop_id: @crop.id), class: 'btn btn-default'
 
     - if can? :create, Seed
       = link_to 'Add seeds to stash', new_seed_path(params: { crop_id: @crop.id }), class: 'btn btn-default'
   - if member_signed_in?
     = display_seed_availability(@current_member, @crop)
-    = link_to "View your seeds", seeds_by_owner_path(owner: current_member.slug)
+    = link_to 'View your seeds', seeds_by_owner_path(owner: current_member.slug)
 
 .row
   .col-md-9
@@ -28,7 +28,7 @@
       - if @crop.plantings.size > 0
         = @crop.name.titleize
         has been planted
-        = pluralize(@crop.plantings.size, "time")
+        = pluralize(@crop.plantings.size, 'time')
         by #{ENV['GROWSTUFF_SITE_NAME']} members.
       - else
         Nobody is growing this yet. You could be the first!
@@ -36,7 +36,7 @@
     %p
       Only plantings by members who have set their locations are shown on this map.
       - if current_member && current_member.location.blank?
-        = link_to "Set your location.", edit_member_registration_path
+        = link_to 'Set your location.', edit_member_registration_path
 
 
     %div#cropmap
@@ -49,19 +49,19 @@
         Nobody has posted about #{ @crop.name.pluralize } yet.
       %p
         - if can? :create, Post
-          = link_to "Post something", new_post_path, class: 'btn btn-default'
+          = link_to 'Post something', new_post_path, class: 'btn btn-default'
         - else
           = render partial: "shared/signin_signup", locals: { to: "post your tips and experiences growing #{ @crop.name.pluralize }" }
     - else
       %div.pagination
         = page_entries_info @posts
-        = will_paginate @posts, params: {anchor: "posts"}
+        = will_paginate @posts, params: {anchor: 'posts'}
       - @posts.each do |post|
-        = render partial: "posts/single", locals: { post: post, subject: true }
+        = render partial: 'posts/single', locals: { post: post, subject: true }
 
       %div.pagination
         = page_entries_info @posts
-        = will_paginate @posts, params: {anchor: "posts"}
+        = will_paginate @posts, params: {anchor: 'posts'}
 
   .col-md-3
 

--- a/app/views/crops/show.html.haml
+++ b/app/views/crops/show.html.haml
@@ -1,28 +1,28 @@
 - content_for :title, @crop.name
 - content_for :subtitle, @crop.default_scientific_name
 
-= render :partial => 'approval_status_message', :locals => { :crop => @crop }
+= render partial: 'approval_status_message', locals: { crop: @crop }
 
 - if @crop.approved?
   - content_for :buttonbar do
     - if can? :create, Planting
-      = link_to "Plant this", new_planting_path(:crop_id => @crop.id), :class => 'btn btn-default'
+      = link_to "Plant this", new_planting_path(crop_id: @crop.id), class: 'btn btn-default'
 
     - if can? :create, Harvest
-      = link_to "Harvest this", new_harvest_path(:crop_id => @crop.id), :class => 'btn btn-default'
+      = link_to "Harvest this", new_harvest_path(crop_id: @crop.id), class: 'btn btn-default'
 
     - if can? :create, Seed
-      = link_to 'Add seeds to stash', new_seed_path(:params => { :crop_id => @crop.id }), :class => 'btn btn-default'
+      = link_to 'Add seeds to stash', new_seed_path(params: { crop_id: @crop.id }), class: 'btn btn-default'
   - if member_signed_in?
     = display_seed_availability(@current_member, @crop)
-    = link_to "View your seeds", seeds_by_owner_path(:owner => current_member.slug)
+    = link_to "View your seeds", seeds_by_owner_path(owner: current_member.slug)
 
 .row
   .col-md-9
     - unless current_member
       Learn how to grow #{ @crop.name.pluralize } from growers around the world. #{ ENV['GROWSTUFF_SITE_NAME'] } has tips and advice from real-life growers, including when to plant #{ @crop.name.pluralize }, how to harvest #{ @crop.name.pluralize }, and more.
 
-    = render :partial => 'photos', :locals => { :crop => @crop }
+    = render partial: 'photos', locals: { crop: @crop }
 
     %h2
       - if @crop.plantings.size > 0
@@ -41,7 +41,7 @@
 
     %div#cropmap
 
-    %a{:name => 'posts'}
+    %a{name: 'posts'}
     %h2 What people are saying about #{ @crop.name.pluralize }
 
     - if @posts.empty?
@@ -49,38 +49,38 @@
         Nobody has posted about #{ @crop.name.pluralize } yet.
       %p
         - if can? :create, Post
-          = link_to "Post something", new_post_path, :class => 'btn btn-default'
+          = link_to "Post something", new_post_path, class: 'btn btn-default'
         - else
-          = render :partial => "shared/signin_signup", :locals => { :to => "post your tips and experiences growing #{ @crop.name.pluralize }" }
+          = render partial: "shared/signin_signup", locals: { to: "post your tips and experiences growing #{ @crop.name.pluralize }" }
     - else
       %div.pagination
         = page_entries_info @posts
-        = will_paginate @posts, :params => {:anchor => "posts"}
+        = will_paginate @posts, params: {anchor: "posts"}
       - @posts.each do |post|
-        = render :partial => "posts/single", :locals => { :post => post, :subject => true }
+        = render partial: "posts/single", locals: { post: post, subject: true }
 
       %div.pagination
         = page_entries_info @posts
-        = will_paginate @posts, :params => {:anchor => "posts"}
+        = will_paginate @posts, params: {anchor: "posts"}
 
   .col-md-3
 
-    = render :partial => 'wrangle', :locals => { :crop => @crop }
+    = render partial: 'wrangle', locals: { crop: @crop }
 
     %h4 How to grow #{ @crop.name.pluralize }
 
-    = render :partial => 'grown_for', :locals => { :crop => @crop }
-    = render :partial => 'planting_advice', :locals => { :crop => @crop }
+    = render partial: 'grown_for', locals: { crop: @crop }
+    = render partial: 'planting_advice', locals: { crop: @crop }
 
-    = render :partial => 'scientific_names', :locals => { :crop => @crop }
-    = render :partial => 'alternate_names', :locals => { :crop => @crop }
+    = render partial: 'scientific_names', locals: { crop: @crop }
+    = render partial: 'alternate_names', locals: { crop: @crop }
 
     %h4 #{ @crop.name.capitalize } varieties
-    = render :partial => 'varieties', :locals => { :crop => @crop }
+    = render partial: 'varieties', locals: { crop: @crop }
 
-    = render :partial => 'plantings', :locals => { :crop => @crop }
-    = render :partial => 'harvests', :locals => { :crop => @crop }
-    = render :partial => 'find_seeds', :locals => { :crop => @crop }
+    = render partial: 'plantings', locals: { crop: @crop }
+    = render partial: 'harvests', locals: { crop: @crop }
+    = render partial: 'find_seeds', locals: { crop: @crop }
 
     %h4 Learn more about #{ @crop.name.pluralize }
     %ul

--- a/app/views/crops/wrangle.html.haml
+++ b/app/views/crops/wrangle.html.haml
@@ -37,7 +37,7 @@
   = page_entries_info @crops
   = will_paginate @crops
 
-%table{class: "table table-striped", id: @approval_status.blank? ? 'recently-added-crops' : "#{@approval_status}-crops"}
+%table{class: 'table table-striped', id: @approval_status.blank? ? 'recently-added-crops' : "#{@approval_status}-crops"}
   %tr
     %th System name
     %th English Wikipedia URL

--- a/app/views/crops/wrangle.html.haml
+++ b/app/views/crops/wrangle.html.haml
@@ -17,12 +17,12 @@
 
 .tabbable
   %ul.nav.nav-tabs
-    %li{:class => @approval_status.blank? ? 'active' : ''}
+    %li{class: @approval_status.blank? ? 'active' : ''}
       = link_to "Recently added", wrangle_crops_path
-    %li{:class => @approval_status == "pending" ? 'active' : ''}
-      = link_to "Pending approval", wrangle_crops_path(:approval_status => "pending")
-    %li{:class => @approval_status == "rejected" ? 'active' : ''}
-      = link_to "Rejected", wrangle_crops_path(:approval_status => "rejected")
+    %li{class: @approval_status == "pending" ? 'active' : ''}
+      = link_to "Pending approval", wrangle_crops_path(approval_status: "pending")
+    %li{class: @approval_status == "rejected" ? 'active' : ''}
+      = link_to "Rejected", wrangle_crops_path(approval_status: "rejected")
 
 %h2 
   - if @approval_status == "pending"
@@ -37,7 +37,7 @@
   = page_entries_info @crops
   = will_paginate @crops
 
-%table{:class => "table table-striped", :id => @approval_status.blank? ? 'recently-added-crops' : "#{@approval_status}-crops"}
+%table{class: "table table-striped", id: @approval_status.blank? ? 'recently-added-crops' : "#{@approval_status}-crops"}
   %tr
     %th System name
     %th English Wikipedia URL

--- a/app/views/crops/wrangle.html.haml
+++ b/app/views/crops/wrangle.html.haml
@@ -1,12 +1,12 @@
-- content_for :title, "Crop Wrangling"
+- content_for :title, 'Crop Wrangling'
 
 
 %ul
-  %li= link_to "Requests for new crops", 'http://growstuff.org/posts/skud-20130319-requests-for-new-crops'
+  %li= link_to 'Requests for new crops', 'http://growstuff.org/posts/skud-20130319-requests-for-new-crops'
   %li= link_to "Crop wrangler guidelines", "http://wiki.growstuff.org/index.php/Crop_wrangling"
   %li= link_to "crop-wranglers mailing list", "http://lists.growstuff.org/listinfo/crop-wranglers"
-  %li= link_to "Full crop hierarchy", crops_hierarchy_path
-  %li= link_to "Add Crop", new_crop_path
+  %li= link_to 'Full crop hierarchy', crops_hierarchy_path
+  %li= link_to 'Add Crop', new_crop_path
 
 %div.crop_wranglers
   %h2 Crop Wranglers:
@@ -18,16 +18,16 @@
 .tabbable
   %ul.nav.nav-tabs
     %li{class: @approval_status.blank? ? 'active' : ''}
-      = link_to "Recently added", wrangle_crops_path
-    %li{class: @approval_status == "pending" ? 'active' : ''}
+      = link_to 'Recently added', wrangle_crops_path
+    %li{class: @approval_status == 'pending' ? 'active' : ''}
       = link_to "Pending approval", wrangle_crops_path(approval_status: "pending")
-    %li{class: @approval_status == "rejected" ? 'active' : ''}
+    %li{class: @approval_status == 'rejected' ? 'active' : ''}
       = link_to "Rejected", wrangle_crops_path(approval_status: "rejected")
 
 %h2 
-  - if @approval_status == "pending"
+  - if @approval_status == 'pending'
     Requested Crops
-  - elsif @approval_status == "rejected"
+  - elsif @approval_status == 'rejected'
     Rejected Crops
   - else
     Recently added crops
@@ -43,7 +43,7 @@
     %th English Wikipedia URL
     %th Scientific names
     %th Requested by
-    - if @approval_status == "rejected"
+    - if @approval_status == 'rejected'
       %th Rejected by
     - if @approval_status != "rejected" && @approval_status != "pending"
       %th Added by
@@ -56,9 +56,9 @@
         - c.scientific_names.each do |s|
           = link_to s.scientific_name, s
           %br/
-      %td= c.requester.present? ? (link_to c.requester, c.requester) : "N/A"
-      - unless @approval_status == "pending"
-        %td= c.creator.present? ? (link_to c.creator, c.creator) : "N/A"
+      %td= c.requester.present? ? (link_to c.requester, c.requester) : 'N/A'
+      - unless @approval_status == 'pending'
+        %td= c.creator.present? ? (link_to c.creator, c.creator) : 'N/A'
       %td
         = distance_of_time_in_words(c.created_at, Time.zone.now)
         ago.

--- a/app/views/crops/wrangle.html.haml
+++ b/app/views/crops/wrangle.html.haml
@@ -3,8 +3,8 @@
 
 %ul
   %li= link_to 'Requests for new crops', 'http://growstuff.org/posts/skud-20130319-requests-for-new-crops'
-  %li= link_to "Crop wrangler guidelines", "http://wiki.growstuff.org/index.php/Crop_wrangling"
-  %li= link_to "crop-wranglers mailing list", "http://lists.growstuff.org/listinfo/crop-wranglers"
+  %li= link_to 'Crop wrangler guidelines', 'http://wiki.growstuff.org/index.php/Crop_wrangling'
+  %li= link_to 'crop-wranglers mailing list', 'http://lists.growstuff.org/listinfo/crop-wranglers'
   %li= link_to 'Full crop hierarchy', crops_hierarchy_path
   %li= link_to 'Add Crop', new_crop_path
 
@@ -20,9 +20,9 @@
     %li{class: @approval_status.blank? ? 'active' : ''}
       = link_to 'Recently added', wrangle_crops_path
     %li{class: @approval_status == 'pending' ? 'active' : ''}
-      = link_to "Pending approval", wrangle_crops_path(approval_status: "pending")
+      = link_to 'Pending approval', wrangle_crops_path(approval_status: 'pending')
     %li{class: @approval_status == 'rejected' ? 'active' : ''}
-      = link_to "Rejected", wrangle_crops_path(approval_status: "rejected")
+      = link_to 'Rejected', wrangle_crops_path(approval_status: 'rejected')
 
 %h2 
   - if @approval_status == 'pending'
@@ -45,7 +45,7 @@
     %th Requested by
     - if @approval_status == 'rejected'
       %th Rejected by
-    - if @approval_status != "rejected" && @approval_status != "pending"
+    - if @approval_status != 'rejected' && @approval_status != 'pending'
       %th Added by
     %th When
   - @crops.each do |c|

--- a/app/views/devise/confirmations/new.html.haml
+++ b/app/views/devise/confirmations/new.html.haml
@@ -1,16 +1,16 @@
 - content_for :title, "Resend confirmation instructions"
 
-= form_for(resource, :as => resource_name, :url => confirmation_path(resource_name), :html => { :method => :post, :class => 'form-horizontal', :role => 'form' }) do |f|
+= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post, class: 'form-horizontal', role: 'form' }) do |f|
   = devise_error_messages!
 
   %p Enter either your login name or your email address to resend the confirmation email.
 
   .form-group
-    = f.label :login, :class => 'control-label col-md-2'
+    = f.label :login, class: 'control-label col-md-2'
     .col-md-8
-      = f.text_field :login, :class => 'form-control'
+      = f.text_field :login, class: 'form-control'
   .form-group
     .form-actions.col-md-offset-2.col-md-8
-      = f.submit "Resend confirmation instructions", :class => 'btn btn-primary'
+      = f.submit "Resend confirmation instructions", class: 'btn btn-primary'
 
 = render "devise/shared/links"

--- a/app/views/devise/confirmations/new.html.haml
+++ b/app/views/devise/confirmations/new.html.haml
@@ -1,4 +1,4 @@
-- content_for :title, "Resend confirmation instructions"
+- content_for :title, 'Resend confirmation instructions'
 
 = form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post, class: 'form-horizontal', role: 'form' }) do |f|
   = devise_error_messages!
@@ -11,6 +11,6 @@
       = f.text_field :login, class: 'form-control'
   .form-group
     .form-actions.col-md-offset-2.col-md-8
-      = f.submit "Resend confirmation instructions", class: 'btn btn-primary'
+      = f.submit 'Resend confirmation instructions', class: 'btn btn-primary'
 
-= render "devise/shared/links"
+= render 'devise/shared/links'

--- a/app/views/devise/mailer/confirmation_instructions.html.haml
+++ b/app/views/devise/mailer/confirmation_instructions.html.haml
@@ -5,7 +5,7 @@
   Your account on #{site_name} has been created.  You just need to confirm
   your email address through the link below:
 
-%p= link_to 'Confirm my account', confirmation_url(@resource, :confirmation_token => @token)
+%p= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token)
 
 %p
   Once you're confirmed, you can sign in with your login name
@@ -17,9 +17,9 @@
   We're excited to have you as a member, and hope you'll enjoy
   what #{site_name} has to offer. Take a look around the site,
   = succeed "," do
-    = link_to('plant some things', url_for(:controller => '/crops', :only_path => false))
+    = link_to('plant some things', url_for(controller: '/crops', only_path: false))
   and feel free to drop in on the
-  = link_to 'forums', url_for(:controller => '/forums', :only_path => false)
+  = link_to 'forums', url_for(controller: '/forums', only_path: false)
   if you have any questions or feedback.
 
 %p

--- a/app/views/devise/mailer/confirmation_instructions.html.haml
+++ b/app/views/devise/mailer/confirmation_instructions.html.haml
@@ -16,7 +16,7 @@
 %p
   We're excited to have you as a member, and hope you'll enjoy
   what #{site_name} has to offer. Take a look around the site,
-  = succeed "," do
+  = succeed ',' do
     = link_to('plant some things', url_for(controller: '/crops', only_path: false))
   and feel free to drop in on the
   = link_to 'forums', url_for(controller: '/forums', only_path: false)
@@ -24,7 +24,7 @@
 
 %p
   We'd also appreciate it if you'd read our
-  = succeed "," do
+  = succeed ',' do
     = link_to 'Community Guidelines', "#{root_url}/policy/community"
   and make sure you follow them. We want #{site_name} to be a
   friendly, welcoming environment for everyone, and we hope you'll

--- a/app/views/devise/mailer/reset_password_instructions.html.haml
+++ b/app/views/devise/mailer/reset_password_instructions.html.haml
@@ -5,7 +5,7 @@
   Someone has requested a link to reset your password on #{site_name}.
   We presume this was you, in which case you can do so through this link:
 
-%p= link_to 'Change my password', edit_password_url(@resource, :reset_password_token => @token)
+%p= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token)
 
 %p
   If it wasn't you, then someone's made a typo or has been messing

--- a/app/views/devise/mailer/unlock_instructions.html.haml
+++ b/app/views/devise/mailer/unlock_instructions.html.haml
@@ -8,7 +8,7 @@
   forgotten your password.  In either case, use the link below to unlock
   your account:
 
-%p= link_to 'Unlock my account', unlock_url(@resource, :unlock_token => @token)
+%p= link_to 'Unlock my account', unlock_url(@resource, unlock_token: @token)
 
 %p
   If you have actually forgotten your password, you can

--- a/app/views/devise/passwords/edit.html.haml
+++ b/app/views/devise/passwords/edit.html.haml
@@ -1,21 +1,21 @@
-- content_for :title, "Change your password"
+- content_for :title, 'Change your password'
 
 = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put, class: 'form-horizontal', role: 'form' }) do |f|
   = devise_error_messages!
   = f.hidden_field :reset_password_token
 
   .form-group
-    = f.label :password, "New password", class: 'control-label col-md-2'
+    = f.label :password, 'New password', class: 'control-label col-md-2'
     .col-md-8
       = f.password_field :password, class: 'form-control'
 
   .form-group
-    = f.label :password_confirmation, "Confirm new password", class: 'control-label col-md-2'
+    = f.label :password_confirmation, 'Confirm new password', class: 'control-label col-md-2'
     .col-md-8
       = f.password_field :password_confirmation, class: 'form-control'
 
   .form-group
     .form-actions.col-md-offset-2.col-md-8
-      = f.submit "Change my password", class: 'btn btn-primary'
+      = f.submit 'Change my password', class: 'btn btn-primary'
 
-= render "devise/shared/links"
+= render 'devise/shared/links'

--- a/app/views/devise/passwords/edit.html.haml
+++ b/app/views/devise/passwords/edit.html.haml
@@ -1,21 +1,21 @@
 - content_for :title, "Change your password"
 
-= form_for(resource, :as => resource_name, :url => password_path(resource_name), :html => { :method => :put, :class => 'form-horizontal', :role => 'form' }) do |f|
+= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put, class: 'form-horizontal', role: 'form' }) do |f|
   = devise_error_messages!
   = f.hidden_field :reset_password_token
 
   .form-group
-    = f.label :password, "New password", :class => 'control-label col-md-2'
+    = f.label :password, "New password", class: 'control-label col-md-2'
     .col-md-8
-      = f.password_field :password, :class => 'form-control'
+      = f.password_field :password, class: 'form-control'
 
   .form-group
-    = f.label :password_confirmation, "Confirm new password", :class => 'control-label col-md-2'
+    = f.label :password_confirmation, "Confirm new password", class: 'control-label col-md-2'
     .col-md-8
-      = f.password_field :password_confirmation, :class => 'form-control'
+      = f.password_field :password_confirmation, class: 'form-control'
 
   .form-group
     .form-actions.col-md-offset-2.col-md-8
-      = f.submit "Change my password", :class => 'btn btn-primary'
+      = f.submit "Change my password", class: 'btn btn-primary'
 
 = render "devise/shared/links"

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -1,14 +1,14 @@
 - content_for :title, "Forgot your password?"
 
-= form_for(resource, :as => resource_name, :url => password_path(resource_name), :html => { :method => :post, :class => 'form-horizontal', :role => 'form' }) do |f|
+= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, class: 'form-horizontal', role: 'form' }) do |f|
   = devise_error_messages!
 
   .form-group
-    = f.label :login, :class => 'control-label col-md-2'
+    = f.label :login, class: 'control-label col-md-2'
     .col-md-8
-      = f.text_field :login, :class => 'form-control'
+      = f.text_field :login, class: 'form-control'
   .form-group
     .form-actions.col-md-offset-2.col-md-8
-      = f.submit "Send me reset password instructions", :class => 'btn btn-primary'
+      = f.submit "Send me reset password instructions", class: 'btn btn-primary'
 
 = render "devise/shared/links"

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -1,4 +1,4 @@
-- content_for :title, "Forgot your password?"
+- content_for :title, 'Forgot your password?'
 
 = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, class: 'form-horizontal', role: 'form' }) do |f|
   = devise_error_messages!
@@ -9,6 +9,6 @@
       = f.text_field :login, class: 'form-control'
   .form-group
     .form-actions.col-md-offset-2.col-md-8
-      = f.submit "Send me reset password instructions", class: 'btn btn-primary'
+      = f.submit 'Send me reset password instructions', class: 'btn btn-primary'
 
-= render "devise/shared/links"
+= render 'devise/shared/links'

--- a/app/views/devise/registrations/_edit_apps.html.haml
+++ b/app/views/devise/registrations/_edit_apps.html.haml
@@ -1,27 +1,27 @@
-= form_for(resource, :as => resource_name, :url => registration_path(resource_name), :html => { :method => :put, :class => 'form-horizontal' }) do |f|
+= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, class: 'form-horizontal' }) do |f|
   %br/
   = devise_error_messages!
 
   .row
     .col-md-12
       %p
-        = image_tag "twitter_32.png", :size => "32x32", :alt => 'Twitter logo'
+        = image_tag "twitter_32.png", size: "32x32", alt: 'Twitter logo'
         - if @twitter_auth
           You are connected to Twitter as
           = succeed "." do
             =link_to @twitter_auth.name, "http://twitter.com/#{@twitter_auth.name}"
-          = link_to "Disconnect", @twitter_auth, :confirm => "Are you sure you want to remove this connection?", :method => :delete, :class => "remove"
+          = link_to "Disconnect", @twitter_auth, confirm: "Are you sure you want to remove this connection?", method: :delete, class: "remove"
         - else
           =link_to 'Connect to Twitter', '/auth/twitter'
 
   .row
     .col-md-12
       %p
-        = image_tag "flickr_32.png", :size => "32x32", :alt => 'Flickr logo'
+        = image_tag "flickr_32.png", size: "32x32", alt: 'Flickr logo'
         - if @flickr_auth
           You are connected to Flickr as
           = succeed "." do
             =link_to @flickr_auth.name, "http://flickr.com/photos/#{@flickr_auth.uid}"
-          = link_to "Disconnect", @flickr_auth, :confirm => "Are you sure you want to remove this connection?", :method => :delete, :class => "remove"
+          = link_to "Disconnect", @flickr_auth, confirm: "Are you sure you want to remove this connection?", method: :delete, class: "remove"
         - else
           =link_to 'Connect to Flickr', '/auth/flickr'

--- a/app/views/devise/registrations/_edit_apps.html.haml
+++ b/app/views/devise/registrations/_edit_apps.html.haml
@@ -5,23 +5,23 @@
   .row
     .col-md-12
       %p
-        = image_tag "twitter_32.png", size: "32x32", alt: 'Twitter logo'
+        = image_tag 'twitter_32.png', size: '32x32', alt: 'Twitter logo'
         - if @twitter_auth
           You are connected to Twitter as
           = succeed '.' do
             =link_to @twitter_auth.name, "http://twitter.com/#{@twitter_auth.name}"
-          = link_to "Disconnect", @twitter_auth, confirm: "Are you sure you want to remove this connection?", method: :delete, class: "remove"
+          = link_to 'Disconnect', @twitter_auth, confirm: 'Are you sure you want to remove this connection?', method: :delete, class: 'remove'
         - else
           =link_to 'Connect to Twitter', '/auth/twitter'
 
   .row
     .col-md-12
       %p
-        = image_tag "flickr_32.png", size: "32x32", alt: 'Flickr logo'
+        = image_tag 'flickr_32.png', size: '32x32', alt: 'Flickr logo'
         - if @flickr_auth
           You are connected to Flickr as
           = succeed '.' do
             =link_to @flickr_auth.name, "http://flickr.com/photos/#{@flickr_auth.uid}"
-          = link_to "Disconnect", @flickr_auth, confirm: "Are you sure you want to remove this connection?", method: :delete, class: "remove"
+          = link_to 'Disconnect', @flickr_auth, confirm: 'Are you sure you want to remove this connection?', method: :delete, class: 'remove'
         - else
           =link_to 'Connect to Flickr', '/auth/flickr'

--- a/app/views/devise/registrations/_edit_apps.html.haml
+++ b/app/views/devise/registrations/_edit_apps.html.haml
@@ -8,7 +8,7 @@
         = image_tag "twitter_32.png", size: "32x32", alt: 'Twitter logo'
         - if @twitter_auth
           You are connected to Twitter as
-          = succeed "." do
+          = succeed '.' do
             =link_to @twitter_auth.name, "http://twitter.com/#{@twitter_auth.name}"
           = link_to "Disconnect", @twitter_auth, confirm: "Are you sure you want to remove this connection?", method: :delete, class: "remove"
         - else
@@ -20,7 +20,7 @@
         = image_tag "flickr_32.png", size: "32x32", alt: 'Flickr logo'
         - if @flickr_auth
           You are connected to Flickr as
-          = succeed "." do
+          = succeed '.' do
             =link_to @flickr_auth.name, "http://flickr.com/photos/#{@flickr_auth.uid}"
           = link_to "Disconnect", @flickr_auth, confirm: "Are you sure you want to remove this connection?", method: :delete, class: "remove"
         - else

--- a/app/views/devise/registrations/_edit_email.html.haml
+++ b/app/views/devise/registrations/_edit_email.html.haml
@@ -1,11 +1,11 @@
-= form_for(resource, :as => resource_name, :url => registration_path(resource_name), :html => { :method => :put, :class => 'form-horizontal' }) do |f|
+= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, class: 'form-horizontal' }) do |f|
   %br/
   = devise_error_messages!
 
   .form-group
-    = f.label :email, :class => 'control-label col-md-2'
+    = f.label :email, class: 'control-label col-md-2'
     .col-md-8
-      = f.email_field :email, :class => 'form-control'
+      = f.email_field :email, class: 'form-control'
       %span.help-block If you change your email address you will have to reconfirm.
 
   .form-group
@@ -32,10 +32,10 @@
         = f.check_box :newsletter
         Subscribe to the #{ENV['GROWSTUFF_SITE_NAME']} newsletter
       .help-block
-        = render :partial => 'newsletter_blurb'
+        = render partial: 'newsletter_blurb'
 
   .form-group
     .form-actions.col-md-offset-2.col-md-8
-      = f.submit "Save", :class => 'btn btn-primary'
+      = f.submit "Save", class: 'btn btn-primary'
 
-      =f.hidden_field(:tos_agreement, :value => true)
+      =f.hidden_field(:tos_agreement, value: true)

--- a/app/views/devise/registrations/_edit_email.html.haml
+++ b/app/views/devise/registrations/_edit_email.html.haml
@@ -36,6 +36,6 @@
 
   .form-group
     .form-actions.col-md-offset-2.col-md-8
-      = f.submit "Save", class: 'btn btn-primary'
+      = f.submit 'Save', class: 'btn btn-primary'
 
       =f.hidden_field(:tos_agreement, value: true)

--- a/app/views/devise/registrations/_edit_password.html.haml
+++ b/app/views/devise/registrations/_edit_password.html.haml
@@ -8,9 +8,9 @@
       = f.password_field :current_password, class: 'form-control'
 
   .form-group
-    = f.label :password, "New password", class: 'control-label col-md-2'
+    = f.label :password, 'New password', class: 'control-label col-md-2'
     .col-md-4
-      = f.password_field :password, autocomplete: "off", class: 'form-control'
+      = f.password_field :password, autocomplete: 'off', class: 'form-control'
 
   .form-group
     = f.label :password_confirmation, class: 'control-label col-md-2'
@@ -18,6 +18,6 @@
 
   .form-group
     .form-actions.col-md-offset-2.col-md-8
-      = f.submit "Save", class: 'btn btn-primary'
+      = f.submit 'Save', class: 'btn btn-primary'
 
       =f.hidden_field(:tos_agreement, value: true)

--- a/app/views/devise/registrations/_edit_password.html.haml
+++ b/app/views/devise/registrations/_edit_password.html.haml
@@ -1,23 +1,23 @@
-= form_for(resource, :as => resource_name, :url => registration_path(resource_name), :html => { :method => :put, :class => 'form-horizontal' }) do |f|
+= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, class: 'form-horizontal' }) do |f|
   %br/
   = devise_error_messages!
 
   .form-group
-    = f.label :current_password, :class => 'control-label col-md-2'
+    = f.label :current_password, class: 'control-label col-md-2'
     .col-md-4
-      = f.password_field :current_password, :class => 'form-control'
+      = f.password_field :current_password, class: 'form-control'
 
   .form-group
-    = f.label :password, "New password", :class => 'control-label col-md-2'
+    = f.label :password, "New password", class: 'control-label col-md-2'
     .col-md-4
-      = f.password_field :password, :autocomplete => "off", :class => 'form-control'
+      = f.password_field :password, autocomplete: "off", class: 'form-control'
 
   .form-group
-    = f.label :password_confirmation, :class => 'control-label col-md-2'
-    .col-md-4= f.password_field :password_confirmation, :class => 'form-control'
+    = f.label :password_confirmation, class: 'control-label col-md-2'
+    .col-md-4= f.password_field :password_confirmation, class: 'form-control'
 
   .form-group
     .form-actions.col-md-offset-2.col-md-8
-      = f.submit "Save", :class => 'btn btn-primary'
+      = f.submit "Save", class: 'btn btn-primary'
 
-      =f.hidden_field(:tos_agreement, :value => true)
+      =f.hidden_field(:tos_agreement, value: true)

--- a/app/views/devise/registrations/_edit_profile.html.haml
+++ b/app/views/devise/registrations/_edit_profile.html.haml
@@ -5,7 +5,7 @@
   .form-group
     =f.label :location, 'Your location', class: 'control-label col-md-2'
     .col-md-8
-      =f.text_field :location, autocomplete: "off", class: 'form-control'
+      =f.text_field :location, autocomplete: 'off', class: 'form-control'
       %span.help-block This will be displayed on a map. You can be as detailed or vague as you like.
 
   .form-group
@@ -17,15 +17,15 @@
     %label.control-label.col-md-2
       Profile picture
     .col-md-8
-      = render partial: "members/avatar", locals: { member: @member }
+      = render partial: 'members/avatar', locals: { member: @member }
       %p
         %br/
         To change your profile picture, visit
-        = succeed "." do
-          = link_to 'gravatar.com', "http://gravatar.com/"
+        = succeed '.' do
+          = link_to 'gravatar.com', 'http://gravatar.com/'
 
   .form-group
     .form-actions.col-md-offset-2.col-md-8
-      = f.submit "Save", class: 'btn btn-primary'
+      = f.submit 'Save', class: 'btn btn-primary'
 
       =f.hidden_field(:tos_agreement, value: true)

--- a/app/views/devise/registrations/_edit_profile.html.haml
+++ b/app/views/devise/registrations/_edit_profile.html.haml
@@ -1,23 +1,23 @@
-= form_for(resource, :as => resource_name, :url => registration_path(resource_name), :html => { :method => :put, :class => 'form-horizontal' }) do |f|
+= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, class: 'form-horizontal' }) do |f|
   %br/
   = devise_error_messages!
 
   .form-group
-    =f.label :location, 'Your location', :class => 'control-label col-md-2'
+    =f.label :location, 'Your location', class: 'control-label col-md-2'
     .col-md-8
-      =f.text_field :location, :autocomplete => "off", :class => 'form-control'
+      =f.text_field :location, autocomplete: "off", class: 'form-control'
       %span.help-block This will be displayed on a map. You can be as detailed or vague as you like.
 
   .form-group
-    =f.label :bio, :class => 'control-label col-md-2'
+    =f.label :bio, class: 'control-label col-md-2'
     .col-md-8
-      =f.text_area :bio, :rows => 6, :class => 'form-control'
+      =f.text_area :bio, rows: 6, class: 'form-control'
 
   .form-group
     %label.control-label.col-md-2
       Profile picture
     .col-md-8
-      = render :partial => "members/avatar", :locals => { :member => @member }
+      = render partial: "members/avatar", locals: { member: @member }
       %p
         %br/
         To change your profile picture, visit
@@ -26,6 +26,6 @@
 
   .form-group
     .form-actions.col-md-offset-2.col-md-8
-      = f.submit "Save", :class => 'btn btn-primary'
+      = f.submit "Save", class: 'btn btn-primary'
 
-      =f.hidden_field(:tos_agreement, :value => true)
+      =f.hidden_field(:tos_agreement, value: true)

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -1,25 +1,25 @@
 - content_for :title, "Settings for #{current_member.login_name}"
 
-%ul.nav.nav-tabs{:role => 'tablist'}
+%ul.nav.nav-tabs{role: 'tablist'}
   %li.active
-    %a{:href => '#profile', :role => 'tab', 'data-toggle' => 'tab'}
+    %a{href: '#profile', role: 'tab', 'data-toggle' => 'tab'}
       Profile
   %li
-    %a{:href => '#email', :role => 'tab', 'data-toggle' => 'tab'}
+    %a{href: '#email', role: 'tab', 'data-toggle' => 'tab'}
       Email
   %li
-    %a{:href => '#apps', :role => 'tab', 'data-toggle' => 'tab'}
+    %a{href: '#apps', role: 'tab', 'data-toggle' => 'tab'}
       Apps
   %li
-    %a{:href => '#password', :role => 'tab', 'data-toggle' => 'tab'}
+    %a{href: '#password', role: 'tab', 'data-toggle' => 'tab'}
       Password
 
 .tab-content
   .tab-pane.active#profile
-    = render :partial => 'edit_profile'
+    = render partial: 'edit_profile'
   .tab-pane#email
-    = render :partial => 'edit_email'
+    = render partial: 'edit_email'
   .tab-pane#apps
-    = render :partial => 'edit_apps'
+    = render partial: 'edit_apps'
   .tab-pane#password
-    = render :partial => 'edit_password'
+    = render partial: 'edit_password'

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -2,28 +2,28 @@
 
 %p Sign up for a Growstuff account to track your veggie garden and connect with other local growers.
 
-= form_for(resource, :as => resource_name, :url => registration_path(resource_name), :html => {:class => "form-horizontal"}) do |f|
+= form_for(resource, as: resource_name, url: registration_path(resource_name), html: {class: "form-horizontal"}) do |f|
   = devise_error_messages!
 
   .form-group
-    = f.label :login_name, :class => "control-label col-md-2"
+    = f.label :login_name, class: "control-label col-md-2"
     .col-md-8
-      = f.text_field :login_name, :class => 'form-control'
+      = f.text_field :login_name, class: 'form-control'
       %span.help-inline This is the name that will show on the website.
 
   .form-group
-    = f.label :email, :class => "control-label col-md-2"
+    = f.label :email, class: "control-label col-md-2"
     .col-md-8
-      = f.email_field :email, :class => 'form-control'
+      = f.email_field :email, class: 'form-control'
       %span.help-inline We'll use this address to contact you (we never spam!)
 
   .form-group
-    = f.label :password, :class => "control-label col-md-2"
-    .col-md-8= f.password_field :password, :class => 'form-control'
+    = f.label :password, class: "control-label col-md-2"
+    .col-md-8= f.password_field :password, class: 'form-control'
 
   .form-group
-    = f.label :password_confirmation, :class => "control-label col-md-2"
-    .col-md-8= f.password_field :password_confirmation, :class => 'form-control'
+    = f.label :password_confirmation, class: "control-label col-md-2"
+    .col-md-8= f.password_field :password_confirmation, class: 'form-control'
 
   .form-group
     .col-md-offset-2.col-md-8.checkbox
@@ -35,14 +35,14 @@
   .form-group
     .col-md-offset-2.col-md-8.checkbox
       %label
-        = f.check_box :newsletter, :checked => true
+        = f.check_box :newsletter, checked: true
         Subscribe to the #{ENV['GROWSTUFF_SITE_NAME']} newsletter
       .help-inline
-        = render :partial => 'newsletter_blurb'
+        = render partial: 'newsletter_blurb'
 
   .form-group
     .form-actions.col-md-offset-2.col-md-8
-      = f.submit "Sign up", :class => 'btn btn-primary'
+      = f.submit "Sign up", class: 'btn btn-primary'
 
   .form-group
     .col-md-offset-2.col-md-8

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,28 +1,28 @@
-- content_for :title, "Join Growstuff"
+- content_for :title, 'Join Growstuff'
 
 %p Sign up for a Growstuff account to track your veggie garden and connect with other local growers.
 
-= form_for(resource, as: resource_name, url: registration_path(resource_name), html: {class: "form-horizontal"}) do |f|
+= form_for(resource, as: resource_name, url: registration_path(resource_name), html: {class: 'form-horizontal'}) do |f|
   = devise_error_messages!
 
   .form-group
-    = f.label :login_name, class: "control-label col-md-2"
+    = f.label :login_name, class: 'control-label col-md-2'
     .col-md-8
       = f.text_field :login_name, class: 'form-control'
       %span.help-inline This is the name that will show on the website.
 
   .form-group
-    = f.label :email, class: "control-label col-md-2"
+    = f.label :email, class: 'control-label col-md-2'
     .col-md-8
       = f.email_field :email, class: 'form-control'
       %span.help-inline We'll use this address to contact you (we never spam!)
 
   .form-group
-    = f.label :password, class: "control-label col-md-2"
+    = f.label :password, class: 'control-label col-md-2'
     .col-md-8= f.password_field :password, class: 'form-control'
 
   .form-group
-    = f.label :password_confirmation, class: "control-label col-md-2"
+    = f.label :password_confirmation, class: 'control-label col-md-2'
     .col-md-8= f.password_field :password_confirmation, class: 'form-control'
 
   .form-group
@@ -30,7 +30,7 @@
       %label
         = f.check_box :tos_agreement
         I agree to the
-        = succeed "." do
+        = succeed '.' do
           = link_to 'Terms of Service', "#{root_url}/policy/tos"
   .form-group
     .col-md-offset-2.col-md-8.checkbox
@@ -42,8 +42,8 @@
 
   .form-group
     .form-actions.col-md-offset-2.col-md-8
-      = f.submit "Sign up", class: 'btn btn-primary'
+      = f.submit 'Sign up', class: 'btn btn-primary'
 
   .form-group
     .col-md-offset-2.col-md-8
-      = render "devise/shared/links"
+      = render 'devise/shared/links'

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,15 +1,15 @@
-- content_for :title, "Sign in"
+- content_for :title, 'Sign in'
 
-= form_for(resource, as: resource_name, url: session_path(resource_name), html: {class: "form-horizontal"}) do |f|
+= form_for(resource, as: resource_name, url: session_path(resource_name), html: {class: 'form-horizontal'}) do |f|
   = devise_error_messages!
 
   .form-group
-    = f.label :login, class: "control-label col-md-2"
+    = f.label :login, class: 'control-label col-md-2'
     .col-md-8
       = f.text_field :login, class: 'form-control'
 
   .form-group
-    = f.label :password, class: "control-label col-md-2"
+    = f.label :password, class: 'control-label col-md-2'
     .col-md-8
       = f.password_field :password, class: 'form-control'
 
@@ -22,8 +22,8 @@
 
   .form-group
     .form-actions.col-md-8.col-md-offset-2
-      = f.submit "Sign in", class: 'btn btn-primary'
+      = f.submit 'Sign in', class: 'btn btn-primary'
 
   .form-group
     .col-md-8.col-md-offset-2
-      = render "devise/shared/links"
+      = render 'devise/shared/links'

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,17 +1,17 @@
 - content_for :title, "Sign in"
 
-= form_for(resource, :as => resource_name, :url => session_path(resource_name), :html => {:class => "form-horizontal"}) do |f|
+= form_for(resource, as: resource_name, url: session_path(resource_name), html: {class: "form-horizontal"}) do |f|
   = devise_error_messages!
 
   .form-group
-    = f.label :login, :class => "control-label col-md-2"
+    = f.label :login, class: "control-label col-md-2"
     .col-md-8
-      = f.text_field :login, :class => 'form-control'
+      = f.text_field :login, class: 'form-control'
 
   .form-group
-    = f.label :password, :class => "control-label col-md-2"
+    = f.label :password, class: "control-label col-md-2"
     .col-md-8
-      = f.password_field :password, :class => 'form-control'
+      = f.password_field :password, class: 'form-control'
 
   - if devise_mapping.rememberable?
     .form-group
@@ -22,7 +22,7 @@
 
   .form-group
     .form-actions.col-md-8.col-md-offset-2
-      = f.submit "Sign in", :class => 'btn btn-primary'
+      = f.submit "Sign in", class: 'btn btn-primary'
 
   .form-group
     .col-md-8.col-md-offset-2

--- a/app/views/devise/shared/_links.haml
+++ b/app/views/devise/shared/_links.haml
@@ -1,5 +1,5 @@
 - if devise_mapping.recoverable? && controller_name != 'passwords'
-  = link_to "Forgot your password?", new_password_path(resource_name)
+  = link_to 'Forgot your password?', new_password_path(resource_name)
   %br
 
 - if devise_mapping.confirmable? && controller_name != 'confirmations'

--- a/app/views/devise/unlocks/new.html.haml
+++ b/app/views/devise/unlocks/new.html.haml
@@ -1,4 +1,4 @@
-- content_for :title, "Resend unlock instructions"
+- content_for :title, 'Resend unlock instructions'
 
 = form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post, class: 'form-horizontal', role: 'form' }) do |f|
   = devise_error_messages!
@@ -9,6 +9,6 @@
       = f.email_field :email, class: 'form-control'
   .form-group
     .form-actions.col-md-offset-2.col-md-8
-      = f.submit "Resend unlock instructions", class: 'btn btn-primary'
+      = f.submit 'Resend unlock instructions', class: 'btn btn-primary'
 
-= render "devise/shared/links"
+= render 'devise/shared/links'

--- a/app/views/devise/unlocks/new.html.haml
+++ b/app/views/devise/unlocks/new.html.haml
@@ -1,14 +1,14 @@
 - content_for :title, "Resend unlock instructions"
 
-= form_for(resource, :as => resource_name, :url => unlock_path(resource_name), :html => { :method => :post, :class => 'form-horizontal', :role => 'form' }) do |f|
+= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post, class: 'form-horizontal', role: 'form' }) do |f|
   = devise_error_messages!
 
   .form-group
-    = f.label :email, :class => 'control-label col-md-2'
+    = f.label :email, class: 'control-label col-md-2'
     .col-md-8
-      = f.email_field :email, :class => 'form-control'
+      = f.email_field :email, class: 'form-control'
   .form-group
     .form-actions.col-md-offset-2.col-md-8
-      = f.submit "Resend unlock instructions", :class => 'btn btn-primary'
+      = f.submit "Resend unlock instructions", class: 'btn btn-primary'
 
 = render "devise/shared/links"

--- a/app/views/forums/_form.html.haml
+++ b/app/views/forums/_form.html.haml
@@ -1,4 +1,4 @@
-= form_for @forum, :html => { :class => 'form-horizontal', :role => "form" } do |f|
+= form_for @forum, html: { class: 'form-horizontal', role: "form" } do |f|
   - if @forum.errors.any?
     #error_explanation
       %h2= "#{pluralize(@forum.errors.size, "error")} prohibited this forum from being saved:"
@@ -7,17 +7,17 @@
           %li= msg
 
   .form-group
-    = f.label :name, :class => 'control-label col-md-2'
+    = f.label :name, class: 'control-label col-md-2'
     .col-md-8
-      = f.text_field :name, :class => 'form-control'
+      = f.text_field :name, class: 'form-control'
   .form-group
-    = f.label :description, :class => 'control-label col-md-2'
+    = f.label :description, class: 'control-label col-md-2'
     .col-md-8
-      = f.text_area :description, :rows => 6, :class => 'form-control'
+      = f.text_area :description, rows: 6, class: 'form-control'
   .form-group
-    = f.label :owner_id, :class => 'control-label col-md-2'
+    = f.label :owner_id, class: 'control-label col-md-2'
     .col-md-8
-      = collection_select(:forum, :owner_id, Member.all, :id, :login_name, {}, :class => 'form-control')
+      = collection_select(:forum, :owner_id, Member.all, :id, :login_name, {}, class: 'form-control')
   .form-group
     .form-actions.col-md-offset-2.col-md-8
-      = f.submit 'Save', :class => 'btn btn-primary'
+      = f.submit 'Save', class: 'btn btn-primary'

--- a/app/views/forums/_form.html.haml
+++ b/app/views/forums/_form.html.haml
@@ -1,4 +1,4 @@
-= form_for @forum, html: { class: 'form-horizontal', role: "form" } do |f|
+= form_for @forum, html: { class: 'form-horizontal', role: 'form' } do |f|
   - if @forum.errors.any?
     #error_explanation
       %h2= "#{pluralize(@forum.errors.size, "error")} prohibited this forum from being saved:"

--- a/app/views/forums/edit.html.haml
+++ b/app/views/forums/edit.html.haml
@@ -1,3 +1,3 @@
-- content_for :title, "Editing forum"
+- content_for :title, 'Editing forum'
 
 = render 'form'

--- a/app/views/forums/index.html.haml
+++ b/app/views/forums/index.html.haml
@@ -2,15 +2,15 @@
 
 - if can? :create, Forum
   %p
-    = link_to "New forum", new_forum_path, class: 'btn btn-default'
+    = link_to 'New forum', new_forum_path, class: 'btn btn-default'
 
 - @forums.each do |forum|
   %h2= forum
   %p
-    = pluralize(forum.posts.size, "post")
+    = pluralize(forum.posts.size, 'post')
     |
-    =link_to "Visit forum", forum
+    =link_to 'Visit forum', forum
     |
-    =link_to "Post", new_post_path(forum_id: forum.id)
-  =render partial: "posts/summary", locals: { posts: forum.posts, howmany: 4 }
+    =link_to 'Post', new_post_path(forum_id: forum.id)
+  =render partial: 'posts/summary', locals: { posts: forum.posts, howmany: 4 }
 

--- a/app/views/forums/index.html.haml
+++ b/app/views/forums/index.html.haml
@@ -2,7 +2,7 @@
 
 - if can? :create, Forum
   %p
-    = link_to "New forum", new_forum_path, :class => 'btn btn-default'
+    = link_to "New forum", new_forum_path, class: 'btn btn-default'
 
 - @forums.each do |forum|
   %h2= forum
@@ -11,6 +11,6 @@
     |
     =link_to "Visit forum", forum
     |
-    =link_to "Post", new_post_path(:forum_id => forum.id)
-  =render :partial => "posts/summary", :locals => { :posts => forum.posts, :howmany => 4 }
+    =link_to "Post", new_post_path(forum_id: forum.id)
+  =render partial: "posts/summary", locals: { posts: forum.posts, howmany: 4 }
 

--- a/app/views/forums/new.html.haml
+++ b/app/views/forums/new.html.haml
@@ -1,3 +1,3 @@
-- content_for :title, "New Forum"
+- content_for :title, 'New Forum'
 
 = render 'form'

--- a/app/views/forums/show.html.haml
+++ b/app/views/forums/show.html.haml
@@ -11,16 +11,16 @@
     #{ strip_tags(@forum.description) }
 
 - if can? :edit, @forum
-  =link_to "Edit", edit_forum_path(@forum), :class => 'btn btn-default btn-xs'
+  =link_to "Edit", edit_forum_path(@forum), class: 'btn btn-default btn-xs'
 - if can? :delete, @forum
-  = link_to 'Delete', @forum, :method => :delete, :data => { :confirm => 'Are you sure?' }
+  = link_to 'Delete', @forum, method: :delete, data: { confirm: 'Are you sure?' }
 
 %h2
   Posts
-  =link_to "Post something", new_post_path(:forum_id => @forum.id), :class => 'btn btn-primary'
+  =link_to "Post something", new_post_path(forum_id: @forum.id), class: 'btn btn-primary'
 
 - if @forum.posts.size > 0
-  =render :partial => "posts/summary", :locals => { :posts => @forum.posts }
+  =render partial: "posts/summary", locals: { posts: @forum.posts }
 - else
   No posts yet.
 

--- a/app/views/forums/show.html.haml
+++ b/app/views/forums/show.html.haml
@@ -11,16 +11,16 @@
     #{ strip_tags(@forum.description) }
 
 - if can? :edit, @forum
-  =link_to "Edit", edit_forum_path(@forum), class: 'btn btn-default btn-xs'
+  =link_to 'Edit', edit_forum_path(@forum), class: 'btn btn-default btn-xs'
 - if can? :delete, @forum
   = link_to 'Delete', @forum, method: :delete, data: { confirm: 'Are you sure?' }
 
 %h2
   Posts
-  =link_to "Post something", new_post_path(forum_id: @forum.id), class: 'btn btn-primary'
+  =link_to 'Post something', new_post_path(forum_id: @forum.id), class: 'btn btn-primary'
 
 - if @forum.posts.size > 0
-  =render partial: "posts/summary", locals: { posts: @forum.posts }
+  =render partial: 'posts/summary', locals: { posts: @forum.posts }
 - else
   No posts yet.
 

--- a/app/views/gardens/_form.html.haml
+++ b/app/views/gardens/_form.html.haml
@@ -1,6 +1,6 @@
 = required_field_help_text
 
-= form_for(@garden, html: {class: "form-horizontal", role: "form"}) do |f|
+= form_for(@garden, html: {class: 'form-horizontal', role: 'form'}) do |f|
   - if @garden.errors.any?
     #error_explanation
       %h2= "#{pluralize(@garden.errors.size, "error")} prohibited this garden from being saved:"

--- a/app/views/gardens/_form.html.haml
+++ b/app/views/gardens/_form.html.haml
@@ -1,6 +1,6 @@
 = required_field_help_text
 
-= form_for(@garden, :html => {:class => "form-horizontal", :role => "form"}) do |f|
+= form_for(@garden, html: {class: "form-horizontal", role: "form"}) do |f|
   - if @garden.errors.any?
     #error_explanation
       %h2= "#{pluralize(@garden.errors.size, "error")} prohibited this garden from being saved:"
@@ -9,19 +9,19 @@
           %li= msg
 
   .form-group.required
-    = f.label :name, :class => 'control-label col-md-2'
+    = f.label :name, class: 'control-label col-md-2'
     .col-md-8
-      = f.text_field :name, :class => 'form-control', :maxlength => 255, :required => "required"
+      = f.text_field :name, class: 'form-control', maxlength: 255, required: "required"
 
   .form-group
-    = f.label :description, :class => 'control-label col-md-2'
+    = f.label :description, class: 'control-label col-md-2'
     .col-md-8
-      = f.text_area :description, :rows => 6, :class => 'form-control', :placeholder => 'optional'
+      = f.text_area :description, rows: 6, class: 'form-control', placeholder: 'optional'
 
   .form-group
-    = f.label :location, :class => 'control-label col-md-2'
+    = f.label :location, class: 'control-label col-md-2'
     .col-md-8
-      = f.text_field :location, :value => @garden.location || current_member.location, :class => 'form-control', :placeholder => 'optional', :maxlength => 255
+      = f.text_field :location, value: @garden.location || current_member.location, class: 'form-control', placeholder: 'optional', maxlength: 255
       %span.help-block
         If you have a location set in your profile, it will be used when
         you create a new garden.
@@ -31,14 +31,14 @@
           =link_to "Change your location.", edit_member_registration_path
 
   .form-group
-    = f.label :area, :class => 'control-label col-md-2'
+    = f.label :area, class: 'control-label col-md-2'
     .col-md-2
-      = f.number_field :area, :class => 'input-small form-control', :placeholder => 'optional'
+      = f.number_field :area, class: 'input-small form-control', placeholder: 'optional'
     .col-md-2
-      = f.select(:area_unit, Garden::AREA_UNITS_VALUES, {:include_blank => false}, :class => 'form-control')
+      = f.select(:area_unit, Garden::AREA_UNITS_VALUES, {include_blank: false}, class: 'form-control')
 
   .form-group
-    = f.label :active, 'Active? ', :class => 'control-label col-md-2'
+    = f.label :active, 'Active? ', class: 'control-label col-md-2'
     .col-md-8
       = f.check_box :active
       You can mark a garden as inactive if you no longer use it.  Note:
@@ -46,4 +46,4 @@
 
   .form-group
     .form-actions.col-md-offset-2.col-md-8
-      = f.submit 'Save Garden', :class => 'btn btn-primary'
+      = f.submit 'Save Garden', class: 'btn btn-primary'

--- a/app/views/gardens/_form.html.haml
+++ b/app/views/gardens/_form.html.haml
@@ -11,7 +11,7 @@
   .form-group.required
     = f.label :name, class: 'control-label col-md-2'
     .col-md-8
-      = f.text_field :name, class: 'form-control', maxlength: 255, required: "required"
+      = f.text_field :name, class: 'form-control', maxlength: 255, required: 'required'
 
   .form-group
     = f.label :description, class: 'control-label col-md-2'
@@ -26,9 +26,9 @@
         If you have a location set in your profile, it will be used when
         you create a new garden.
         - if current_member.location.blank?
-          =link_to "Set your location now.", edit_member_registration_path
+          =link_to 'Set your location now.', edit_member_registration_path
         - else
-          =link_to "Change your location.", edit_member_registration_path
+          =link_to 'Change your location.', edit_member_registration_path
 
   .form-group
     = f.label :area, class: 'control-label col-md-2'

--- a/app/views/gardens/_thumbnail.html.haml
+++ b/app/views/gardens/_thumbnail.html.haml
@@ -3,12 +3,12 @@
     %h3.panel-title
       = link_to "#{garden.owner.login_name}'s garden", garden.owner
       - if can? :edit, garden
-        %a.pull-right{:href => edit_garden_path(garden), :role => "button", :id => "edit_garden_glyphicon"}
-          %span.glyphicon.glyphicon-pencil{:title => "Edit"}
-  .panel-body{:id => "gardens_panel_body"}
+        %a.pull-right{href: edit_garden_path(garden), role: "button", id: "edit_garden_glyphicon"}
+          %span.glyphicon.glyphicon-pencil{title: "Edit"}
+  .panel-body{id: "gardens_panel_body"}
     .row
       .col-md-4
-        = link_to image_tag((garden.default_photo ?  garden.default_photo.thumbnail_url : 'placeholder_150.png'), :alt => garden.name, :class => 'img'), garden
+        = link_to image_tag((garden.default_photo ?  garden.default_photo.thumbnail_url : 'placeholder_150.png'), alt: garden.name, class: 'img'), garden
       .col-md-8
         %dl.dl-horizontal
           %dt Name : 

--- a/app/views/gardens/_thumbnail.html.haml
+++ b/app/views/gardens/_thumbnail.html.haml
@@ -3,7 +3,7 @@
     %h3.panel-title
       = link_to "#{garden.owner.login_name}'s garden", garden.owner
       - if can? :edit, garden
-        %a.pull-right{href: edit_garden_path(garden), role: "button", id: "edit_garden_glyphicon"}
+        %a.pull-right{href: edit_garden_path(garden), role: 'button', id: 'edit_garden_glyphicon'}
           %span.glyphicon.glyphicon-pencil{title: 'Edit'}
   .panel-body{id: 'gardens_panel_body'}
     .row
@@ -22,7 +22,7 @@
           %dt Area : 
           %dd= garden.area.nil? ? 'not specified' : pluralize(garden.area, garden.area_unit)
           %dt Active? :       
-          %dd= garden.active ? "Yes" : "No"
+          %dd= garden.active ? 'Yes' : 'No'
       .col-md-12
         %b
           = "#{pluralize(garden.plantings.size, "Planting")} : "

--- a/app/views/gardens/_thumbnail.html.haml
+++ b/app/views/gardens/_thumbnail.html.haml
@@ -4,8 +4,8 @@
       = link_to "#{garden.owner.login_name}'s garden", garden.owner
       - if can? :edit, garden
         %a.pull-right{href: edit_garden_path(garden), role: "button", id: "edit_garden_glyphicon"}
-          %span.glyphicon.glyphicon-pencil{title: "Edit"}
-  .panel-body{id: "gardens_panel_body"}
+          %span.glyphicon.glyphicon-pencil{title: 'Edit'}
+  .panel-body{id: 'gardens_panel_body'}
     .row
       .col-md-4
         = link_to image_tag((garden.default_photo ?  garden.default_photo.thumbnail_url : 'placeholder_150.png'), alt: garden.name, class: 'img'), garden
@@ -18,9 +18,9 @@
             - if garden.location.blank?
               not specified
             - else
-              = link_to garden.location, place_path(garden.location, anchor: "gardens")
+              = link_to garden.location, place_path(garden.location, anchor: 'gardens')
           %dt Area : 
-          %dd= garden.area.nil? ? "not specified" : pluralize(garden.area, garden.area_unit)
+          %dd= garden.area.nil? ? 'not specified' : pluralize(garden.area, garden.area_unit)
           %dt Active? :       
           %dd= garden.active ? "Yes" : "No"
       .col-md-12
@@ -29,7 +29,7 @@
         = display_garden_plantings(garden.plantings.current)
         - if garden.plantings.size > 2
           %br
-          = link_to "See more plantings >>", garden_path(garden)
+          = link_to 'See more plantings >>', garden_path(garden)
   .panel-footer
     %dt Description
     %dd

--- a/app/views/gardens/edit.html.haml
+++ b/app/views/gardens/edit.html.haml
@@ -1,3 +1,3 @@
-= content_for :title, "Edit garden"
+= content_for :title, 'Edit garden'
 
-= render "form"
+= render 'form'

--- a/app/views/gardens/index.html.haml
+++ b/app/views/gardens/index.html.haml
@@ -5,14 +5,14 @@
     - if @owner
       %p
         - if @owner == current_member
-          = link_to 'Add a garden', new_garden_path, :class => 'btn btn-primary'
-        = link_to "View everyone's gardens", gardens_path, :class => 'btn btn-default'
+          = link_to 'Add a garden', new_garden_path, class: 'btn btn-primary'
+        = link_to "View everyone's gardens", gardens_path, class: 'btn btn-default'
     - else # everyone's gardens
-      = link_to 'Add a garden', new_garden_path, :class => 'btn btn-primary'
+      = link_to 'Add a garden', new_garden_path, class: 'btn btn-primary'
       - if current_member
-        = link_to 'View your gardens', gardens_by_owner_path(:owner => current_member.slug), :class => 'btn btn-default'
+        = link_to 'View your gardens', gardens_by_owner_path(owner: current_member.slug), class: 'btn btn-default'
   - else
-    = render :partial => 'shared/signin_signup', :locals => { :to => 'add a new garden' }
+    = render partial: 'shared/signin_signup', locals: { to: 'add a new garden' }
 
 %div.pagination
   = page_entries_info @gardens
@@ -22,7 +22,7 @@
   - if @gardens.size > 0
     - @gardens.each do |garden|
       .col-md-6
-        =render :partial => 'gardens/thumbnail', :locals => {:garden => garden}
+        =render partial: 'gardens/thumbnail', locals: {garden: garden}
   - else
     %p There are no gardens to display.
 

--- a/app/views/gardens/new.html.haml
+++ b/app/views/gardens/new.html.haml
@@ -1,3 +1,3 @@
-- content_for :title, "New garden"
+- content_for :title, 'New garden'
 
 = render 'form'

--- a/app/views/gardens/show.html.haml
+++ b/app/views/gardens/show.html.haml
@@ -6,16 +6,16 @@
       %p.btn-group
         - if can? :edit, @garden
           - if @garden.active
-            = link_to "Plant something", new_planting_path(:garden_id => @garden.id), :class => 'btn btn-primary'
-            = link_to "Mark as inactive", garden_path(@garden, :garden => {:active => 0}), |
-              :method => :put, :class => 'btn btn-default', |
+            = link_to "Plant something", new_planting_path(garden_id: @garden.id), class: 'btn btn-primary'
+            = link_to "Mark as inactive", garden_path(@garden, garden: {active: 0}), |
+              method: :put, class: 'btn btn-default', |
               data: { confirm: 'All plantings associated with this garden will be marked as finished. Are you sure?' }
           - else
-            = link_to "Mark as active", garden_path(@garden, :garden => {:active => 1}),  :method => :put, :class => 'btn btn-default'
-          = link_to 'Edit garden', edit_garden_path(@garden), :class => 'btn btn-default'
+            = link_to "Mark as active", garden_path(@garden, garden: {active: 1}),  method: :put, class: 'btn btn-default'
+          = link_to 'Edit garden', edit_garden_path(@garden), class: 'btn btn-default'
         - if can? :destroy, @garden
           = link_to 'Delete garden', @garden, method: :delete, |
-            data: { confirm: 'All plantings associated with this garden will also be deleted. Are you sure?' }, :class => 'btn btn-default'
+            data: { confirm: 'All plantings associated with this garden will also be deleted. Are you sure?' }, class: 'btn btn-default'
 
     - if ! @garden.active
       .alert.alert-warning
@@ -44,17 +44,17 @@
           %ul.thumbnails
             - @garden.photos.each do |p|
               .col-md-2.six-across
-                = render :partial => 'photos/thumbnail', :locals => { :photo => p }
+                = render partial: 'photos/thumbnail', locals: { photo: p }
         .row-fluid
           - if can? :create, Photo and can? :edit, @garden
             %p
-              = link_to "Add photo", new_photo_path(:type => "garden", :id => @garden.id), :class => 'btn btn-primary'
+              = link_to "Add photo", new_photo_path(type: "garden", id: @garden.id), class: 'btn btn-primary'
 
     .row-fluid
       %h3 What's planted here?
       - if @garden.plantings.current.size > 0
         - @garden.plantings.current.each.with_index do |planting_current, index_current|
-          = render partial: "plantings/thumbnail", locals: {:planting => planting_current}
+          = render partial: "plantings/thumbnail", locals: {planting: planting_current}
       - else
         %p
           Nothing is currently planted here.
@@ -63,7 +63,7 @@
       %h3 Previously planted in this garden
       - if @garden.plantings.finished.size > 0
         - @garden.plantings.finished.each.with_index do |planting_finished|
-          = render partial: "plantings/thumbnail", locals: {:planting => planting_finished}
+          = render partial: "plantings/thumbnail", locals: {planting: planting_finished}
       - else
         %p
           Nothing has been planted here.
@@ -101,4 +101,4 @@
               = link_to "#{othergarden}", garden_path(othergarden)
 
     - if can? :create, @garden
-      = link_to 'Add New Garden', new_garden_path, :class => 'btn btn-default btn-xs'
+      = link_to 'Add New Garden', new_garden_path, class: 'btn btn-default btn-xs'

--- a/app/views/gardens/show.html.haml
+++ b/app/views/gardens/show.html.haml
@@ -6,12 +6,12 @@
       %p.btn-group
         - if can? :edit, @garden
           - if @garden.active
-            = link_to "Plant something", new_planting_path(garden_id: @garden.id), class: 'btn btn-primary'
-            = link_to "Mark as inactive", garden_path(@garden, garden: {active: 0}), |
+            = link_to 'Plant something', new_planting_path(garden_id: @garden.id), class: 'btn btn-primary'
+            = link_to 'Mark as inactive', garden_path(@garden, garden: {active: 0}), |
               method: :put, class: 'btn btn-default', |
               data: { confirm: 'All plantings associated with this garden will be marked as finished. Are you sure?' }
           - else
-            = link_to "Mark as active", garden_path(@garden, garden: {active: 1}),  method: :put, class: 'btn btn-default'
+            = link_to 'Mark as active', garden_path(@garden, garden: {active: 1}),  method: :put, class: 'btn btn-default'
           = link_to 'Edit garden', edit_garden_path(@garden), class: 'btn btn-default'
         - if can? :destroy, @garden
           = link_to 'Delete garden', @garden, method: :delete, |
@@ -39,7 +39,7 @@
     - if @garden.photos.size > 0 or (can? :edit, @garden and can? :create, Photo)
       .row-fluid
         %h3 Photos
-        %p= pluralize(@garden.photos.length, "photo")
+        %p= pluralize(@garden.photos.length, 'photo')
         .row-fluid
           %ul.thumbnails
             - @garden.photos.each do |p|
@@ -54,7 +54,7 @@
       %h3 What's planted here?
       - if @garden.plantings.current.size > 0
         - @garden.plantings.current.each.with_index do |planting_current, index_current|
-          = render partial: "plantings/thumbnail", locals: {planting: planting_current}
+          = render partial: 'plantings/thumbnail', locals: {planting: planting_current}
       - else
         %p
           Nothing is currently planted here.
@@ -63,7 +63,7 @@
       %h3 Previously planted in this garden
       - if @garden.plantings.finished.size > 0
         - @garden.plantings.finished.each.with_index do |planting_finished|
-          = render partial: "plantings/thumbnail", locals: {planting: planting_finished}
+          = render partial: 'plantings/thumbnail', locals: {planting: planting_finished}
       - else
         %p
           Nothing has been planted here.
@@ -91,7 +91,7 @@
             = link_to "#{othergarden}", garden_path(othergarden)
 
     - if @garden.owner.gardens.inactive.size > 0
-      %h4= "Inactive gardens"
+      %h4= 'Inactive gardens'
       %ul
         - @garden.owner.gardens.inactive.each do |othergarden|
           %li

--- a/app/views/gardens/show.html.haml
+++ b/app/views/gardens/show.html.haml
@@ -48,7 +48,7 @@
         .row-fluid
           - if can? :create, Photo and can? :edit, @garden
             %p
-              = link_to "Add photo", new_photo_path(type: "garden", id: @garden.id), class: 'btn btn-primary'
+              = link_to 'Add photo', new_photo_path(type: 'garden', id: @garden.id), class: 'btn btn-primary'
 
     .row-fluid
       %h3 What's planted here?

--- a/app/views/harvests/_form.html.haml
+++ b/app/views/harvests/_form.html.haml
@@ -1,6 +1,6 @@
 = required_field_help_text
 
-= form_for(@harvest, :html => {:class => "form-horizontal", :role => :form}) do |f|
+= form_for(@harvest, html: {class: "form-horizontal", role: :form}) do |f|
   - if @harvest.errors.any?
     #error_explanation
       %h2= "#{pluralize(@harvest.errors.size, "error")} prohibited this harvest from being saved:"
@@ -9,42 +9,42 @@
           %li= msg
 
   .form-group.required
-    = f.label :crop, 'What did you harvest?', :class => 'control-label col-md-2'
+    = f.label :crop, 'What did you harvest?', class: 'control-label col-md-2'
     .col-md-4
-      = auto_suggest @harvest, :crop, :class => 'form-control col-md-2', :default => @crop
+      = auto_suggest @harvest, :crop, class: 'form-control col-md-2', default: @crop
     .col-md-4
-      = collection_select(:harvest, :plant_part_id, PlantPart.all, :id, :name, { :selected => @harvest.plant_part_id }, { :class => 'form-control', :prompt => 'e.g. fruit', :required => "required" })
+      = collection_select(:harvest, :plant_part_id, PlantPart.all, :id, :name, { selected: @harvest.plant_part_id }, { class: 'form-control', prompt: 'e.g. fruit', required: "required" })
     %span.help-block.col-md-8
       Can't find what you're looking for?
       = link_to "Request new crops.", new_crop_path
 
   .form-group
-    = f.label :harvested_at, 'When?', :class => 'control-label col-md-2', :placeholder => 'optional'
+    = f.label :harvested_at, 'When?', class: 'control-label col-md-2', placeholder: 'optional'
     .col-md-2
-      = f.text_field :harvested_at, :value => @harvest.harvested_at ? @harvest.harvested_at.to_s(:ymd) : '', :class => 'add-datepicker form-control'
+      = f.text_field :harvested_at, value: @harvest.harvested_at ? @harvest.harvested_at.to_s(:ymd) : '', class: 'add-datepicker form-control'
 
   .form-group
-    = f.label :quantity, 'How many?', :class => 'control-label col-md-2'
+    = f.label :quantity, 'How many?', class: 'control-label col-md-2'
     .col-md-2
       -# Some browsers (eg Firefox for Android) assume "number" means
       -# "integer" unless you specify step="any":
       -# http://blog.isotoma.com/2012/03/html5-input-typenumber-and-decimalsfloats-in-chrome/
-      = f.number_field :quantity, :class => 'input-small form-control', :step => 'any', :placeholder => 'optional'
+      = f.number_field :quantity, class: 'input-small form-control', step: 'any', placeholder: 'optional'
     .col-md-2
-      = f.select(:unit, Harvest::UNITS_VALUES, {:include_blank => false}, :class => 'input-medium form-control')
+      = f.select(:unit, Harvest::UNITS_VALUES, {include_blank: false}, class: 'input-medium form-control')
 
   .form-group
-    = f.label :weight_quantity, 'Weighing (in total):', :class => 'control-label col-md-2'
+    = f.label :weight_quantity, 'Weighing (in total):', class: 'control-label col-md-2'
     .col-md-2
-      = f.number_field :weight_quantity, :class => 'input-small form-control', :step => 'any', :placeholder => 'optional'
+      = f.number_field :weight_quantity, class: 'input-small form-control', step: 'any', placeholder: 'optional'
     .col-md-2
-      = f.select(:weight_unit, Harvest::WEIGHT_UNITS_VALUES, {:include_blank => false}, :class => 'form-control')
+      = f.select(:weight_unit, Harvest::WEIGHT_UNITS_VALUES, {include_blank: false}, class: 'form-control')
   .form-group
-    = f.label :description, 'Notes', :class => 'control-label col-md-2'
+    = f.label :description, 'Notes', class: 'control-label col-md-2'
     .col-md-8
-      = f.text_area :description, :rows => 6, :class => 'form-control', :placeholder => 'optional'
+      = f.text_area :description, rows: 6, class: 'form-control', placeholder: 'optional'
 
   .form-group
     .form-actions.col-md-offset-2.col-md-8
-      = f.submit 'Save', :class => 'btn btn-primary'
+      = f.submit 'Save', class: 'btn btn-primary'
 

--- a/app/views/harvests/_form.html.haml
+++ b/app/views/harvests/_form.html.haml
@@ -1,6 +1,6 @@
 = required_field_help_text
 
-= form_for(@harvest, html: {class: "form-horizontal", role: :form}) do |f|
+= form_for(@harvest, html: {class: 'form-horizontal', role: :form}) do |f|
   - if @harvest.errors.any?
     #error_explanation
       %h2= "#{pluralize(@harvest.errors.size, "error")} prohibited this harvest from being saved:"
@@ -13,10 +13,10 @@
     .col-md-4
       = auto_suggest @harvest, :crop, class: 'form-control col-md-2', default: @crop
     .col-md-4
-      = collection_select(:harvest, :plant_part_id, PlantPart.all, :id, :name, { selected: @harvest.plant_part_id }, { class: 'form-control', prompt: 'e.g. fruit', required: "required" })
+      = collection_select(:harvest, :plant_part_id, PlantPart.all, :id, :name, { selected: @harvest.plant_part_id }, { class: 'form-control', prompt: 'e.g. fruit', required: 'required' })
     %span.help-block.col-md-8
       Can't find what you're looking for?
-      = link_to "Request new crops.", new_crop_path
+      = link_to 'Request new crops.', new_crop_path
 
   .form-group
     = f.label :harvested_at, 'When?', class: 'control-label col-md-2', placeholder: 'optional'

--- a/app/views/harvests/_thumbnail.html.haml
+++ b/app/views/harvests/_thumbnail.html.haml
@@ -3,12 +3,12 @@
     %h3.panel-title
       = link_to "#{harvest.owner.login_name}'s harvest", harvest.owner
       - if can? :edit, harvest
-        %a.pull-right{:href => edit_harvest_path(harvest), :role => "button", :id => "edit_harvest_glyphicon"}
-          %span.glyphicon.glyphicon-pencil{:title => "Edit"}
+        %a.pull-right{href: edit_harvest_path(harvest), role: "button", id: "edit_harvest_glyphicon"}
+          %span.glyphicon.glyphicon-pencil{title: "Edit"}
   .panel-body
     .row
       .col-md-4
-        = link_to image_tag((harvest.crop.default_photo ?  harvest.crop.default_photo.thumbnail_url : 'placeholder_150.png'), :alt => harvest.crop.name, :class => 'img'), harvest.crop
+        = link_to image_tag((harvest.crop.default_photo ?  harvest.crop.default_photo.thumbnail_url : 'placeholder_150.png'), alt: harvest.crop.name, class: 'img'), harvest.crop
       .col-md-8
         %dl.dl-horizontal
           %dt Crop : 

--- a/app/views/harvests/_thumbnail.html.haml
+++ b/app/views/harvests/_thumbnail.html.haml
@@ -3,7 +3,7 @@
     %h3.panel-title
       = link_to "#{harvest.owner.login_name}'s harvest", harvest.owner
       - if can? :edit, harvest
-        %a.pull-right{href: edit_harvest_path(harvest), role: "button", id: "edit_harvest_glyphicon"}
+        %a.pull-right{href: edit_harvest_path(harvest), role: 'button', id: 'edit_harvest_glyphicon'}
           %span.glyphicon.glyphicon-pencil{title: 'Edit'}
   .panel-body
     .row

--- a/app/views/harvests/_thumbnail.html.haml
+++ b/app/views/harvests/_thumbnail.html.haml
@@ -4,7 +4,7 @@
       = link_to "#{harvest.owner.login_name}'s harvest", harvest.owner
       - if can? :edit, harvest
         %a.pull-right{href: edit_harvest_path(harvest), role: "button", id: "edit_harvest_glyphicon"}
-          %span.glyphicon.glyphicon-pencil{title: "Edit"}
+          %span.glyphicon.glyphicon-pencil{title: 'Edit'}
   .panel-body
     .row
       .col-md-4
@@ -24,4 +24,4 @@
     %dd.truncate
       = display_harvest_description(harvest)
     = if not harvest.description.empty?
-      - link_to "Read more", harvest_path(harvest)
+      - link_to 'Read more', harvest_path(harvest)

--- a/app/views/harvests/edit.html.haml
+++ b/app/views/harvests/edit.html.haml
@@ -1,4 +1,4 @@
-- content_for :title, "Editing harvest"
+- content_for :title, 'Editing harvest'
 
 = render 'form'
 

--- a/app/views/harvests/index.html.haml
+++ b/app/views/harvests/index.html.haml
@@ -36,8 +36,8 @@
   %ul.list-inline
     %li The data on this page is available in the following formats:
     - if @owner
-      %li= link_to "CSV", harvests_by_owner_path(@owner, format: 'csv')
-      %li= link_to "JSON", harvests_by_owner_path(@owner, format: 'json')
+      %li= link_to 'CSV', harvests_by_owner_path(@owner, format: 'csv')
+      %li= link_to 'JSON', harvests_by_owner_path(@owner, format: 'json')
     - else
-      %li= link_to "CSV", harvests_path(format: 'csv')
-      %li= link_to "JSON", harvests_path(format: 'json')
+      %li= link_to 'CSV', harvests_path(format: 'csv')
+      %li= link_to 'JSON', harvests_path(format: 'json')

--- a/app/views/harvests/index.html.haml
+++ b/app/views/harvests/index.html.haml
@@ -11,14 +11,14 @@
     - if @owner
       %p
         - if @owner == current_member
-          = link_to 'Add harvest', new_harvest_path, :class => 'btn btn-primary'
-        = link_to "View everyone's harvests", harvests_path, :class => 'btn btn-default'
+          = link_to 'Add harvest', new_harvest_path, class: 'btn btn-primary'
+        = link_to "View everyone's harvests", harvests_path, class: 'btn btn-default'
     - else # everyone's harvests
-      = link_to 'Add harvest', new_harvest_path, :class => 'btn btn-primary'
+      = link_to 'Add harvest', new_harvest_path, class: 'btn btn-primary'
       - if current_member
-        = link_to 'View your harvests', harvests_by_owner_path(:owner => current_member.slug), :class => 'btn btn-default'
+        = link_to 'View your harvests', harvests_by_owner_path(owner: current_member.slug), class: 'btn btn-default'
   - else
-    = render :partial => 'shared/signin_signup', :locals => { :to => 'track your harvests' }
+    = render partial: 'shared/signin_signup', locals: { to: 'track your harvests' }
 
 %div.pagination
   = page_entries_info @harvests
@@ -27,7 +27,7 @@
   - if @harvests.size > 0
     - @harvests.each do |harvest|
       .col-md-6
-        =render :partial => 'harvests/thumbnail', :locals => {:harvest => harvest}
+        =render partial: 'harvests/thumbnail', locals: {harvest: harvest}
 
 %div.pagination
   = page_entries_info @harvests
@@ -36,8 +36,8 @@
   %ul.list-inline
     %li The data on this page is available in the following formats:
     - if @owner
-      %li= link_to "CSV", harvests_by_owner_path(@owner, :format => 'csv')
-      %li= link_to "JSON", harvests_by_owner_path(@owner, :format => 'json')
+      %li= link_to "CSV", harvests_by_owner_path(@owner, format: 'csv')
+      %li= link_to "JSON", harvests_by_owner_path(@owner, format: 'json')
     - else
-      %li= link_to "CSV", harvests_path(:format => 'csv')
-      %li= link_to "JSON", harvests_path(:format => 'json')
+      %li= link_to "CSV", harvests_path(format: 'csv')
+      %li= link_to "JSON", harvests_path(format: 'json')

--- a/app/views/harvests/new.html.haml
+++ b/app/views/harvests/new.html.haml
@@ -1,3 +1,3 @@
-- content_for :title, "New Harvest"
+- content_for :title, 'New Harvest'
 
 = render 'form'

--- a/app/views/harvests/show.html.haml
+++ b/app/views/harvests/show.html.haml
@@ -33,7 +33,7 @@
 %h2 Notes
 
 :growstuff_markdown
-  #{ @harvest.description != "" ? @harvest.description : "No description given." }
+  #{ @harvest.description != '' ? @harvest.description : 'No description given.' }
 
 - if @harvest.photos.size > 0 or (can? :edit, @harvest and can? :create, Photo)
   %h2 Pictures
@@ -46,4 +46,4 @@
       .col-md-2
         .thumbnail(style='height: 220px')
           %p{style: 'text-align: center; padding-top: 50px'}
-            = link_to "Add photo", new_photo_path(type: "harvest", id: @harvest.id), class: 'btn btn-primary'
+            = link_to 'Add photo', new_photo_path(type: 'harvest', id: @harvest.id), class: 'btn btn-primary'

--- a/app/views/harvests/show.html.haml
+++ b/app/views/harvests/show.html.haml
@@ -15,7 +15,7 @@
         not specified
     %p
       %b Harvested:
-      = @harvest.harvested_at ? @harvest.harvested_at : "not specified"
+      = @harvest.harvested_at ? @harvest.harvested_at : 'not specified'
     %p
       %b Quantity:
       = display_quantity(@harvest)
@@ -28,7 +28,7 @@
         =link_to 'Delete', @harvest, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-default btn-xs'
 
   .col-md-6
-    = render partial: "crops/index_card", locals: { crop: @harvest.crop}
+    = render partial: 'crops/index_card', locals: { crop: @harvest.crop}
 
 %h2 Notes
 

--- a/app/views/harvests/show.html.haml
+++ b/app/views/harvests/show.html.haml
@@ -6,7 +6,7 @@
       %b Owner:
       = link_to @harvest.owner, @harvest.owner
       &mdash;
-      = link_to "view all #{@harvest.owner}'s harvests", harvests_by_owner_path(:owner => @harvest.owner.slug)
+      = link_to "view all #{@harvest.owner}'s harvests", harvests_by_owner_path(owner: @harvest.owner.slug)
     %p
       %b Plant part:
       - if @harvest.plant_part 
@@ -23,12 +23,12 @@
     - if can? :edit, @harvest or can? :destroy, @harvest
       %p
       - if can? :edit, @harvest
-        =link_to 'Edit', edit_harvest_path(@harvest), :class => 'btn btn-default btn-xs'
+        =link_to 'Edit', edit_harvest_path(@harvest), class: 'btn btn-default btn-xs'
       - if can? :destroy, @harvest
-        =link_to 'Delete', @harvest, method: :delete, data: { confirm: 'Are you sure?' }, :class => 'btn btn-default btn-xs'
+        =link_to 'Delete', @harvest, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-default btn-xs'
 
   .col-md-6
-    = render :partial => "crops/index_card", :locals => { :crop => @harvest.crop}
+    = render partial: "crops/index_card", locals: { crop: @harvest.crop}
 
 %h2 Notes
 
@@ -41,9 +41,9 @@
   %ul.thumbnails
     - @harvest.photos.each do |p|
       .col-md-2.six-across
-        = render :partial => 'photos/thumbnail', :locals => { :photo => p }
+        = render partial: 'photos/thumbnail', locals: { photo: p }
     - if can? :create, Photo and can? :edit, @harvest
       .col-md-2
         .thumbnail(style='height: 220px')
-          %p{:style => 'text-align: center; padding-top: 50px'}
-            = link_to "Add photo", new_photo_path(:type => "harvest", :id => @harvest.id), :class => 'btn btn-primary'
+          %p{style: 'text-align: center; padding-top: 50px'}
+            = link_to "Add photo", new_photo_path(type: "harvest", id: @harvest.id), class: 'btn btn-primary'

--- a/app/views/home/_blurb.html.haml
+++ b/app/views/home/_blurb.html.haml
@@ -6,10 +6,10 @@
   .col-md-8.info
     %p= t('.intro', site_name: ENV['GROWSTUFF_SITE_NAME'])
 
-    = render :partial => 'stats'
+    = render partial: 'stats'
   .col-md-4.signup
     %p= t('.perks')
-    %p= link_to(t('.sign_up'), new_member_registration_path, :class => 'btn btn-primary btn-lg')
+    %p= link_to(t('.sign_up'), new_member_registration_path, class: 'btn btn-primary btn-lg')
     %p
       %small
         = t('.already_html', sign_in: link_to(t('.sign_in_linktext'), new_member_session_path))

--- a/app/views/home/_crops.html.haml
+++ b/app/views/home/_crops.html.haml
@@ -1,25 +1,25 @@
 .row
   .col-md-8
-    - cache cache_key_for(Crop, 'interesting'), :expires_in => 1.day do
+    - cache cache_key_for(Crop, 'interesting'), expires_in: 1.day do
       %h2= t('.our_crops')
       .hidden-xs
         - Crop.interesting.first(8).each do |c|
           .col-md-3
-            = render :partial => 'crops/thumbnail', :locals => { :crop => c }
+            = render partial: 'crops/thumbnail', locals: { crop: c }
       .visible-xs
         - Crop.interesting.first(3).each do |c|
           .col-md-3
-            = render :partial => 'crops/thumbnail', :locals => { :crop => c }
+            = render partial: 'crops/thumbnail', locals: { crop: c }
 
   .col-md-4.hidden-xs
     - cache cache_key_for(Planting) do
       %h2= t('.recently_planted')
-      = render :partial => 'plantings/list', :locals => { :plantings => Planting.interesting.first(6) }
+      = render partial: 'plantings/list', locals: { plantings: Planting.interesting.first(6) }
 
 .row
   .col-md-12
     - cache cache_key_for(Crop, 'recent') do
-      %p{ :style => 'margin-top: 11.25px' }
+      %p{ style: 'margin-top: 11.25px' }
         %strong
           #{t('.recently_added')}:
         != Crop.recent.limit(12).map {|c| link_to(c, c) }.join(", ")

--- a/app/views/home/_crops.html.haml
+++ b/app/views/home/_crops.html.haml
@@ -22,7 +22,7 @@
       %p{ style: 'margin-top: 11.25px' }
         %strong
           #{t('.recently_added')}:
-        != Crop.recent.limit(12).map {|c| link_to(c, c) }.join(", ")
+        != Crop.recent.limit(12).map {|c| link_to(c, c) }.join(', ')
 
     %p.text-right
       =link_to "#{t('.view_all')} »", crops_path

--- a/app/views/home/_discuss.html.haml
+++ b/app/views/home/_discuss.html.haml
@@ -2,7 +2,7 @@
 
 - posts = Post.limit(6)
 - if posts
-  =render :partial => "posts/summary", :locals => { :posts => posts, :howmany => 6 }
+  =render partial: "posts/summary", locals: { posts: posts, howmany: 6 }
 
 - cache cache_key_for(Forum) do
   - forums = Forum.all

--- a/app/views/home/_discuss.html.haml
+++ b/app/views/home/_discuss.html.haml
@@ -2,7 +2,7 @@
 
 - posts = Post.limit(6)
 - if posts
-  =render partial: "posts/summary", locals: { posts: posts, howmany: 6 }
+  =render partial: 'posts/summary', locals: { posts: posts, howmany: 6 }
 
 - cache cache_key_for(Forum) do
   - forums = Forum.all

--- a/app/views/home/_members.html.haml
+++ b/app/views/home/_members.html.haml
@@ -7,7 +7,7 @@
 
       .member-cards
         - members.each do |m|
-          = render partial: "members/thumbnail", locals: { member: m }
+          = render partial: 'members/thumbnail', locals: { member: m }
 
       %p.text-right
         = link_to "#{t('.view_all')} »", members_path

--- a/app/views/home/_members.html.haml
+++ b/app/views/home/_members.html.haml
@@ -7,7 +7,7 @@
 
       .member-cards
         - members.each do |m|
-          = render :partial => "members/thumbnail", :locals => { :member => m }
+          = render partial: "members/thumbnail", locals: { member: m }
 
       %p.text-right
         = link_to "#{t('.view_all')} »", members_path

--- a/app/views/home/_seeds.html.haml
+++ b/app/views/home/_seeds.html.haml
@@ -19,12 +19,12 @@
           %tr
             %td= link_to seed.owner.login_name, seed.owner
             %td= link_to seed.crop.name, seed.crop
-            %td.hidden-xs.hidden-sm= truncate(seed.description, :length => 40, :separator => ' ')
+            %td.hidden-xs.hidden-sm= truncate(seed.description, length: 40, separator: ' ')
             %td= seed.tradable? ? seed.tradable_to : ''
             %td
               - if seed.tradable?
-                = seed.owner.location.blank? ? t('.unspecified') : truncate(seed.owner.location, :length => 25, :separator => ', ')
-            %td= link_to t('.details'), seed, :class => 'btn btn-default btn-xs'
+                = seed.owner.location.blank? ? t('.unspecified') : truncate(seed.owner.location, length: 25, separator: ', ')
+            %td= link_to t('.details'), seed, class: 'btn btn-default btn-xs'
 
   %p.text-right
     = link_to "#{t('.view_all')} »", seeds_path

--- a/app/views/home/_stats.html.haml
+++ b/app/views/home/_stats.html.haml
@@ -1,4 +1,4 @@
-- cache("homepage_stats") do
+- cache('homepage_stats') do
   %p.stats
     = t('.message_html', { member: link_to(t('.member_linktext', count: Member.confirmed.size.to_i), members_path),
                            number_crops: link_to(t('.number_crops_linktext', count: Crop.count.to_i), crops_path),

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -3,23 +3,23 @@
     - if member_signed_in?
       %h1= t('.welcome', site_name: ENV['GROWSTUFF_SITE_NAME'], member_name: current_member)
 
-      = render :partial => 'stats'
+      = render partial: 'stats'
       %p
         .btn-group
-          = link_to t('.plant'), new_planting_path, :class => 'btn btn-default'
-          = link_to t('.harvest'), new_harvest_path, :class => 'btn btn-default'
-          = link_to t('.add_seeds'), new_seed_path, :class => 'btn btn-default'
-          = link_to t('.post'), new_post_path, :class => 'btn btn-default'
+          = link_to t('.plant'), new_planting_path, class: 'btn btn-default'
+          = link_to t('.harvest'), new_harvest_path, class: 'btn btn-default'
+          = link_to t('.add_seeds'), new_seed_path, class: 'btn btn-default'
+          = link_to t('.post'), new_post_path, class: 'btn btn-default'
 
     - else
       .hidden-xs
         .jumbotron
-          = render :partial => 'blurb'
+          = render partial: 'blurb'
       .visible-xs
-        = render :partial => 'blurb'
+        = render partial: 'blurb'
 
-    = render :partial => 'crops'
-    = render :partial => 'seeds'
-    = render :partial => 'members'
-    = render :partial => 'discuss'
+    = render partial: 'crops'
+    = render partial: 'seeds'
+    = render partial: 'members'
+    = render partial: 'discuss'
 

--- a/app/views/layouts/_crowdfunding.html.haml
+++ b/app/views/layouts/_crowdfunding.html.haml
@@ -2,6 +2,6 @@
 - if daysleft > 0
   .crowdfunding-banner
     Help us share free growing information with the world.
-    = link_to "Support our crowdfunding campaign.", "https://www.indiegogo.com/projects/growstuff/x/6079859"
+    = link_to 'Support our crowdfunding campaign.', 'https://www.indiegogo.com/projects/growstuff/x/6079859'
     There are only #{daysleft.to_i} days left.
 

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -9,17 +9,17 @@
         %span.icon-bar
         %span.icon-bar
       %a.navbar-brand(href=root_path)
-        = image_tag("growstuff-brand.png", :size => "200x50", :alt => ENV['GROWSTUFF_SITE_NAME'])
-      = form_tag crops_search_path, :method => :get, :id => 'navbar-search', :class => 'navbar-form pull-right' do
+        = image_tag("growstuff-brand.png", size: "200x50", alt: ENV['GROWSTUFF_SITE_NAME'])
+      = form_tag crops_search_path, method: :get, id: 'navbar-search', class: 'navbar-form pull-right' do
         .input
-          = label_tag :term, "Search crop database:", :class => 'sr-only'
-          = text_field_tag 'term', nil, :class => 'search-query input-medium form-control', :placeholder => 'Search crops'
-          = submit_tag "Search", :class => 'btn sr-only'
+          = label_tag :term, "Search crop database:", class: 'sr-only'
+          = text_field_tag 'term', nil, class: 'search-query input-medium form-control', placeholder: 'Search crops'
+          = submit_tag "Search", class: 'btn sr-only'
 
     .navbar-collapse.collapse#navbar-collapse
       %ul.nav.navbar-nav.pull-right
         %li.dropdown<
-          %a.dropdown-toggle{'data-toggle' => 'dropdown', :href => crops_path}
+          %a.dropdown-toggle{'data-toggle' => 'dropdown', href: crops_path}
             Crops
             %b.caret
           %ul.dropdown-menu
@@ -28,7 +28,7 @@
             %li= link_to t('.plantings'), plantings_path
             %li= link_to t('.harvests'), harvests_path
         %li.dropdown<
-          %a.dropdown-toggle{'data-toggle' => 'dropdown', :href => members_path}
+          %a.dropdown-toggle{'data-toggle' => 'dropdown', href: members_path}
             Community
             %b.caret
           %ul.dropdown-menu
@@ -40,7 +40,7 @@
 
         - if member_signed_in?
           %li.dropdown<
-            %a.dropdown-toggle{'data-toggle' => 'dropdown', :href => root_path}
+            %a.dropdown-toggle{'data-toggle' => 'dropdown', href: root_path}
               - if current_member.notifications.unread_count > 0
                 = t('.your_stuff', unread_count: current_member.notifications.unread_count)
               - else
@@ -48,11 +48,11 @@
               %b.caret
             %ul.dropdown-menu
               %li= link_to t('.profile'), member_path(current_member)
-              %li= link_to t('.gardens'), gardens_by_owner_path(:owner => current_member.slug)
-              %li= link_to t('.plantings'), plantings_by_owner_path(:owner => current_member.slug)
-              %li= link_to t('.harvest'), harvests_by_owner_path(:owner => current_member.slug)
-              %li= link_to t('.seeds'), seeds_by_owner_path(:owner => current_member.slug)
-              %li= link_to t('.posts'), posts_by_author_path(:author => current_member.slug)
+              %li= link_to t('.gardens'), gardens_by_owner_path(owner: current_member.slug)
+              %li= link_to t('.plantings'), plantings_by_owner_path(owner: current_member.slug)
+              %li= link_to t('.harvest'), harvests_by_owner_path(owner: current_member.slug)
+              %li= link_to t('.seeds'), seeds_by_owner_path(owner: current_member.slug)
+              %li= link_to t('.posts'), posts_by_author_path(author: current_member.slug)
               %li= link_to t('.account'), orders_path
               %li
                 - if current_member.notifications.unread_count > 0
@@ -60,19 +60,19 @@
                 - else
                   = link_to(t('.inbox'), notifications_path)
               - if current_member.has_role?(:crop_wrangler) || current_member.has_role?(:admin)
-                %li{:class => 'divider', :role => 'presentation'}
+                %li{class: 'divider', role: 'presentation'}
                 - if current_member.has_role?(:crop_wrangler)
                   %li= link_to t('.crop_wrangling'), wrangle_crops_path
                 - if current_member.has_role?(:admin)
                   %li= link_to t('.admin'), admin_path
 
 
-          %li= link_to "Sign out", destroy_member_session_path, :method => :delete
+          %li= link_to "Sign out", destroy_member_session_path, method: :delete
 
         - else
-          %li= link_to 'Sign in', new_member_session_path, :id => 'navbar-signin'
-          %li= link_to 'Sign up', new_member_registration_path, :id => 'navbar-signup'
+          %li= link_to 'Sign in', new_member_session_path, id: 'navbar-signin'
+          %li= link_to 'Sign up', new_member_registration_path, id: 'navbar-signup'
 
 
 - # anchor tag for accessibility link to skip the navigation menu
-%a{:name => 'skipnav'}
+%a{name: 'skipnav'}

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -1,9 +1,9 @@
 .sr-only
   =link_to t('.skip'), '#skipnav'
-.navbar.navbar-default.navbar-fixed-top(role="navigation")
+.navbar.navbar-default.navbar-fixed-top(role='navigation')
   .container
     .navbar-header
-      %button.navbar-toggle(data-target="#navbar-collapse" data-toggle="collapse")
+      %button.navbar-toggle(data-target='#navbar-collapse' data-toggle='collapse')
         %span.sr-only Toggle Navigation
         %span.icon-bar
         %span.icon-bar

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -12,9 +12,9 @@
         = image_tag("growstuff-brand.png", size: "200x50", alt: ENV['GROWSTUFF_SITE_NAME'])
       = form_tag crops_search_path, method: :get, id: 'navbar-search', class: 'navbar-form pull-right' do
         .input
-          = label_tag :term, "Search crop database:", class: 'sr-only'
+          = label_tag :term, 'Search crop database:', class: 'sr-only'
           = text_field_tag 'term', nil, class: 'search-query input-medium form-control', placeholder: 'Search crops'
-          = submit_tag "Search", class: 'btn sr-only'
+          = submit_tag 'Search', class: 'btn sr-only'
 
     .navbar-collapse.collapse#navbar-collapse
       %ul.nav.navbar-nav.pull-right
@@ -67,7 +67,7 @@
                   %li= link_to t('.admin'), admin_path
 
 
-          %li= link_to "Sign out", destroy_member_session_path, method: :delete
+          %li= link_to 'Sign out', destroy_member_session_path, method: :delete
 
         - else
           %li= link_to 'Sign in', new_member_session_path, id: 'navbar-signin'

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -1,5 +1,5 @@
 .sr-only
-  =link_to t(".skip"), "#skipnav"
+  =link_to t('.skip'), '#skipnav'
 .navbar.navbar-default.navbar-fixed-top(role="navigation")
   .container
     .navbar-header
@@ -9,7 +9,7 @@
         %span.icon-bar
         %span.icon-bar
       %a.navbar-brand(href=root_path)
-        = image_tag("growstuff-brand.png", size: "200x50", alt: ENV['GROWSTUFF_SITE_NAME'])
+        = image_tag('growstuff-brand.png', size: '200x50', alt: ENV['GROWSTUFF_SITE_NAME'])
       = form_tag crops_search_path, method: :get, id: 'navbar-search', class: 'navbar-form pull-right' do
         .input
           = label_tag :term, 'Search crop database:', class: 'sr-only'

--- a/app/views/layouts/_meta.html.haml
+++ b/app/views/layouts/_meta.html.haml
@@ -8,10 +8,10 @@
   <meta property="og:site_name" content="#{ENV['GROWSTUFF_SITE_NAME']}" />
 
   - if (content_for?(:member_rss_login_name) && content_for(:member_rss_slug))
-    = auto_discovery_link_tag(:rss, { :controller => "/members", :action => 'show', :format => "rss", :id => yield(:member_rss_slug) }, { :title => "#{ ENV['GROWSTUFF_SITE_NAME'] }- #{yield(:member_rss_login_name)}'s posts" })
-  = auto_discovery_link_tag(:rss, { :controller => "/posts", :format => "rss" }, { :title => "#{ ENV['GROWSTUFF_SITE_NAME'] } - Recent posts from all members" })
-  = auto_discovery_link_tag(:rss, { :controller => "/crops", :format => "rss" }, { :title => "#{ ENV['GROWSTUFF_SITE_NAME'] } - Recently added crops" })
-  = auto_discovery_link_tag(:rss, { :controller => "/plantings", :format => "rss" }, { :title => "#{ ENV['GROWSTUFF_SITE_NAME'] } - Recent plantings from all members" })
+    = auto_discovery_link_tag(:rss, { controller: "/members", action: 'show', format: "rss", id: yield(:member_rss_slug) }, { title: "#{ ENV['GROWSTUFF_SITE_NAME'] }- #{yield(:member_rss_login_name)}'s posts" })
+  = auto_discovery_link_tag(:rss, { controller: "/posts", format: "rss" }, { title: "#{ ENV['GROWSTUFF_SITE_NAME'] } - Recent posts from all members" })
+  = auto_discovery_link_tag(:rss, { controller: "/crops", format: "rss" }, { title: "#{ ENV['GROWSTUFF_SITE_NAME'] } - Recently added crops" })
+  = auto_discovery_link_tag(:rss, { controller: "/plantings", format: "rss" }, { title: "#{ ENV['GROWSTUFF_SITE_NAME'] } - Recent plantings from all members" })
 
   %title
     = content_for?(:title) ? yield(:title) + " - #{ ENV['GROWSTUFF_SITE_NAME']} " : ENV['GROWSTUFF_SITE_NAME']
@@ -19,7 +19,7 @@
   / Le HTML5 shim, for IE6-8 support of HTML elements
   /[if lt IE 9]
     = javascript_include_tag "http://html5shim.googlecode.com/svn/trunk/html5.js"
-  = stylesheet_link_tag "application", :media => "all"
+  = stylesheet_link_tag "application", media: "all"
 
   %link(href="/growstuff-apple-touch-icon-precomposed.png" rel="apple-touch-icon-precomposed")
   = favicon_link_tag 'favicon.ico'

--- a/app/views/layouts/_meta.html.haml
+++ b/app/views/layouts/_meta.html.haml
@@ -8,10 +8,10 @@
   <meta property="og:site_name" content="#{ENV['GROWSTUFF_SITE_NAME']}" />
 
   - if (content_for?(:member_rss_login_name) && content_for(:member_rss_slug))
-    = auto_discovery_link_tag(:rss, { controller: "/members", action: 'show', format: "rss", id: yield(:member_rss_slug) }, { title: "#{ ENV['GROWSTUFF_SITE_NAME'] }- #{yield(:member_rss_login_name)}'s posts" })
-  = auto_discovery_link_tag(:rss, { controller: "/posts", format: "rss" }, { title: "#{ ENV['GROWSTUFF_SITE_NAME'] } - Recent posts from all members" })
-  = auto_discovery_link_tag(:rss, { controller: "/crops", format: "rss" }, { title: "#{ ENV['GROWSTUFF_SITE_NAME'] } - Recently added crops" })
-  = auto_discovery_link_tag(:rss, { controller: "/plantings", format: "rss" }, { title: "#{ ENV['GROWSTUFF_SITE_NAME'] } - Recent plantings from all members" })
+    = auto_discovery_link_tag(:rss, { controller: '/members', action: 'show', format: 'rss', id: yield(:member_rss_slug) }, { title: "#{ ENV['GROWSTUFF_SITE_NAME'] }- #{yield(:member_rss_login_name)}'s posts" })
+  = auto_discovery_link_tag(:rss, { controller: '/posts', format: 'rss' }, { title: "#{ ENV['GROWSTUFF_SITE_NAME'] } - Recent posts from all members" })
+  = auto_discovery_link_tag(:rss, { controller: '/crops', format: 'rss' }, { title: "#{ ENV['GROWSTUFF_SITE_NAME'] } - Recently added crops" })
+  = auto_discovery_link_tag(:rss, { controller: '/plantings', format: 'rss' }, { title: "#{ ENV['GROWSTUFF_SITE_NAME'] } - Recent plantings from all members" })
 
   %title
     = content_for?(:title) ? yield(:title) + " - #{ ENV['GROWSTUFF_SITE_NAME']} " : ENV['GROWSTUFF_SITE_NAME']

--- a/app/views/layouts/_meta.html.haml
+++ b/app/views/layouts/_meta.html.haml
@@ -19,7 +19,7 @@
   / Le HTML5 shim, for IE6-8 support of HTML elements
   /[if lt IE 9]
     = javascript_include_tag 'http://html5shim.googlecode.com/svn/trunk/html5.js'
-  = stylesheet_link_tag "application", media: "all"
+  = stylesheet_link_tag 'application', media: 'all'
 
   %link(href="/growstuff-apple-touch-icon-precomposed.png" rel="apple-touch-icon-precomposed")
   = favicon_link_tag 'favicon.ico'

--- a/app/views/layouts/_meta.html.haml
+++ b/app/views/layouts/_meta.html.haml
@@ -18,7 +18,7 @@
   = csrf_meta_tags
   / Le HTML5 shim, for IE6-8 support of HTML elements
   /[if lt IE 9]
-    = javascript_include_tag "http://html5shim.googlecode.com/svn/trunk/html5.js"
+    = javascript_include_tag 'http://html5shim.googlecode.com/svn/trunk/html5.js'
   = stylesheet_link_tag "application", media: "all"
 
   %link(href="/growstuff-apple-touch-icon-precomposed.png" rel="apple-touch-icon-precomposed")

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,9 +1,9 @@
 !!! 5
 %html(lang="en" prefix="og: http://ogp.me/ns#")
-  = render :partial => "layouts/meta"
+  = render partial: "layouts/meta"
   %body
-    = render :partial => "layouts/header"
-    = render :partial => "layouts/crowdfunding"
+    = render partial: "layouts/header"
+    = render partial: "layouts/crowdfunding"
 
     #maincontainer.container
       .row
@@ -27,7 +27,7 @@
           = yield
 
     %footer
-      = render :partial => "layouts/footer"
+      = render partial: "layouts/footer"
     /
       Javascripts
       \==================================================

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,9 +1,9 @@
 !!! 5
 %html(lang="en" prefix="og: http://ogp.me/ns#")
-  = render partial: "layouts/meta"
+  = render partial: 'layouts/meta'
   %body
-    = render partial: "layouts/header"
-    = render partial: "layouts/crowdfunding"
+    = render partial: 'layouts/header'
+    = render partial: 'layouts/crowdfunding'
 
     #maincontainer.container
       .row
@@ -27,11 +27,11 @@
           = yield
 
     %footer
-      = render partial: "layouts/footer"
+      = render partial: 'layouts/footer'
     /
       Javascripts
       \==================================================
     / Placed at the end of the document so the pages load faster
-    = javascript_include_tag "application"
+    = javascript_include_tag 'application'
 
     != Growstuff::Application.config.analytics_code

--- a/app/views/members/_avatar.html.haml
+++ b/app/views/members/_avatar.html.haml
@@ -1,5 +1,5 @@
 = link_to                                      |
   image_tag(avatar_uri(member, 150),           |
-    :alt => '',                                |
-    :class => 'img img-responsive avatar' ),   |
+    alt: '',                                |
+    class: 'img img-responsive avatar' ),   |
   member_path(member)

--- a/app/views/members/_bio.html.haml
+++ b/app/views/members/_bio.html.haml
@@ -1,7 +1,7 @@
 %h2 All about #{member.login_name}
 - if member.bio.blank?
   - if can? :edit, member
-    = link_to "Add a bio to complete your profile."
+    = link_to 'Add a bio to complete your profile.'
   - else
     #{member.login_name} hasn't written a bio yet.
 - else

--- a/app/views/members/_contact.html.haml
+++ b/app/views/members/_contact.html.haml
@@ -3,12 +3,12 @@
 
   - if twitter_auth
     %p
-      = image_tag "twitter_32.png", size: "32x32", alt: 'Twitter logo'
+      = image_tag 'twitter_32.png', size: '32x32', alt: 'Twitter logo'
       =link_to twitter_auth.name, "http://twitter.com/#{twitter_auth.name}"
 
   - if flickr_auth
     %p
-      = image_tag "flickr_32.png", size: "32x32", alt: 'Flickr logo'
+      = image_tag 'flickr_32.png', size: '32x32', alt: 'Flickr logo'
       =link_to flickr_auth.name, "http://flickr.com/photos/#{flickr_auth.uid}"
 
   - if member.show_email

--- a/app/views/members/_contact.html.haml
+++ b/app/views/members/_contact.html.haml
@@ -3,12 +3,12 @@
 
   - if twitter_auth
     %p
-      = image_tag "twitter_32.png", :size => "32x32", :alt => 'Twitter logo'
+      = image_tag "twitter_32.png", size: "32x32", alt: 'Twitter logo'
       =link_to twitter_auth.name, "http://twitter.com/#{twitter_auth.name}"
 
   - if flickr_auth
     %p
-      = image_tag "flickr_32.png", :size => "32x32", :alt => 'Flickr logo'
+      = image_tag "flickr_32.png", size: "32x32", alt: 'Flickr logo'
       =link_to flickr_auth.name, "http://flickr.com/photos/#{flickr_auth.uid}"
 
   - if member.show_email

--- a/app/views/members/_gardens.html.haml
+++ b/app/views/members/_gardens.html.haml
@@ -10,7 +10,7 @@
       %li.navbar-right 
         = link_to new_garden_path, class: 'btn' do
           Add New Garden
-  .tab-content{style: "padding-top: 1em"}
+  .tab-content{style: 'padding-top: 1em'}
     - first_garden = true
     - member.gardens.each do |g|
 
@@ -33,7 +33,7 @@
           - if g.photos.size > 0 or (can? :edit, g and can? :create, Photo)
             .row
               %h3 Photos
-              %p= pluralize(g.photos.length, "photo")
+              %p= pluralize(g.photos.length, 'photo')
               .row
                 %ul.thumbnails
                   - g.photos.each do |p|
@@ -49,7 +49,7 @@
             - if g.featured_plantings.size > 0
               - g.featured_plantings.each.with_index do |planting|
                 .col-xs-12.col-lg-6
-                  = render partial: "plantings/thumbnail", locals: {planting: planting}
+                  = render partial: 'plantings/thumbnail', locals: {planting: planting}
 
           %p
-            = link_to "More about this garden...", url_for(g)
+            = link_to 'More about this garden...', url_for(g)

--- a/app/views/members/_gardens.html.haml
+++ b/app/views/members/_gardens.html.haml
@@ -3,7 +3,7 @@
   %ul.nav.nav-tabs
     - first_garden = true
     - member.gardens.each do |g|
-      %li{:class => first_garden ? 'active' : '' }
+      %li{class: first_garden ? 'active' : '' }
         - first_garden = false
         = link_to g.name, "#garden#{g.id}", 'data-toggle' => 'tab'
     - if current_member == member
@@ -14,7 +14,7 @@
     - first_garden = true
     - member.gardens.each do |g|
 
-      %div{:class => ['tab-pane', first_garden ? 'active' : ''], :id => "garden#{g.id}"}
+      %div{class: ['tab-pane', first_garden ? 'active' : ''], id: "garden#{g.id}"}
         - first_garden = false
 
         .container
@@ -38,18 +38,18 @@
                 %ul.thumbnails
                   - g.photos.each do |p|
                     .col-md-2.six-across
-                      = render :partial => 'photos/thumbnail', :locals => { :photo => p }
+                      = render partial: 'photos/thumbnail', locals: { photo: p }
               .row
               - if can? :create, Photo and can? :edit, g
                 %p
-                  = link_to "Add photo", new_photo_path(:type => "garden", :id => g.id), :class => 'btn btn-primary'
+                  = link_to "Add photo", new_photo_path(type: "garden", id: g.id), class: 'btn btn-primary'
 
           %h3 What's planted here?
           .row
             - if g.featured_plantings.size > 0
               - g.featured_plantings.each.with_index do |planting|
                 .col-xs-12.col-lg-6
-                  = render partial: "plantings/thumbnail", locals: {:planting => planting}
+                  = render partial: "plantings/thumbnail", locals: {planting: planting}
 
           %p
             = link_to "More about this garden...", url_for(g)

--- a/app/views/members/_gardens.html.haml
+++ b/app/views/members/_gardens.html.haml
@@ -42,7 +42,7 @@
               .row
               - if can? :create, Photo and can? :edit, g
                 %p
-                  = link_to "Add photo", new_photo_path(type: "garden", id: g.id), class: 'btn btn-primary'
+                  = link_to 'Add photo', new_photo_path(type: 'garden', id: g.id), class: 'btn btn-primary'
 
           %h3 What's planted here?
           .row

--- a/app/views/members/_location.html.haml
+++ b/app/views/members/_location.html.haml
@@ -2,4 +2,4 @@
   - if member.location.blank?
     unknown location
   - else
-    = link_to member.location, place_path(place: member.location, anchor: "members")
+    = link_to member.location, place_path(place: member.location, anchor: 'members')

--- a/app/views/members/_location.html.haml
+++ b/app/views/members/_location.html.haml
@@ -2,4 +2,4 @@
   - if member.location.blank?
     unknown location
   - else
-    = link_to member.location, place_path(:place => member.location, anchor: "members")
+    = link_to member.location, place_path(place: member.location, anchor: "members")

--- a/app/views/members/_map.html.haml
+++ b/app/views/members/_map.html.haml
@@ -2,4 +2,4 @@
   %div#membermap
   %p
     See other members, plantings, seeds and more near
-    = link_to member.location, place_path(member.location, anchor: "members")
+    = link_to member.location, place_path(member.location, anchor: 'members')

--- a/app/views/members/_stats.html.haml
+++ b/app/views/members/_stats.html.haml
@@ -3,34 +3,34 @@
 %ul
   %li
     - if member.plantings.size > 0
-      = link_to pluralize(member.plantings.size, "planting"), plantings_by_owner_path(owner: member)
+      = link_to pluralize(member.plantings.size, 'planting'), plantings_by_owner_path(owner: member)
     - else
       0 plantings
   %li
     - if member.harvests.size > 0
-      = link_to pluralize(member.harvests.size, "harvest"), harvests_by_owner_path(owner: member)
+      = link_to pluralize(member.harvests.size, 'harvest'), harvests_by_owner_path(owner: member)
     - else
       0 harvests
   %li
     - if member.seeds.size > 0
-      = link_to pluralize(member.seeds.size, "seeds"), seeds_by_owner_path(owner: member)
+      = link_to pluralize(member.seeds.size, 'seeds'), seeds_by_owner_path(owner: member)
     - else
       0 seeds
   %li
     - if member.posts.size > 0
-      = link_to pluralize(member.posts.size, "post"), posts_by_author_path(author: member)
+      = link_to pluralize(member.posts.size, 'post'), posts_by_author_path(author: member)
     - else
       0 posts
 
   %li
     - if member.followed.size > 0
-      = link_to pluralize(member.followed.size, "follow"), member_follows_path(member)
+      = link_to pluralize(member.followed.size, 'follow'), member_follows_path(member)
     - else
       0 following
 
   %li
     - if member.followers.size > 0
-      = link_to pluralize(member.followers.size, "follower"), member_followers_path(member)
+      = link_to pluralize(member.followers.size, 'follower'), member_followers_path(member)
     - else
       0 followers
 

--- a/app/views/members/_stats.html.haml
+++ b/app/views/members/_stats.html.haml
@@ -3,22 +3,22 @@
 %ul
   %li
     - if member.plantings.size > 0
-      = link_to pluralize(member.plantings.size, "planting"), plantings_by_owner_path(:owner => member)
+      = link_to pluralize(member.plantings.size, "planting"), plantings_by_owner_path(owner: member)
     - else
       0 plantings
   %li
     - if member.harvests.size > 0
-      = link_to pluralize(member.harvests.size, "harvest"), harvests_by_owner_path(:owner => member)
+      = link_to pluralize(member.harvests.size, "harvest"), harvests_by_owner_path(owner: member)
     - else
       0 harvests
   %li
     - if member.seeds.size > 0
-      = link_to pluralize(member.seeds.size, "seeds"), seeds_by_owner_path(:owner => member)
+      = link_to pluralize(member.seeds.size, "seeds"), seeds_by_owner_path(owner: member)
     - else
       0 seeds
   %li
     - if member.posts.size > 0
-      = link_to pluralize(member.posts.size, "post"), posts_by_author_path(:author => member)
+      = link_to pluralize(member.posts.size, "post"), posts_by_author_path(author: member)
     - else
       0 posts
 

--- a/app/views/members/_thumbnail.html.haml
+++ b/app/views/members/_thumbnail.html.haml
@@ -21,4 +21,4 @@
           ago.
       %p
         %small
-          = [pluralize(member.gardens.size, "garden"), pluralize(member.plantings.size, "planting"), pluralize(member.seeds.size, "seed")].join(", ")
+          = [pluralize(member.gardens.size, 'garden'), pluralize(member.plantings.size, 'planting'), pluralize(member.seeds.size, 'seed')].join(', ')

--- a/app/views/members/_thumbnail.html.haml
+++ b/app/views/members/_thumbnail.html.haml
@@ -1,7 +1,7 @@
 - cache member do
   .member-thumbnail.panel
     %div
-      = render partial: "members/avatar", locals: { member: member }
+      = render partial: 'members/avatar', locals: { member: member }
     %div
       %p.login-name
         = link_to member.login_name, member
@@ -13,7 +13,7 @@
           %small
             %br/
             Recently planted:
-            != member.plantings.first(3).map{|p| link_to p.crop_name, p }.join(", ")
+            != member.plantings.first(3).map{|p| link_to p.crop_name, p }.join(', ')
       %p
         %small
           Joined

--- a/app/views/members/_thumbnail.html.haml
+++ b/app/views/members/_thumbnail.html.haml
@@ -1,7 +1,7 @@
 - cache member do
   .member-thumbnail.panel
     %div
-      = render :partial => "members/avatar", :locals => { :member => member }
+      = render partial: "members/avatar", locals: { member: member }
     %div
       %p.login-name
         = link_to member.login_name, member

--- a/app/views/members/index.html.haml
+++ b/app/views/members/index.html.haml
@@ -3,7 +3,7 @@
 = form_tag(members_path, method: :get, class: 'form-inline', role: 'form') do
   .form-group
     = label_tag :sort, 'Sort by:', class: 'sr-only'
-    = select_tag "sort", options_for_select({"Sort alphabetically" => 'alpha', "Sort by recently joined" => "recently_joined"}, @sort || 'alpha'), class: 'form-control'
+    = select_tag 'sort', options_for_select({'Sort alphabetically' => 'alpha', 'Sort by recently joined' => 'recently_joined'}, @sort || 'alpha'), class: 'form-control'
   = submit_tag 'Show', class: 'btn btn-primary'
 
 %div.pagination

--- a/app/views/members/index.html.haml
+++ b/app/views/members/index.html.haml
@@ -2,9 +2,9 @@
 
 = form_tag(members_path, method: :get, class: 'form-inline', role: 'form') do
   .form-group
-    = label_tag :sort, "Sort by:", class: 'sr-only'
+    = label_tag :sort, 'Sort by:', class: 'sr-only'
     = select_tag "sort", options_for_select({"Sort alphabetically" => 'alpha', "Sort by recently joined" => "recently_joined"}, @sort || 'alpha'), class: 'form-control'
-  = submit_tag "Show", class: 'btn btn-primary'
+  = submit_tag 'Show', class: 'btn btn-primary'
 
 %div.pagination
   = page_entries_info @members
@@ -12,7 +12,7 @@
 
 .member-cards
   - @members.each do |m|
-    = render partial: "members/thumbnail", locals: { member: m }
+    = render partial: 'members/thumbnail', locals: { member: m }
 
 %div.pagination
   = page_entries_info @members

--- a/app/views/members/index.html.haml
+++ b/app/views/members/index.html.haml
@@ -1,4 +1,4 @@
-= content_for :title, t(".title", site_name: "#{ENV['GROWSTUFF_SITE_NAME']}")
+= content_for :title, t('.title', site_name: ENV['GROWSTUFF_SITE_NAME'])
 
 = form_tag(members_path, method: :get, class: 'form-inline', role: 'form') do
   .form-group

--- a/app/views/members/index.html.haml
+++ b/app/views/members/index.html.haml
@@ -1,10 +1,10 @@
 = content_for :title, t(".title", site_name: "#{ENV['GROWSTUFF_SITE_NAME']}")
 
-= form_tag(members_path, :method => :get, :class => 'form-inline', :role => 'form') do
+= form_tag(members_path, method: :get, class: 'form-inline', role: 'form') do
   .form-group
-    = label_tag :sort, "Sort by:", :class => 'sr-only'
-    = select_tag "sort", options_for_select({"Sort alphabetically" => 'alpha', "Sort by recently joined" => "recently_joined"}, @sort || 'alpha'), :class => 'form-control'
-  = submit_tag "Show", :class => 'btn btn-primary'
+    = label_tag :sort, "Sort by:", class: 'sr-only'
+    = select_tag "sort", options_for_select({"Sort alphabetically" => 'alpha', "Sort by recently joined" => "recently_joined"}, @sort || 'alpha'), class: 'form-control'
+  = submit_tag "Show", class: 'btn btn-primary'
 
 %div.pagination
   = page_entries_info @members
@@ -12,7 +12,7 @@
 
 .member-cards
   - @members.each do |m|
-    = render :partial => "members/thumbnail", :locals => { :member => m }
+    = render partial: "members/thumbnail", locals: { member: m }
 
 %div.pagination
   = page_entries_info @members

--- a/app/views/members/nearby.html.haml
+++ b/app/views/members/nearby.html.haml
@@ -1,25 +1,25 @@
 - if @location
   - content_for :title, "Members near #{@location}"
-- else content_for :title, "Find nearby members"
+- else content_for :title, 'Find nearby members'
 
 %p
   = form_tag(nearby_members_path, method: :get, class: 'form-inline') do
-    = label_tag :distance, "Find members within", class: 'control-label'
+    = label_tag :distance, 'Find members within', class: 'control-label'
     = text_field_tag :distance, @distance, class: 'input-mini'
     = select_tag :units, options_for_select({"miles" => :mi, "km" => :km}, @units), class: 'input-small'
-    = label_tag :location, "of", class: 'control-label'
+    = label_tag :location, 'of', class: 'control-label'
     = text_field_tag :location, @location
-    = submit_tag "Search", class: 'btn btn-primary'
+    = submit_tag 'Search', class: 'btn btn-primary'
 
 - if can? :update, current_member
   %p
-    = link_to "Edit your location", edit_member_registration_path(current_member)
+    = link_to 'Edit your location', edit_member_registration_path(current_member)
 
 - if !@nearby_members.empty?
   %h3 Results found
   .row
     - @nearby_members.each do |member|
       .col-md-4.three-across
-        = render partial: "members/thumbnail", locals: { member: member }
+        = render partial: 'members/thumbnail', locals: { member: member }
 - elsif @location
   %h3 No results found

--- a/app/views/members/nearby.html.haml
+++ b/app/views/members/nearby.html.haml
@@ -3,13 +3,13 @@
 - else content_for :title, "Find nearby members"
 
 %p
-  = form_tag(nearby_members_path, :method => :get, :class => 'form-inline') do
-    = label_tag :distance, "Find members within", :class => 'control-label'
-    = text_field_tag :distance, @distance, :class => 'input-mini'
-    = select_tag :units, options_for_select({"miles" => :mi, "km" => :km}, @units), :class => 'input-small'
-    = label_tag :location, "of", :class => 'control-label'
+  = form_tag(nearby_members_path, method: :get, class: 'form-inline') do
+    = label_tag :distance, "Find members within", class: 'control-label'
+    = text_field_tag :distance, @distance, class: 'input-mini'
+    = select_tag :units, options_for_select({"miles" => :mi, "km" => :km}, @units), class: 'input-small'
+    = label_tag :location, "of", class: 'control-label'
     = text_field_tag :location, @location
-    = submit_tag "Search", :class => 'btn btn-primary'
+    = submit_tag "Search", class: 'btn btn-primary'
 
 - if can? :update, current_member
   %p
@@ -20,6 +20,6 @@
   .row
     - @nearby_members.each do |member|
       .col-md-4.three-across
-        = render :partial => "members/thumbnail", :locals => { :member => member }
+        = render partial: "members/thumbnail", locals: { member: member }
 - elsif @location
   %h3 No results found

--- a/app/views/members/nearby.html.haml
+++ b/app/views/members/nearby.html.haml
@@ -6,7 +6,7 @@
   = form_tag(nearby_members_path, method: :get, class: 'form-inline') do
     = label_tag :distance, 'Find members within', class: 'control-label'
     = text_field_tag :distance, @distance, class: 'input-mini'
-    = select_tag :units, options_for_select({"miles" => :mi, "km" => :km}, @units), class: 'input-small'
+    = select_tag :units, options_for_select({'miles' => :mi, 'km' => :km}, @units), class: 'input-small'
     = label_tag :location, 'of', class: 'control-label'
     = text_field_tag :location, @location
     = submit_tag 'Search', class: 'btn btn-primary'

--- a/app/views/members/show.html.haml
+++ b/app/views/members/show.html.haml
@@ -2,18 +2,18 @@
 - content_for :subtitle, @member.location
 - content_for :buttonbar do
   - if can? :update, @member
-    = link_to 'Edit profile', edit_member_registration_path, :class => 'btn btn-default'
+    = link_to 'Edit profile', edit_member_registration_path, class: 'btn btn-default'
   - if @member == current_member && !@member.is_paid?
-    = link_to "Upgrade account", shop_path, :class => 'btn btn-default'
+    = link_to "Upgrade account", shop_path, class: 'btn btn-default'
   - if can? :create, Notification and current_member != @member
-    = link_to 'Send message', new_notification_path(:recipient_id => @member.id), :class => 'btn btn-default'
+    = link_to 'Send message', new_notification_path(recipient_id: @member.id), class: 'btn btn-default'
 
   - if current_member and current_member != @member # must be logged in, can't follow yourself
     - follow = current_member.get_follow(@member)
     - if !follow and can? :create, Follow # not already following
-      = link_to 'Follow', follows_path(:followed_id => @member.id), :method => :post, :class => 'btn btn-default'
+      = link_to 'Follow', follows_path(followed_id: @member.id), method: :post, class: 'btn btn-default'
     - if follow and can? :destroy, follow # already following
-      = link_to 'Unfollow', follow_path(follow), :method => :delete, :class => 'btn btn-default'
+      = link_to 'Unfollow', follow_path(follow), method: :delete, class: 'btn btn-default'
 
 - content_for :member_rss_login_name, @member.login_name
 - content_for :member_rss_slug, @member.slug
@@ -22,12 +22,12 @@
 
   .col-md-9
 
-    = render :partial => "map", :locals => { :member => @member }
-    = render :partial => "bio", :locals => { :member => @member }
-    = render :partial => "gardens", :locals => { :member => @member }
+    = render partial: "map", locals: { member: @member }
+    = render partial: "bio", locals: { member: @member }
+    = render partial: "gardens", locals: { member: @member }
 
   .col-md-3
-    = render :partial => "avatar", :locals => { :member => @member }
-    = render :partial => "account", :locals => { :member => @member }
-    = render :partial => "stats", :locals => { :member => @member }
-    = render :partial => "contact", :locals => { :member => @member, :twitter_auth => @twitter_auth, :flickr_auth => @flickr_auth }
+    = render partial: "avatar", locals: { member: @member }
+    = render partial: "account", locals: { member: @member }
+    = render partial: "stats", locals: { member: @member }
+    = render partial: "contact", locals: { member: @member, twitter_auth: @twitter_auth, flickr_auth: @flickr_auth }

--- a/app/views/members/show.html.haml
+++ b/app/views/members/show.html.haml
@@ -4,7 +4,7 @@
   - if can? :update, @member
     = link_to 'Edit profile', edit_member_registration_path, class: 'btn btn-default'
   - if @member == current_member && !@member.is_paid?
-    = link_to "Upgrade account", shop_path, class: 'btn btn-default'
+    = link_to 'Upgrade account', shop_path, class: 'btn btn-default'
   - if can? :create, Notification and current_member != @member
     = link_to 'Send message', new_notification_path(recipient_id: @member.id), class: 'btn btn-default'
 
@@ -22,12 +22,12 @@
 
   .col-md-9
 
-    = render partial: "map", locals: { member: @member }
-    = render partial: "bio", locals: { member: @member }
-    = render partial: "gardens", locals: { member: @member }
+    = render partial: 'map', locals: { member: @member }
+    = render partial: 'bio', locals: { member: @member }
+    = render partial: 'gardens', locals: { member: @member }
 
   .col-md-3
-    = render partial: "avatar", locals: { member: @member }
-    = render partial: "account", locals: { member: @member }
-    = render partial: "stats", locals: { member: @member }
-    = render partial: "contact", locals: { member: @member, twitter_auth: @twitter_auth, flickr_auth: @flickr_auth }
+    = render partial: 'avatar', locals: { member: @member }
+    = render partial: 'account', locals: { member: @member }
+    = render partial: 'stats', locals: { member: @member }
+    = render partial: 'contact', locals: { member: @member, twitter_auth: @twitter_auth, flickr_auth: @flickr_auth }

--- a/app/views/members/show.rss.haml
+++ b/app/views/members/show.rss.haml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-%rss{:version => 2.0}
+%rss{version: 2.0}
   %channel
     %title #{@member.login_name}'s recent posts (#{ENV['GROWSTUFF_SITE_NAME']})
     %link= member_url(@member)

--- a/app/views/members/unsubscribe.html.haml
+++ b/app/views/members/unsubscribe.html.haml
@@ -2,4 +2,4 @@
 
 %p
   If you wish to unsubscribe from other Growstuff emails, you may do so via
-  = link_to "your settings page", edit_member_registration_url
+  = link_to 'your settings page', edit_member_registration_url

--- a/app/views/members/view_followers.html.haml
+++ b/app/views/members/view_followers.html.haml
@@ -9,7 +9,7 @@
     - @followers.each do |f|
       .col-md-4.three-across      
         .thumbnail 
-          = render partial: "members/thumbnail", locals: { member: f }
+          = render partial: 'members/thumbnail', locals: { member: f }
           
 %div.pagination
   = page_entries_info @followers

--- a/app/views/members/view_followers.html.haml
+++ b/app/views/members/view_followers.html.haml
@@ -9,7 +9,7 @@
     - @followers.each do |f|
       .col-md-4.three-across      
         .thumbnail 
-          = render :partial => "members/thumbnail", :locals => { :member => f }
+          = render partial: "members/thumbnail", locals: { member: f }
           
 %div.pagination
   = page_entries_info @followers

--- a/app/views/members/view_follows.html.haml
+++ b/app/views/members/view_follows.html.haml
@@ -9,7 +9,7 @@
     - @follows.each do |f|
       .col-md-4.three-across      
         .thumbnail 
-          = render :partial => "members/thumbnail", :locals => { :member => f }
+          = render partial: "members/thumbnail", locals: { member: f }
 
 %div.pagination
   = page_entries_info @follows

--- a/app/views/members/view_follows.html.haml
+++ b/app/views/members/view_follows.html.haml
@@ -9,7 +9,7 @@
     - @follows.each do |f|
       .col-md-4.three-across      
         .thumbnail 
-          = render partial: "members/thumbnail", locals: { member: f }
+          = render partial: 'members/thumbnail', locals: { member: f }
 
 %div.pagination
   = page_entries_info @follows

--- a/app/views/notifications/_form.html.haml
+++ b/app/views/notifications/_form.html.haml
@@ -7,16 +7,16 @@
           %li= msg
 
   .field
-    = f.hidden_field :recipient_id, :value => @recipient.id
+    = f.hidden_field :recipient_id, value: @recipient.id
 
   %p
     To:
     = link_to @recipient, @recipient
   = label_tag :notification, "Subject:"
-  = f.text_field :subject, :value => @subject, :class => 'form-control', :maxlength => 255
+  = f.text_field :subject, value: @subject, class: 'form-control', maxlength: 255
   = label_tag :body, "Type your message here:"
-  = f.text_area :body, :rows => 12, :class => 'form-control'
+  = f.text_area :body, rows: 12, class: 'form-control'
   %span.help-block
-    = render :partial => "shared/markdown_help"
+    = render partial: "shared/markdown_help"
 
-  = f.submit "Send", :class => 'btn btn-primary'
+  = f.submit "Send", class: 'btn btn-primary'

--- a/app/views/notifications/_form.html.haml
+++ b/app/views/notifications/_form.html.haml
@@ -12,11 +12,11 @@
   %p
     To:
     = link_to @recipient, @recipient
-  = label_tag :notification, "Subject:"
+  = label_tag :notification, 'Subject:'
   = f.text_field :subject, value: @subject, class: 'form-control', maxlength: 255
-  = label_tag :body, "Type your message here:"
+  = label_tag :body, 'Type your message here:'
   = f.text_area :body, rows: 12, class: 'form-control'
   %span.help-block
-    = render partial: "shared/markdown_help"
+    = render partial: 'shared/markdown_help'
 
-  = f.submit "Send", class: 'btn btn-primary'
+  = f.submit 'Send', class: 'btn btn-primary'

--- a/app/views/notifications/index.html.haml
+++ b/app/views/notifications/index.html.haml
@@ -28,7 +28,7 @@
             - else
               %strong= n.created_at
           %td
-            = link_to 'Delete', n, method: :delete, data: { confirm: 'Are you sure?' }, :class => 'btn btn-default btn-xs'
+            = link_to 'Delete', n, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-default btn-xs'
   = paginate @notifications, theme: 'twitter-bootstrap-3'
 - else
   You have no messages.

--- a/app/views/notifications/index.html.haml
+++ b/app/views/notifications/index.html.haml
@@ -1,4 +1,4 @@
-- content_for :title, "Inbox"
+- content_for :title, 'Inbox'
 
 - if @notifications.size > 0
   = paginate @notifications, theme: 'twitter-bootstrap-3'

--- a/app/views/notifications/show.html.haml
+++ b/app/views/notifications/show.html.haml
@@ -3,5 +3,5 @@
 = render @notification
 
 %p
-  =link_to 'Delete', @notification, method: :delete, data: { confirm: 'Are you sure?' }, :class => 'btn btn-default'
-  =link_to 'Reply', @reply_link, :class => 'btn btn-primary'
+  =link_to 'Delete', @notification, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-default'
+  =link_to 'Reply', @reply_link, class: 'btn btn-primary'

--- a/app/views/notifier/crop_request_approved.html.haml
+++ b/app/views/notifier/crop_request_approved.html.haml
@@ -12,5 +12,5 @@
   %li
     = link_to "Stash seeds for #{@crop.name}", new_seed_url(crop_id: @crop.id)
 
-= render :partial => 'signature'
+= render partial: 'signature'
 

--- a/app/views/notifier/crop_request_rejected.html.haml
+++ b/app/views/notifier/crop_request_rejected.html.haml
@@ -4,4 +4,4 @@
 %p
   We're sorry, but your request for the new crop: #{link_to @crop.name, crop_url(@crop)} has been rejected for the following reason: #{@crop.rejection_explanation}
 
-= render :partial => 'signature'
+= render partial: 'signature'

--- a/app/views/notifier/new_crop_request.html.haml
+++ b/app/views/notifier/new_crop_request.html.haml
@@ -19,4 +19,4 @@
 %p
   Thanks for your help!
 
-= render :partial => 'signature'
+= render partial: 'signature'

--- a/app/views/notifier/notify.html.haml
+++ b/app/views/notifier/notify.html.haml
@@ -21,4 +21,4 @@
   = link_to "Unsubscribe from direct message notifications", unsubscribe_member_url(@signed_message)
   from these notifications
 
-= render :partial => 'signature'
+= render partial: 'signature'

--- a/app/views/notifier/notify.html.haml
+++ b/app/views/notifier/notify.html.haml
@@ -14,11 +14,11 @@
     #{strip_tags @notification.body}
 
 %p
-  = link_to "Reply to this message", @reply_link
+  = link_to 'Reply to this message', @reply_link
   %br/
-  = link_to "View this message in your inbox", notification_url(@notification)
+  = link_to 'View this message in your inbox', notification_url(@notification)
   %br/
-  = link_to "Unsubscribe from direct message notifications", unsubscribe_member_url(@signed_message)
+  = link_to 'Unsubscribe from direct message notifications', unsubscribe_member_url(@signed_message)
   from these notifications
 
 = render partial: 'signature'

--- a/app/views/notifier/planting_reminder.html.haml
+++ b/app/views/notifier/planting_reminder.html.haml
@@ -10,7 +10,7 @@
     #{site_name} lets you track what food you're growing
     in your garden and see what other people near you are planting too.
   %p
-    = link_to "Get started now", new_planting_url
+    = link_to 'Get started now', new_planting_url
     by planting your first crop.
 
 - else
@@ -26,7 +26,7 @@
       ago.
 
   %p
-    = link_to "Plant something new", new_planting_url
+    = link_to 'Plant something new', new_planting_url
     to keep your garden records up to date.
 
 %h2 Your recent harvests
@@ -38,7 +38,7 @@
     and see what other people near you are harvesting, too.
 
   %p
-    = link_to "Get started now", new_harvest_url
+    = link_to 'Get started now', new_harvest_url
     by tracking your first harvest.
 
 - else
@@ -54,7 +54,7 @@
 
   %p
     Harvested anything else lately?
-    = link_to "Track your harvests here.", new_harvest_url
+    = link_to 'Track your harvests here.', new_harvest_url
 
 %h2
   See you soon on #{site_name}!
@@ -64,5 +64,5 @@
 %hr/
 %p
   Don't want to get these emails any more?
-  = link_to "Unsubscribe from planting reminders", unsubscribe_member_url(@signed_message)
+  = link_to 'Unsubscribe from planting reminders', unsubscribe_member_url(@signed_message)
 

--- a/app/views/notifier/planting_reminder.html.haml
+++ b/app/views/notifier/planting_reminder.html.haml
@@ -59,7 +59,7 @@
 %h2
   See you soon on #{site_name}!
 
-= render :partial => 'signature'
+= render partial: 'signature'
 
 %hr/
 %p

--- a/app/views/orders/complete.html.haml
+++ b/app/views/orders/complete.html.haml
@@ -1,4 +1,4 @@
--content_for :title, "Completed order"
+-content_for :title, 'Completed order'
 
 %p Thank you for your order.
 
@@ -10,7 +10,7 @@
   %strong Order number:
   = @order.id
 
-= render "shared/account_status"
+= render 'shared/account_status'
 
 %h2 Order items
 
@@ -42,4 +42,4 @@
         = price_with_currency(total)
 
 %p
-  = link_to "View other orders/order history", orders_path
+  = link_to 'View other orders/order history', orders_path

--- a/app/views/orders/index.html.haml
+++ b/app/views/orders/index.html.haml
@@ -36,7 +36,7 @@
               @
               = price_with_currency(o.price)
               %br/
-        %td= link_to 'Details', order, :class => 'btn btn-default btn-xs'
+        %td= link_to 'Details', order, class: 'btn btn-default btn-xs'
 - else
   %p
     You have not made any orders.  You can place an order via our

--- a/app/views/orders/index.html.haml
+++ b/app/views/orders/index.html.haml
@@ -1,6 +1,6 @@
-- content_for :title, "Your Account"
+- content_for :title, 'Your Account'
 
-= render "shared/account_status"
+= render 'shared/account_status'
 
 
 %h2 Orders
@@ -10,8 +10,8 @@
 
   %p
     Your order history shows what you have bought via our
-    =succeed "." do
-      =link_to "shop", shop_path
+    =succeed '.' do
+      =link_to 'shop', shop_path
 
   %table.table.table-striped
     %tr
@@ -40,5 +40,5 @@
 - else
   %p
     You have not made any orders.  You can place an order via our
-    =succeed "." do
-      =link_to "shop", shop_path
+    =succeed '.' do
+      =link_to 'shop', shop_path

--- a/app/views/orders/show.html.haml
+++ b/app/views/orders/show.html.haml
@@ -1,4 +1,4 @@
--content_for :title, @order.completed_at ? "Order details (##{@order.id})" : "Current order"
+-content_for :title, @order.completed_at ? "Order details (##{@order.id})" : 'Current order'
 
 %p
   %strong Order number:

--- a/app/views/orders/show.html.haml
+++ b/app/views/orders/show.html.haml
@@ -67,15 +67,15 @@
           %li= msg
 
 - if can? :complete, @order or can? :destroy, @order
-  = form_tag(checkout_order_path(@order), :method => :get, :class => 'form-inline') do
+  = form_tag(checkout_order_path(@order), method: :get, class: 'form-inline') do
     %p
       - if can? :complete, @order
         = label_tag :referral_code, "Do you have a referral code?"
-        = text_field_tag :referral_code, @order.referral_code, :class => 'input-medium'
-        = submit_tag "Checkout with PayPal", :class => 'btn btn-primary'
+        = text_field_tag :referral_code, @order.referral_code, class: 'input-medium'
+        = submit_tag "Checkout with PayPal", class: 'btn btn-primary'
       - if can? :destroy, @order
         = link_to 'Delete this order', @order, method: :delete, |
-          data: { confirm: 'Are you sure?' }, :class => 'btn btn-default'
-      = link_to "View other orders/order history", orders_path, :class => 'btn btn-default'
+          data: { confirm: 'Are you sure?' }, class: 'btn btn-default'
+      = link_to "View other orders/order history", orders_path, class: 'btn btn-default'
 
 %p

--- a/app/views/orders/show.html.haml
+++ b/app/views/orders/show.html.haml
@@ -70,12 +70,12 @@
   = form_tag(checkout_order_path(@order), method: :get, class: 'form-inline') do
     %p
       - if can? :complete, @order
-        = label_tag :referral_code, "Do you have a referral code?"
+        = label_tag :referral_code, 'Do you have a referral code?'
         = text_field_tag :referral_code, @order.referral_code, class: 'input-medium'
-        = submit_tag "Checkout with PayPal", class: 'btn btn-primary'
+        = submit_tag 'Checkout with PayPal', class: 'btn btn-primary'
       - if can? :destroy, @order
         = link_to 'Delete this order', @order, method: :delete, |
           data: { confirm: 'Are you sure?' }, class: 'btn btn-default'
-      = link_to "View other orders/order history", orders_path, class: 'btn btn-default'
+      = link_to 'View other orders/order history', orders_path, class: 'btn btn-default'
 
 %p

--- a/app/views/photos/_thumbnail.html.haml
+++ b/app/views/photos/_thumbnail.html.haml
@@ -1,5 +1,5 @@
 .thumbnail.photo-thumbnail
-  = link_to image_tag(photo.thumbnail_url, :alt => photo.title, :class => 'img img-responsive'), photo
+  = link_to image_tag(photo.thumbnail_url, alt: photo.title, class: 'img img-responsive'), photo
   .text
     %p
       = link_to photo.title, photo

--- a/app/views/photos/edit.html.haml
+++ b/app/views/photos/edit.html.haml
@@ -1,2 +1,2 @@
-- content_for :title, "Edit Photo"
+- content_for :title, 'Edit Photo'
 

--- a/app/views/photos/index.html.haml
+++ b/app/views/photos/index.html.haml
@@ -10,7 +10,7 @@
   - @photos.each do |p|
     .col-md-2.six-across
       .thumbnail(style='height: 220px')
-        = link_to image_tag(p.thumbnail_url, :alt => p.title, :class => 'img'), p
+        = link_to image_tag(p.thumbnail_url, alt: p.title, class: 'img'), p
         %p
           = link_to p.title, p
           by

--- a/app/views/photos/index.html.haml
+++ b/app/views/photos/index.html.haml
@@ -1,4 +1,4 @@
-- content_for :title, "Photos"
+- content_for :title, 'Photos'
 
 %p Most recent photos added to #{ENV['GROWSTUFF_SITE_NAME']}.
 

--- a/app/views/photos/new.html.haml
+++ b/app/views/photos/new.html.haml
@@ -1,9 +1,9 @@
-- content_for :title, "New Photo"
+- content_for :title, 'New Photo'
 
 - if @flickr_auth
   %p
     Connected to Flickr as
-    = succeed "." do
+    = succeed '.' do
       = link_to @flickr_auth.name, "http://flickr.com/photos/#{@flickr_auth.uid}"
     Please select a photo from your recent uploads.
 
@@ -13,11 +13,11 @@
   - if @sets and @sets.size > 0
     %p
       = form_tag(new_photo_path, method: :get, class: 'form-inline') do
-        = label_tag :set, "Choose a photo album:", class: 'control-label'
+        = label_tag :set, 'Choose a photo album:', class: 'control-label'
         = select_tag :set, options_for_select(@sets, @current_set), class: 'input-large'
         = hidden_field_tag :type, @type
         = hidden_field_tag :id, @id
-        = submit_tag "Search", class: 'btn btn-primary'
+        = submit_tag 'Search', class: 'btn btn-primary'
 
   %div.pagination
     = page_entries_info @photos
@@ -34,5 +34,5 @@
 - else
   .alert
     You must
-    =link_to "connect your account to Flickr", '/auth/flickr'
+    =link_to 'connect your account to Flickr', '/auth/flickr'
     to add photos.

--- a/app/views/photos/new.html.haml
+++ b/app/views/photos/new.html.haml
@@ -12,12 +12,12 @@
 
   - if @sets and @sets.size > 0
     %p
-      = form_tag(new_photo_path, :method => :get, :class => 'form-inline') do
-        = label_tag :set, "Choose a photo album:", :class => 'control-label'
-        = select_tag :set, options_for_select(@sets, @current_set), :class => 'input-large'
+      = form_tag(new_photo_path, method: :get, class: 'form-inline') do
+        = label_tag :set, "Choose a photo album:", class: 'control-label'
+        = select_tag :set, options_for_select(@sets, @current_set), class: 'input-large'
         = hidden_field_tag :type, @type
         = hidden_field_tag :id, @id
-        = submit_tag "Search", :class => 'btn btn-primary'
+        = submit_tag "Search", class: 'btn btn-primary'
 
   %div.pagination
     = page_entries_info @photos
@@ -27,7 +27,7 @@
   - @photos.each do |p|
     .col-md-2.six-across
       .thumbnail(style='height: 220px')
-        = link_to image_tag(FlickRaw.url_q(p), :alt => '', :class => 'img'), photos_path(:photo => { :flickr_photo_id => p.id }, :type => @type, :id => @id), :method => :post
+        = link_to image_tag(FlickRaw.url_q(p), alt: '', class: 'img'), photos_path(photo: { flickr_photo_id: p.id }, type: @type, id: @id), method: :post
         %p
           =p.title
 

--- a/app/views/photos/show.html.haml
+++ b/app/views/photos/show.html.haml
@@ -16,7 +16,7 @@
       = link_to "View on Flickr", @photo.link_url
 
     - if can? :destroy, @photo
-      %p= link_to 'Delete Photo', @photo, method: :delete, data: { confirm: 'Are you sure?' }, :class => 'btn btn-default btn-xs'
+      %p= link_to 'Delete Photo', @photo, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-default btn-xs'
 
   .col-md-6
     - if @photo.plantings.size > 0 or @photo.harvests.size > 0 or @photo.gardens.size > 0
@@ -35,5 +35,5 @@
 
 .row
   .col-md-12
-    %p= image_tag(@photo.fullsize_url, :alt => @photo.title, :class => 'img')
+    %p= image_tag(@photo.fullsize_url, alt: @photo.title, class: 'img')
 

--- a/app/views/photos/show.html.haml
+++ b/app/views/photos/show.html.haml
@@ -10,10 +10,10 @@
       - if @photo.license_url
         = link_to @photo.license_name, @photo.license_url
       - else
-        = succeed "." do
+        = succeed '.' do
           = @photo.license_name
     %p
-      = link_to "View on Flickr", @photo.link_url
+      = link_to 'View on Flickr', @photo.link_url
 
     - if can? :destroy, @photo
       %p= link_to 'Delete Photo', @photo, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-default btn-xs'

--- a/app/views/places/_map_attribution.html.haml
+++ b/app/views/places/_map_attribution.html.haml
@@ -1,6 +1,6 @@
 Map data &copy;
-= link_to "OpenStreetMap", "http://openstreetmap.org"
+= link_to 'OpenStreetMap', 'http://openstreetmap.org'
 contributors under
-= link_to "ODbL", "http://www.openstreetmap.org/copyright"
+= link_to 'ODbL', 'http://www.openstreetmap.org/copyright'
 | Imagery &copy;
-= link_to "CloudMade", "http://cloudmade.com"
+= link_to 'CloudMade', 'http://cloudmade.com'

--- a/app/views/places/_search_form.html.haml
+++ b/app/views/places/_search_form.html.haml
@@ -1,6 +1,6 @@
 %form{action: search_places_path, method: :get, class: 'form-inline', role: 'form'}
   .form-group
-    = label_tag :new_place, "Change location:", class: 'sr-only'
-    = text_field_tag :new_place, '', class: 'form-control', placeholder: "New location..."
+    = label_tag :new_place, 'Change location:', class: 'sr-only'
+    = text_field_tag :new_place, '', class: 'form-control', placeholder: 'New location...'
   = submit_tag "Search", class: 'btn btn-primary', id: "search_button"
 %br/

--- a/app/views/places/_search_form.html.haml
+++ b/app/views/places/_search_form.html.haml
@@ -2,5 +2,5 @@
   .form-group
     = label_tag :new_place, 'Change location:', class: 'sr-only'
     = text_field_tag :new_place, '', class: 'form-control', placeholder: 'New location...'
-  = submit_tag "Search", class: 'btn btn-primary', id: "search_button"
+  = submit_tag 'Search', class: 'btn btn-primary', id: 'search_button'
 %br/

--- a/app/views/places/_search_form.html.haml
+++ b/app/views/places/_search_form.html.haml
@@ -1,6 +1,6 @@
-%form{:action => search_places_path, :method => :get, :class => 'form-inline', :role => 'form'}
+%form{action: search_places_path, method: :get, class: 'form-inline', role: 'form'}
   .form-group
-    = label_tag :new_place, "Change location:", :class => 'sr-only'
-    = text_field_tag :new_place, '', :class => 'form-control', :placeholder => "New location..."
-  = submit_tag "Search", :class => 'btn btn-primary', :id => "search_button"
+    = label_tag :new_place, "Change location:", class: 'sr-only'
+    = text_field_tag :new_place, '', class: 'form-control', placeholder: "New location..."
+  = submit_tag "Search", class: 'btn btn-primary', id: "search_button"
 %br/

--- a/app/views/places/index.html.haml
+++ b/app/views/places/index.html.haml
@@ -1,4 +1,4 @@
--content_for :title, t(".title", site_name: "#{ENV['GROWSTUFF_SITE_NAME']}")
+-content_for :title, t('.title', site_name: ENV['GROWSTUFF_SITE_NAME'])
 = render partial: 'search_form'
 %div#placesmap
 

--- a/app/views/places/show.html.haml
+++ b/app/views/places/show.html.haml
@@ -2,7 +2,7 @@
 
 = render partial: 'search_form'
 
-%div#placesmap{ :style => "height:300px"}
+%div#placesmap{ style: "height:300px"}
 
 %h3#members= "Nearby members"
 
@@ -10,7 +10,7 @@
   .row
     - @nearby_members.first(30).each do |member|
       .col-md-4.three-across
-        = render :partial => "members/thumbnail", :locals => { :member => member }
+        = render partial: "members/thumbnail", locals: { member: member }
   = link_to "View all members >>", members_path
 
   %h3#seeds= "Seeds available for trade near #{@place}"
@@ -22,7 +22,7 @@
     .row
       - crop_id.uniq.first(20).each do |crop|
         .col-md-2.six-across
-          = render :partial => "crops/thumbnail", :locals => { :crop => Crop.find(crop) }
+          = render partial: "crops/thumbnail", locals: { crop: Crop.find(crop) }
     = link_to "View all seeds >>", seeds_path
   - else
     %p No nearby seeds found
@@ -39,7 +39,7 @@
     .row
       - plantings.first(10).each.with_index do |planting, index|
         .col-xs-12.col-lg-6
-          = render partial: "plantings/thumbnail", locals: {:planting => planting, :index => index}
+          = render partial: "plantings/thumbnail", locals: {planting: planting, index: index}
     .row
       = link_to "View all plantings >>", plantings_path
   - else

--- a/app/views/places/show.html.haml
+++ b/app/views/places/show.html.haml
@@ -2,16 +2,16 @@
 
 = render partial: 'search_form'
 
-%div#placesmap{ style: "height:300px"}
+%div#placesmap{ style: 'height:300px'}
 
-%h3#members= "Nearby members"
+%h3#members= 'Nearby members'
 
 - if !@nearby_members.empty?
   .row
     - @nearby_members.first(30).each do |member|
       .col-md-4.three-across
-        = render partial: "members/thumbnail", locals: { member: member }
-  = link_to "View all members >>", members_path
+        = render partial: 'members/thumbnail', locals: { member: member }
+  = link_to 'View all members >>', members_path
 
   %h3#seeds= "Seeds available for trade near #{@place}"
   - crop_id = []
@@ -22,8 +22,8 @@
     .row
       - crop_id.uniq.first(20).each do |crop|
         .col-md-2.six-across
-          = render partial: "crops/thumbnail", locals: { crop: Crop.find(crop) }
-    = link_to "View all seeds >>", seeds_path
+          = render partial: 'crops/thumbnail', locals: { crop: Crop.find(crop) }
+    = link_to 'View all seeds >>', seeds_path
   - else
     %p No nearby seeds found
 
@@ -39,9 +39,9 @@
     .row
       - plantings.first(10).each.with_index do |planting, index|
         .col-xs-12.col-lg-6
-          = render partial: "plantings/thumbnail", locals: {planting: planting, index: index}
+          = render partial: 'plantings/thumbnail', locals: {planting: planting, index: index}
     .row
-      = link_to "View all plantings >>", plantings_path
+      = link_to 'View all plantings >>', plantings_path
   - else
     .row
       %p No nearby plantings found

--- a/app/views/plant_parts/edit.html.haml
+++ b/app/views/plant_parts/edit.html.haml
@@ -1,4 +1,4 @@
-- content_for :title, "Editing plant part"
+- content_for :title, 'Editing plant part'
 
 = render 'form'
 

--- a/app/views/plant_parts/index.html.haml
+++ b/app/views/plant_parts/index.html.haml
@@ -15,9 +15,9 @@
 
   %p
   - if can? :edit, plant_part
-    = link_to 'Edit', edit_plant_part_path(plant_part), :class => 'btn btn-default btn-xs'
+    = link_to 'Edit', edit_plant_part_path(plant_part), class: 'btn btn-default btn-xs'
   - if can? :destroy, plant_part
-    = link_to 'Delete', plant_part, :method => :delete, :data => { :confirm => 'Are you sure?' }, :class => 'btn btn-default btn-xs'
+    = link_to 'Delete', plant_part, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-default btn-xs'
 
 
 

--- a/app/views/plant_parts/index.html.haml
+++ b/app/views/plant_parts/index.html.haml
@@ -1,4 +1,4 @@
-- content_for :title, "Plant parts"
+- content_for :title, 'Plant parts'
 
 - if can? :create, PlantPart
   = link_to 'New Plant part', new_plant_part_path
@@ -9,9 +9,9 @@
     %p No crops are harvested for this plant part (yet).
   - else
     %p
-      != plant_part.crops.map {|c| link_to(c, c) }.join(", ")
+      != plant_part.crops.map {|c| link_to(c, c) }.join(', ')
   %p
-    = link_to "More detail", plant_part
+    = link_to 'More detail', plant_part
 
   %p
   - if can? :edit, plant_part

--- a/app/views/plant_parts/new.html.haml
+++ b/app/views/plant_parts/new.html.haml
@@ -1,4 +1,4 @@
-- content_for :title, "New plant part"
+- content_for :title, 'New plant part'
 
 = render 'form'
 

--- a/app/views/plant_parts/show.html.haml
+++ b/app/views/plant_parts/show.html.haml
@@ -8,7 +8,7 @@
     - @plant_part.crops.each do |c|
       %li= link_to c, c
 
-%p= link_to "View other plant parts", plant_parts_path
+%p= link_to 'View other plant parts', plant_parts_path
 
 %p
 - if can? :edit, @plant_part

--- a/app/views/plant_parts/show.html.haml
+++ b/app/views/plant_parts/show.html.haml
@@ -12,6 +12,6 @@
 
 %p
 - if can? :edit, @plant_part
-  = link_to 'Edit', edit_plant_part_path(@plant_part), :class => 'btn btn-default btn-xs'
+  = link_to 'Edit', edit_plant_part_path(@plant_part), class: 'btn btn-default btn-xs'
 - if can? :destroy, @plant_part
-  = link_to 'Delete', @plant_part, :method => :delete, :data => { :confirm => 'Are you sure?' }, :class => 'btn btn-default btn-xs'
+  = link_to 'Delete', @plant_part, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-default btn-xs'

--- a/app/views/plantings/_form.html.haml
+++ b/app/views/plantings/_form.html.haml
@@ -1,6 +1,6 @@
 = required_field_help_text
 
-= form_for(@planting, html: {class: "form-horizontal", role: "form"}) do |f|
+= form_for(@planting, html: {class: 'form-horizontal', role: 'form'}) do |f|
   - if @planting.errors.any?
     #error_explanation
       %h2= "#{pluralize(@planting.errors.size, "error")} prohibited this planting from being saved:"

--- a/app/views/plantings/_form.html.haml
+++ b/app/views/plantings/_form.html.haml
@@ -14,13 +14,13 @@
       = auto_suggest @planting, :crop, class: 'form-control', default: @crop
       %span.help-inline
         Can't find what you're looking for?
-        = link_to "Request new crops.", new_crop_path
+        = link_to 'Request new crops.', new_crop_path
   .form-group.required
     = f.label :garden_id, 'Where did you plant it?', class: 'control-label col-md-2'
     .col-md-8
       = collection_select(:planting, :garden_id, Garden.active.where(owner_id: current_member), :id, :name, {selected: @planting.garden_id || @garden.id}, {class: 'form-control'})
       %span.help-inline
-        = link_to "Add a garden.", new_garden_path
+        = link_to 'Add a garden.', new_garden_path
   .form-group
     = f.label :planted_at, 'When?', class: 'control-label col-md-2'
     .col-md-2= f.text_field :planted_at, value: @planting.planted_at ? @planting.planted_at.to_s(:ymd) : '', class: 'add-datepicker form-control', placeholder: 'optional'

--- a/app/views/plantings/_form.html.haml
+++ b/app/views/plantings/_form.html.haml
@@ -1,6 +1,6 @@
 = required_field_help_text
 
-= form_for(@planting, :html => {:class => "form-horizontal", :role => "form"}) do |f|
+= form_for(@planting, html: {class: "form-horizontal", role: "form"}) do |f|
   - if @planting.errors.any?
     #error_explanation
       %h2= "#{pluralize(@planting.errors.size, "error")} prohibited this planting from being saved:"
@@ -9,46 +9,46 @@
           %li= msg
 
   .form-group.required
-    = f.label :crop, 'What did you plant?', :class => 'control-label col-md-2'
+    = f.label :crop, 'What did you plant?', class: 'control-label col-md-2'
     .col-md-8
-      = auto_suggest @planting, :crop, :class => 'form-control', :default => @crop
+      = auto_suggest @planting, :crop, class: 'form-control', default: @crop
       %span.help-inline
         Can't find what you're looking for?
         = link_to "Request new crops.", new_crop_path
   .form-group.required
-    = f.label :garden_id, 'Where did you plant it?', :class => 'control-label col-md-2'
+    = f.label :garden_id, 'Where did you plant it?', class: 'control-label col-md-2'
     .col-md-8
-      = collection_select(:planting, :garden_id, Garden.active.where(:owner_id => current_member), :id, :name, {:selected => @planting.garden_id || @garden.id}, {:class => 'form-control'})
+      = collection_select(:planting, :garden_id, Garden.active.where(owner_id: current_member), :id, :name, {selected: @planting.garden_id || @garden.id}, {class: 'form-control'})
       %span.help-inline
         = link_to "Add a garden.", new_garden_path
   .form-group
-    = f.label :planted_at, 'When?', :class => 'control-label col-md-2'
-    .col-md-2= f.text_field :planted_at, :value => @planting.planted_at ? @planting.planted_at.to_s(:ymd) : '', :class => 'add-datepicker form-control', :placeholder => 'optional'
+    = f.label :planted_at, 'When?', class: 'control-label col-md-2'
+    .col-md-2= f.text_field :planted_at, value: @planting.planted_at ? @planting.planted_at.to_s(:ymd) : '', class: 'add-datepicker form-control', placeholder: 'optional'
   .form-group
-    = f.label :quantity, 'How many?', :class => 'control-label col-md-2'
+    = f.label :quantity, 'How many?', class: 'control-label col-md-2'
     .col-md-2
-      = f.number_field :quantity, :class => 'form-control', :placeholder => 'optional'
+      = f.number_field :quantity, class: 'form-control', placeholder: 'optional'
   .form-group
-    = f.label :planted_from, 'Planted from:', :class => 'control-label col-md-2'
+    = f.label :planted_from, 'Planted from:', class: 'control-label col-md-2'
     .col-md-8
-      = f.select(:planted_from, Planting::PLANTED_FROM_VALUES, {:include_blank => 'optional'}, :class => 'form-control')
+      = f.select(:planted_from, Planting::PLANTED_FROM_VALUES, {include_blank: 'optional'}, class: 'form-control')
   .form-group
-    = f.label :sunniness, 'Sun or shade?', :class => 'control-label col-md-2'
+    = f.label :sunniness, 'Sun or shade?', class: 'control-label col-md-2'
     .col-md-8
-      = f.select(:sunniness, Planting::SUNNINESS_VALUES, {:include_blank => 'optional'}, :class => 'form-control')
+      = f.select(:sunniness, Planting::SUNNINESS_VALUES, {include_blank: 'optional'}, class: 'form-control')
   .form-group
-    = f.label :description, 'Tell us more about it', :class => 'control-label col-md-2'
-    .col-md-8= f.text_area :description, :rows => 6, :class => 'form-control', :placeholder => 'optional'
+    = f.label :description, 'Tell us more about it', class: 'control-label col-md-2'
+    .col-md-8= f.text_area :description, rows: 6, class: 'form-control', placeholder: 'optional'
   .form-group
-    = f.label :finished, 'Mark as finished', :class => 'control-label col-md-2'
+    = f.label :finished, 'Mark as finished', class: 'control-label col-md-2'
     .col-md-8
       = f.check_box :finished
       %span.help-block
         A planting is finished when you've harvested all of the crop, or it dies, or it's otherwise no longer growing in your garden.
   .form-group
-    = f.label :finished_at, 'Finished date', { :class => 'control-label col-md-2', :placeholder => 'optional' }
+    = f.label :finished_at, 'Finished date', { class: 'control-label col-md-2', placeholder: 'optional' }
     .col-md-2
-      = f.text_field :finished_at, :value => @planting.finished_at ? @planting.finished_at.to_s(:ymd) : '', :class => 'add-datepicker form-control', :placeholder => 'optional'
+      = f.text_field :finished_at, value: @planting.finished_at ? @planting.finished_at.to_s(:ymd) : '', class: 'add-datepicker form-control', placeholder: 'optional'
   .form-group
     .form-actions.col-md-offset-2.col-md-8
-      = f.submit 'Save', :class => 'btn btn-primary'
+      = f.submit 'Save', class: 'btn btn-primary'

--- a/app/views/plantings/_image_with_popover.html.haml
+++ b/app/views/plantings/_image_with_popover.html.haml
@@ -2,12 +2,12 @@
   = link_to |
     image_tag( |
       planting.photos.present? ? planting.photos.first.thumbnail_url : 'placeholder_150.png', |
-      :alt => planting.to_s, |
-      :class => 'image-responsive crop-image' |
+      alt: planting.to_s, |
+      class: 'image-responsive crop-image' |
     ), |
     planting, |
-    :rel => "popover", |
+    rel: "popover", |
     'data-trigger' => 'hover', |
     'data-title' => planting.to_s, |
-    'data-content' => "#{ render :partial => 'plantings/popover', :locals => { :planting => planting } }", |
+    'data-content' => "#{ render partial: 'plantings/popover', locals: { planting: planting } }", |
     'data-html' => true

--- a/app/views/plantings/_image_with_popover.html.haml
+++ b/app/views/plantings/_image_with_popover.html.haml
@@ -6,7 +6,7 @@
       class: 'image-responsive crop-image' |
     ), |
     planting, |
-    rel: "popover", |
+    rel: 'popover', |
     'data-trigger' => 'hover', |
     'data-title' => planting.to_s, |
     'data-content' => "#{ render partial: 'plantings/popover', locals: { planting: planting } }", |

--- a/app/views/plantings/_list.html.haml
+++ b/app/views/plantings/_list.html.haml
@@ -1,8 +1,8 @@
 - plantings.each do |p|
   - cache p do
     .row
-      .col-md-3{:style => 'padding-bottom: 6px'}
-        = render :partial => 'plantings/image_with_popover', :locals => { :planting => p }
+      .col-md-3{style: 'padding-bottom: 6px'}
+        = render partial: 'plantings/image_with_popover', locals: { planting: p }
       .col-md-9
         = link_to p.crop, p.crop
         in

--- a/app/views/plantings/_planting_progress.html.haml
+++ b/app/views/plantings/_planting_progress.html.haml
@@ -7,4 +7,4 @@
 	= 'Progress: Not calculated, days before maturity unknown'
 - else
 	= "Progress: #{planting.percentage_grown}%"
-	= render partial: "plantings/progress_bar", locals: {status: "success", progress: "#{planting.percentage_grown}%"}
+	= render partial: 'plantings/progress_bar', locals: {status: 'success', progress: "#{planting.percentage_grown}%"}

--- a/app/views/plantings/_planting_progress.html.haml
+++ b/app/views/plantings/_planting_progress.html.haml
@@ -1,10 +1,10 @@
 - if !planting.planted?
-	= "Progress: 0% - not planted yet"
+	= 'Progress: 0% - not planted yet'
 - elsif planting.finished?
-	= "Progress: 100%"
+	= 'Progress: 100%'
 	= render partial: "plantings/progress_bar", locals: {status: "success", progress: "100%"}
 - elsif planting.days_before_maturity.nil?
-	= "Progress: Not calculated, days before maturity unknown"
+	= 'Progress: Not calculated, days before maturity unknown'
 - else
 	= "Progress: #{planting.percentage_grown}%"
 	= render partial: "plantings/progress_bar", locals: {status: "success", progress: "#{planting.percentage_grown}%"}

--- a/app/views/plantings/_planting_progress.html.haml
+++ b/app/views/plantings/_planting_progress.html.haml
@@ -2,7 +2,7 @@
 	= 'Progress: 0% - not planted yet'
 - elsif planting.finished?
 	= 'Progress: 100%'
-	= render partial: "plantings/progress_bar", locals: {status: "success", progress: "100%"}
+	= render partial: 'plantings/progress_bar', locals: {status: 'success', progress: '100%'}
 - elsif planting.days_before_maturity.nil?
 	= 'Progress: Not calculated, days before maturity unknown'
 - else

--- a/app/views/plantings/_progress_bar.html.haml
+++ b/app/views/plantings/_progress_bar.html.haml
@@ -1,2 +1,2 @@
 .progress
-	%div{:class => "progress-bar progress-bar-#{status}", :role => "progressbar", :style => "width: #{progress}"}
+	%div{class: "progress-bar progress-bar-#{status}", role: "progressbar", style: "width: #{progress}"}

--- a/app/views/plantings/_progress_bar.html.haml
+++ b/app/views/plantings/_progress_bar.html.haml
@@ -1,2 +1,2 @@
 .progress
-	%div{class: "progress-bar progress-bar-#{status}", role: "progressbar", style: "width: #{progress}"}
+	%div{class: "progress-bar progress-bar-#{status}", role: 'progressbar', style: "width: #{progress}"}

--- a/app/views/plantings/_thumbnail.html.haml
+++ b/app/views/plantings/_thumbnail.html.haml
@@ -4,7 +4,7 @@
   .panel-body
     .row
       .col-xs-12.col-md-4
-        = link_to image_tag((planting.default_photo ?  planting.default_photo.thumbnail_url : 'placeholder_150.png'), :alt => planting.crop_id, :class => 'img'), planting
+        = link_to image_tag((planting.default_photo ?  planting.default_photo.thumbnail_url : 'placeholder_150.png'), alt: planting.crop_id, class: 'img'), planting
       .col-xs-7.col-md-5
         %dl.dl-horizontal.planting-attributes
           %dt Owner:
@@ -20,19 +20,19 @@
           %dt Sun/shade?:
           %dd
             - sunniness = planting.sunniness.blank? ? "not specified" : planting.sunniness
-            = image_tag("sunniness_#{sunniness}.png", :size => "25x25", :alt => "#{sunniness}", :title => "#{sunniness}")
+            = image_tag("sunniness_#{sunniness}.png", size: "25x25", alt: "#{sunniness}", title: "#{sunniness}")
             = " (#{sunniness})"
           %dt Planted from:
           %dd= "#{display_planted_from(planting)}"
       .col-xs-1.col-md-3
-        %ul{:style => "list-style-type:none; text-align:right"}
-          %li= link_to 'Details', planting, :class => 'btn btn-default btn-xs'
+        %ul{style: "list-style-type:none; text-align:right"}
+          %li= link_to 'Details', planting, class: 'btn btn-default btn-xs'
           - if can? :edit, planting
-            %li= link_to 'Edit', edit_planting_path(planting), :class => 'btn btn-default btn-xs'
+            %li= link_to 'Edit', edit_planting_path(planting), class: 'btn btn-default btn-xs'
             - if ! planting.finished
-              %li= link_to "Mark as finished", planting_path(planting, :planting => {:finished => 1}),  :method => :put, :class => 'btn btn-default btn-xs append-date'
+              %li= link_to "Mark as finished", planting_path(planting, planting: {finished: 1}),  method: :put, class: 'btn btn-default btn-xs append-date'
           - if can? :destroy, planting
-            %li= link_to 'Delete', planting, method: :delete, data: { confirm: 'Are you sure?' }, :class => 'btn btn-default btn-xs'
+            %li= link_to 'Delete', planting, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-default btn-xs'
 
     .row
       .col-xs-12.col-md-4

--- a/app/views/plantings/_thumbnail.html.haml
+++ b/app/views/plantings/_thumbnail.html.haml
@@ -19,18 +19,18 @@
           %dd= "#{display_finished(planting)}"
           %dt Sun/shade?:
           %dd
-            - sunniness = planting.sunniness.blank? ? "not specified" : planting.sunniness
+            - sunniness = planting.sunniness.blank? ? 'not specified' : planting.sunniness
             = image_tag("sunniness_#{sunniness}.png", size: "25x25", alt: "#{sunniness}", title: "#{sunniness}")
             = " (#{sunniness})"
           %dt Planted from:
           %dd= "#{display_planted_from(planting)}"
       .col-xs-1.col-md-3
-        %ul{style: "list-style-type:none; text-align:right"}
+        %ul{style: 'list-style-type:none; text-align:right'}
           %li= link_to 'Details', planting, class: 'btn btn-default btn-xs'
           - if can? :edit, planting
             %li= link_to 'Edit', edit_planting_path(planting), class: 'btn btn-default btn-xs'
             - if ! planting.finished
-              %li= link_to "Mark as finished", planting_path(planting, planting: {finished: 1}),  method: :put, class: 'btn btn-default btn-xs append-date'
+              %li= link_to 'Mark as finished', planting_path(planting, planting: {finished: 1}),  method: :put, class: 'btn btn-default btn-xs append-date'
           - if can? :destroy, planting
             %li= link_to 'Delete', planting, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-default btn-xs'
 

--- a/app/views/plantings/_thumbnail.html.haml
+++ b/app/views/plantings/_thumbnail.html.haml
@@ -20,7 +20,7 @@
           %dt Sun/shade?:
           %dd
             - sunniness = planting.sunniness.blank? ? 'not specified' : planting.sunniness
-            = image_tag("sunniness_#{sunniness}.png", size: "25x25", alt: "#{sunniness}", title: "#{sunniness}")
+            = image_tag("sunniness_#{sunniness}.png", size: '25x25', alt: "#{sunniness}", title: "#{sunniness}")
             = " (#{sunniness})"
           %dt Planted from:
           %dd= "#{display_planted_from(planting)}"

--- a/app/views/plantings/edit.html.haml
+++ b/app/views/plantings/edit.html.haml
@@ -1,3 +1,3 @@
-= content_for :title, "Editing planting"
+= content_for :title, 'Editing planting'
 
 = render 'form'

--- a/app/views/plantings/index.html.haml
+++ b/app/views/plantings/index.html.haml
@@ -24,7 +24,7 @@
   - if @plantings.size > 0
     - @plantings.each.with_index do |planting|
       .col-xs-12.col-lg-6
-        = render partial: "plantings/thumbnail", locals: {planting: planting}
+        = render partial: 'plantings/thumbnail', locals: {planting: planting}
 
 %div.pagination
   = page_entries_info @plantings
@@ -33,10 +33,10 @@
   %ul.list-inline
     %li The data on this page is available in the following formats:
     - if @owner
-      %li= link_to "CSV", plantings_by_owner_path(@owner, format: 'csv')
-      %li= link_to "JSON", plantings_by_owner_path(@owner, format: 'json')
-      %li= link_to "RSS", plantings_by_owner_path(@owner, format: 'rss')
+      %li= link_to 'CSV', plantings_by_owner_path(@owner, format: 'csv')
+      %li= link_to 'JSON', plantings_by_owner_path(@owner, format: 'json')
+      %li= link_to 'RSS', plantings_by_owner_path(@owner, format: 'rss')
     - else
-      %li= link_to "CSV", plantings_path(format: 'csv')
-      %li= link_to "JSON", plantings_path(format: 'json')
-      %li= link_to "RSS", plantings_path(format: 'rss')
+      %li= link_to 'CSV', plantings_path(format: 'csv')
+      %li= link_to 'JSON', plantings_path(format: 'json')
+      %li= link_to 'RSS', plantings_path(format: 'rss')

--- a/app/views/plantings/index.html.haml
+++ b/app/views/plantings/index.html.haml
@@ -7,14 +7,14 @@
     - if @owner
       %p
         - if @owner == current_member
-          = link_to 'Plant something', new_planting_path, :class => 'btn btn-primary'
-        = link_to "View everyone's plantings", plantings_path, :class => 'btn btn-default'
+          = link_to 'Plant something', new_planting_path, class: 'btn btn-primary'
+        = link_to "View everyone's plantings", plantings_path, class: 'btn btn-default'
     - else # everyone's plantings
-      = link_to 'Plant something', new_planting_path, :class => 'btn btn-primary'
+      = link_to 'Plant something', new_planting_path, class: 'btn btn-primary'
       - if current_member
-        = link_to 'View your plantings', plantings_by_owner_path(:owner => current_member.slug), :class => 'btn btn-default'
+        = link_to 'View your plantings', plantings_by_owner_path(owner: current_member.slug), class: 'btn btn-default'
   - else
-    = render :partial => 'shared/signin_signup', :locals => { :to => "track what you've planted" }
+    = render partial: 'shared/signin_signup', locals: { to: "track what you've planted" }
 
 %div.pagination
   = page_entries_info @plantings
@@ -24,7 +24,7 @@
   - if @plantings.size > 0
     - @plantings.each.with_index do |planting|
       .col-xs-12.col-lg-6
-        = render partial: "plantings/thumbnail", locals: {:planting => planting}
+        = render partial: "plantings/thumbnail", locals: {planting: planting}
 
 %div.pagination
   = page_entries_info @plantings
@@ -33,10 +33,10 @@
   %ul.list-inline
     %li The data on this page is available in the following formats:
     - if @owner
-      %li= link_to "CSV", plantings_by_owner_path(@owner, :format => 'csv')
-      %li= link_to "JSON", plantings_by_owner_path(@owner, :format => 'json')
-      %li= link_to "RSS", plantings_by_owner_path(@owner, :format => 'rss')
+      %li= link_to "CSV", plantings_by_owner_path(@owner, format: 'csv')
+      %li= link_to "JSON", plantings_by_owner_path(@owner, format: 'json')
+      %li= link_to "RSS", plantings_by_owner_path(@owner, format: 'rss')
     - else
-      %li= link_to "CSV", plantings_path(:format => 'csv')
-      %li= link_to "JSON", plantings_path(:format => 'json')
-      %li= link_to "RSS", plantings_path(:format => 'rss')
+      %li= link_to "CSV", plantings_path(format: 'csv')
+      %li= link_to "JSON", plantings_path(format: 'json')
+      %li= link_to "RSS", plantings_path(format: 'rss')

--- a/app/views/plantings/index.rss.haml
+++ b/app/views/plantings/index.rss.haml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-%rss{:version => 2.0}
+%rss{version: 2.0}
   %channel
     %title
       Recent plantings from #{ @owner ? @owner : 'all members' } (#{ENV['GROWSTUFF_SITE_NAME']})

--- a/app/views/plantings/new.html.haml
+++ b/app/views/plantings/new.html.haml
@@ -1,3 +1,3 @@
-=content_for :title, "Plant something"
+=content_for :title, 'Plant something'
 
 = render 'form'

--- a/app/views/plantings/show.html.haml
+++ b/app/views/plantings/show.html.haml
@@ -62,7 +62,7 @@
   %h2 Notes
 
   :growstuff_markdown
-    #{ @planting.description != "" ? @planting.description : "No description given." }
+    #{ @planting.description != '' ? @planting.description : 'No description given.' }
 
 - if @planting.photos.size > 0 or (can? :edit, @planting and can? :create, Photo)
   %h2 Pictures
@@ -75,4 +75,4 @@
       .col-md-2
         .thumbnail(style='height: 220px')
           %p{style: 'text-align: center; padding-top: 50px'}
-            = link_to "Add photo", new_photo_path(type: "planting", id: @planting.id), class: 'btn btn-primary'
+            = link_to 'Add photo', new_photo_path(type: 'planting', id: @planting.id), class: 'btn btn-primary'

--- a/app/views/plantings/show.html.haml
+++ b/app/views/plantings/show.html.haml
@@ -10,7 +10,7 @@
         = link_to "view all #{@planting.owner}'s plantings", plantings_by_owner_path(owner: @planting.owner.slug)
 
       %dt Planted on:
-      %dd= @planting.planted_at ? @planting.planted_at : "not specified"
+      %dd= @planting.planted_at ? @planting.planted_at : 'not specified'
 
       %dt Where:
       %dd
@@ -29,7 +29,7 @@
     
       %dt Sun or shade?
       %dd
-        - sunniness = @planting.sunniness.blank? ? "not specified" : @planting.sunniness
+        - sunniness = @planting.sunniness.blank? ? 'not specified' : @planting.sunniness
         = image_tag("sunniness_#{sunniness}.png", size: "25x25", alt: "#{sunniness}", title: "#{sunniness}")
         = " (#{sunniness})"
 
@@ -47,17 +47,17 @@
         - if can? :edit, @planting
           =link_to 'Edit', edit_planting_path(@planting), class: 'btn btn-default btn-xs'
           - if ! @planting.finished
-            = link_to "Mark as finished", planting_path(@planting, planting: {finished: 1}),  method: :put, class: 'btn btn-default btn-xs append-date'
+            = link_to 'Mark as finished', planting_path(@planting, planting: {finished: 1}),  method: :put, class: 'btn btn-default btn-xs append-date'
         - if can? :destroy, @planting
           =link_to 'Delete', @planting, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-default btn-xs'
 
   .col-md-6
-    = render partial: "crops/index_card", locals: { crop: @planting.crop}
+    = render partial: 'crops/index_card', locals: { crop: @planting.crop}
     - if @planting.owner.location
       %p
         %small
           View other plantings, members and more near
-          = link_to @planting.owner.location, place_path(@planting.owner.location, anchor: "plantings")
+          = link_to @planting.owner.location, place_path(@planting.owner.location, anchor: 'plantings')
 - if @planting.description
   %h2 Notes
 

--- a/app/views/plantings/show.html.haml
+++ b/app/views/plantings/show.html.haml
@@ -7,7 +7,7 @@
       %dd
         = link_to @planting.owner, @planting.owner
         &mdash;
-        = link_to "view all #{@planting.owner}'s plantings", plantings_by_owner_path(:owner => @planting.owner.slug)
+        = link_to "view all #{@planting.owner}'s plantings", plantings_by_owner_path(owner: @planting.owner.slug)
 
       %dt Planted on:
       %dd= @planting.planted_at ? @planting.planted_at : "not specified"
@@ -30,7 +30,7 @@
       %dt Sun or shade?
       %dd
         - sunniness = @planting.sunniness.blank? ? "not specified" : @planting.sunniness
-        = image_tag("sunniness_#{sunniness}.png", :size => "25x25", :alt => "#{sunniness}", :title => "#{sunniness}")
+        = image_tag("sunniness_#{sunniness}.png", size: "25x25", alt: "#{sunniness}", title: "#{sunniness}")
         = " (#{sunniness})"
 
       %dt Days until maturity:
@@ -45,14 +45,14 @@
     - if can? :edit, @planting or can? :destroy, @planting
       %p
         - if can? :edit, @planting
-          =link_to 'Edit', edit_planting_path(@planting), :class => 'btn btn-default btn-xs'
+          =link_to 'Edit', edit_planting_path(@planting), class: 'btn btn-default btn-xs'
           - if ! @planting.finished
-            = link_to "Mark as finished", planting_path(@planting, :planting => {:finished => 1}),  :method => :put, :class => 'btn btn-default btn-xs append-date'
+            = link_to "Mark as finished", planting_path(@planting, planting: {finished: 1}),  method: :put, class: 'btn btn-default btn-xs append-date'
         - if can? :destroy, @planting
-          =link_to 'Delete', @planting, method: :delete, data: { confirm: 'Are you sure?' }, :class => 'btn btn-default btn-xs'
+          =link_to 'Delete', @planting, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-default btn-xs'
 
   .col-md-6
-    = render :partial => "crops/index_card", :locals => { :crop => @planting.crop}
+    = render partial: "crops/index_card", locals: { crop: @planting.crop}
     - if @planting.owner.location
       %p
         %small
@@ -70,9 +70,9 @@
   .row
     - @planting.photos.each do |p|
       .col-md-2.six-across
-        = render :partial => 'photos/thumbnail', :locals => { :photo => p }
+        = render partial: 'photos/thumbnail', locals: { photo: p }
     - if can? :create, Photo and can? :edit, @planting
       .col-md-2
         .thumbnail(style='height: 220px')
-          %p{:style => 'text-align: center; padding-top: 50px'}
-            = link_to "Add photo", new_photo_path(:type => "planting", :id => @planting.id), :class => 'btn btn-primary'
+          %p{style: 'text-align: center; padding-top: 50px'}
+            = link_to "Add photo", new_photo_path(type: "planting", id: @planting.id), class: 'btn btn-primary'

--- a/app/views/plantings/show.html.haml
+++ b/app/views/plantings/show.html.haml
@@ -30,7 +30,7 @@
       %dt Sun or shade?
       %dd
         - sunniness = @planting.sunniness.blank? ? 'not specified' : @planting.sunniness
-        = image_tag("sunniness_#{sunniness}.png", size: "25x25", alt: "#{sunniness}", title: "#{sunniness}")
+        = image_tag("sunniness_#{sunniness}.png", size: '25x25', alt: "#{sunniness}", title: "#{sunniness}")
         = " (#{sunniness})"
 
       %dt Days until maturity:

--- a/app/views/posts/_comments.html.haml
+++ b/app/views/posts/_comments.html.haml
@@ -1,9 +1,9 @@
-%a{:name => "comments"}
+%a{name: "comments"}
 - if post.comments
   %h2
     =pluralize(post.comments.size, "comment")
   - post.comments.post_order.each do |c|
-    = render :partial => "comments/single", :locals => { :comment => c }
+    = render partial: "comments/single", locals: { comment: c }
 
 - else
   %h2 There are no comments yet

--- a/app/views/posts/_comments.html.haml
+++ b/app/views/posts/_comments.html.haml
@@ -1,9 +1,9 @@
-%a{name: "comments"}
+%a{name: 'comments'}
 - if post.comments
   %h2
-    =pluralize(post.comments.size, "comment")
+    =pluralize(post.comments.size, 'comment')
   - post.comments.post_order.each do |c|
-    = render partial: "comments/single", locals: { comment: c }
+    = render partial: 'comments/single', locals: { comment: c }
 
 - else
   %h2 There are no comments yet

--- a/app/views/posts/_form.html.haml
+++ b/app/views/posts/_form.html.haml
@@ -1,4 +1,4 @@
-= form_for(@post, html: {role: "form"}) do |f|
+= form_for(@post, html: {role: 'form'}) do |f|
   - if @post.errors.any?
     #error_explanation
       %h2= "#{pluralize(@post.errors.size, "error")} prohibited this post from being saved:"
@@ -7,7 +7,7 @@
           %li= msg
 
   .form-group
-    = label_tag :post, "Subject", class: 'control-label'
+    = label_tag :post, 'Subject', class: 'control-label'
     = f.text_field :subject, class: 'form-control', autofocus: 'autofocus', maxlength: 255
 
   .form-group
@@ -17,7 +17,7 @@
       = label_tag :body, "What's going on in your food garden?"
     = f.text_area :body, rows: 12, class: 'form-control'
     %span.help-block
-      = render partial: "shared/markdown_help"
+      = render partial: 'shared/markdown_help'
 
   - if @post.forum || @forum
     - forum = @post.forum || @forum
@@ -27,4 +27,4 @@
     .field
       = f.hidden_field :forum_id, value: forum.id
 
-  = f.submit "Post", class: 'btn btn-primary'
+  = f.submit 'Post', class: 'btn btn-primary'

--- a/app/views/posts/_form.html.haml
+++ b/app/views/posts/_form.html.haml
@@ -1,4 +1,4 @@
-= form_for(@post, :html => {:role => "form"}) do |f|
+= form_for(@post, html: {role: "form"}) do |f|
   - if @post.errors.any?
     #error_explanation
       %h2= "#{pluralize(@post.errors.size, "error")} prohibited this post from being saved:"
@@ -7,17 +7,17 @@
           %li= msg
 
   .form-group
-    = label_tag :post, "Subject", :class => 'control-label'
-    = f.text_field :subject, :class => 'form-control', :autofocus => 'autofocus', :maxlength => 255
+    = label_tag :post, "Subject", class: 'control-label'
+    = f.text_field :subject, class: 'form-control', autofocus: 'autofocus', maxlength: 255
 
   .form-group
     - if @post.forum || @forum
-      = label_tag :body, "What's up?", :class => 'control-label'
+      = label_tag :body, "What's up?", class: 'control-label'
     - else
       = label_tag :body, "What's going on in your food garden?"
-    = f.text_area :body, :rows => 12, :class => 'form-control'
+    = f.text_area :body, rows: 12, class: 'form-control'
     %span.help-block
-      = render :partial => "shared/markdown_help"
+      = render partial: "shared/markdown_help"
 
   - if @post.forum || @forum
     - forum = @post.forum || @forum
@@ -25,6 +25,6 @@
       This post will be posted in the forum
       =link_to forum.name, forum
     .field
-      = f.hidden_field :forum_id, :value => forum.id
+      = f.hidden_field :forum_id, value: forum.id
 
-  = f.submit "Post", :class => 'btn btn-primary'
+  = f.submit "Post", class: 'btn btn-primary'

--- a/app/views/posts/_single.html.haml
+++ b/app/views/posts/_single.html.haml
@@ -2,7 +2,7 @@
   .post
     .row
       .col-md-1
-        = render partial: "members/avatar", locals: { member: post.author }
+        = render partial: 'members/avatar', locals: { member: post.author }
       .col-md-11
         - if defined?(subject)
           %h3= link_to strip_tags(post.subject), post
@@ -24,12 +24,12 @@
         - unless defined?(hide_comments)
           .post-comments
             %ul.list-inline
-              %li.first= link_to pluralize(post.comments.size, "comment"),
+              %li.first= link_to pluralize(post.comments.size, 'comment'),
                 post_path(post, anchor: 'comments')
               -if can? :create, Comment
-                %li= link_to "Reply", new_comment_path(post_id: post.id)
-              %li= link_to "Permalink", post
+                %li= link_to 'Reply', new_comment_path(post_id: post.id)
+              %li= link_to 'Permalink', post
               -if can? :edit, post
-                %li= link_to "Edit", edit_post_path(post)
+                %li= link_to 'Edit', edit_post_path(post)
 
 

--- a/app/views/posts/_single.html.haml
+++ b/app/views/posts/_single.html.haml
@@ -2,7 +2,7 @@
   .post
     .row
       .col-md-1
-        = render :partial => "members/avatar", :locals => { :member => post.author }
+        = render partial: "members/avatar", locals: { member: post.author }
       .col-md-11
         - if defined?(subject)
           %h3= link_to strip_tags(post.subject), post
@@ -25,9 +25,9 @@
           .post-comments
             %ul.list-inline
               %li.first= link_to pluralize(post.comments.size, "comment"),
-                post_path(post, :anchor => 'comments')
+                post_path(post, anchor: 'comments')
               -if can? :create, Comment
-                %li= link_to "Reply", new_comment_path(:post_id => post.id)
+                %li= link_to "Reply", new_comment_path(post_id: post.id)
               %li= link_to "Permalink", post
               -if can? :edit, post
                 %li= link_to "Edit", edit_post_path(post)

--- a/app/views/posts/_summary.html.haml
+++ b/app/views/posts/_summary.html.haml
@@ -11,7 +11,7 @@
       - cache post do
         %tr
           %td
-            = link_to truncate(strip_tags(post.subject), :length => 40, :separator => ' '), post
+            = link_to truncate(strip_tags(post.subject), length: 40, separator: ' '), post
           %td.hidden-xs
             =link_to post.author, post.author
           %td

--- a/app/views/posts/edit.html.haml
+++ b/app/views/posts/edit.html.haml
@@ -1,4 +1,4 @@
-= content_for :title, "Edit post"
+= content_for :title, 'Edit post'
 
 =render 'form'
 

--- a/app/views/posts/index.html.haml
+++ b/app/views/posts/index.html.haml
@@ -20,7 +20,7 @@
 
 - unless @posts.empty?
   - @posts.each do |post|
-    = render partial: "single", locals: { post: post, subject: true }
+    = render partial: 'single', locals: { post: post, subject: true }
 
   %div.pagination
     = page_entries_info @posts
@@ -29,12 +29,12 @@
 %p
   - if @author
     Subscribe to
-    = succeed "." do
+    = succeed '.' do
       = link_to "#{@author}'s posts RSS feed", posts_by_author_path(format: 'rss', author: @author)
 
   - else
     Subscribe to the #{ENV['GROWSTUFF_SITE_NAME']}
-    = link_to "posts RSS feed", posts_path(format: 'rss')
+    = link_to 'posts RSS feed', posts_path(format: 'rss')
     or
-    = succeed "." do
-      = link_to "comments RSS feed", comments_path(format: 'rss')
+    = succeed '.' do
+      = link_to 'comments RSS feed', comments_path(format: 'rss')

--- a/app/views/posts/index.html.haml
+++ b/app/views/posts/index.html.haml
@@ -5,14 +5,14 @@
     - if @author
       %p
         - if @author == current_member
-          = link_to 'Post something', new_post_path, :class => 'btn btn-primary'
-        = link_to "View everyone's posts", posts_path, :class => 'btn btn-default'
+          = link_to 'Post something', new_post_path, class: 'btn btn-primary'
+        = link_to "View everyone's posts", posts_path, class: 'btn btn-default'
     - else # everyone's posts
-      = link_to 'Post something', new_post_path, :class => 'btn btn-primary'
+      = link_to 'Post something', new_post_path, class: 'btn btn-primary'
       - if current_member
-        = link_to 'View your posts', posts_by_author_path(:author => current_member.slug), :class => 'btn btn-default'
+        = link_to 'View your posts', posts_by_author_path(author: current_member.slug), class: 'btn btn-default'
   - else
-    = render :partial => 'shared/signin_signup', :locals => { :to => 'write a post' }
+    = render partial: 'shared/signin_signup', locals: { to: 'write a post' }
 
 %div.pagination
   = page_entries_info @posts
@@ -20,7 +20,7 @@
 
 - unless @posts.empty?
   - @posts.each do |post|
-    = render :partial => "single", :locals => { :post => post, :subject => true }
+    = render partial: "single", locals: { post: post, subject: true }
 
   %div.pagination
     = page_entries_info @posts
@@ -34,7 +34,7 @@
 
   - else
     Subscribe to the #{ENV['GROWSTUFF_SITE_NAME']}
-    = link_to "posts RSS feed", posts_path(:format => 'rss')
+    = link_to "posts RSS feed", posts_path(format: 'rss')
     or
     = succeed "." do
-      = link_to "comments RSS feed", comments_path(:format => 'rss')
+      = link_to "comments RSS feed", comments_path(format: 'rss')

--- a/app/views/posts/index.rss.haml
+++ b/app/views/posts/index.rss.haml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-%rss{:version => 2.0}
+%rss{version: 2.0}
   %channel
     %title
       Recent posts from #{ @author ? @author : 'all members' } (#{ENV['GROWSTUFF_SITE_NAME']})

--- a/app/views/posts/new.html.haml
+++ b/app/views/posts/new.html.haml
@@ -1,4 +1,4 @@
-= content_for :title, @forum ? "Post in #{@forum.name}" : "Post something"
+= content_for :title, @forum ? "Post in #{@forum.name}" : 'Post something'
 
 =render 'form'
 

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -4,17 +4,17 @@
   .alert.alert-info
     = link_to @post.author.login_name, member_path(@post.author)
     is using
-    = link_to ENV["GROWSTUFF_SITE_NAME"], root_path
+    = link_to ENV['GROWSTUFF_SITE_NAME'], root_path
     to discuss #{ @post.subject } with a community of food gardeners worldwide.
     We have advice on growing
-    = succeed "," do
+    = succeed ',' do
       = link_to 'hundreds of different crops', crops_url
     and a community from all around the world.
 
-    = render partial: "shared/signin_signup", 
+    = render partial: 'shared/signin_signup', 
       locals: { to: "or to start using #{ENV["GROWSTUFF_SITE_NAME"]} to track what you're planting and harvesting" }
 
-= render partial: "single", locals: { post: @post, subject: false, hide_comments: true }
+= render partial: 'single', locals: { post: @post, subject: false, hide_comments: true }
 
 - unless @post.crops.empty?
   %h3 Crops mentioned in this post
@@ -31,7 +31,7 @@
         = link_to 'Delete Post', @post, method: :delete, |
           data: { confirm: 'Are you sure?' }, class: 'btn btn-default btn-xs'
 
-  = render partial: "comments", locals: { post: @post }
+  = render partial: 'comments', locals: { post: @post }
 
   - if can? :create, Comment
     .post-actions

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -11,28 +11,28 @@
       = link_to 'hundreds of different crops', crops_url
     and a community from all around the world.
 
-    = render :partial => "shared/signin_signup", 
-      :locals => { :to => "or to start using #{ENV["GROWSTUFF_SITE_NAME"]} to track what you're planting and harvesting" }
+    = render partial: "shared/signin_signup", 
+      locals: { to: "or to start using #{ENV["GROWSTUFF_SITE_NAME"]} to track what you're planting and harvesting" }
 
-= render :partial => "single", :locals => { :post => @post, :subject => false, :hide_comments => true }
+= render partial: "single", locals: { post: @post, subject: false, hide_comments: true }
 
 - unless @post.crops.empty?
   %h3 Crops mentioned in this post
   - @post.crops.each do |c|
     .col-md-2
-      = render :partial => 'crops/thumbnail', :locals => { :crop => c }
+      = render partial: 'crops/thumbnail', locals: { crop: c }
 
 .col-md-11
   - if can? :edit, @post or can? :destroy, @post
     .post-actions
       - if can? :edit, @post
-        = link_to 'Edit Post', edit_post_path(@post), :class => 'btn btn-default btn-xs'
+        = link_to 'Edit Post', edit_post_path(@post), class: 'btn btn-default btn-xs'
       - if can? :destroy, @post
         = link_to 'Delete Post', @post, method: :delete, |
-          data: { confirm: 'Are you sure?' }, :class => 'btn btn-default btn-xs'
+          data: { confirm: 'Are you sure?' }, class: 'btn btn-default btn-xs'
 
-  = render :partial => "comments", :locals => { :post => @post }
+  = render partial: "comments", locals: { post: @post }
 
   - if can? :create, Comment
     .post-actions
-      =link_to 'Comment', new_comment_path(:post_id => @post.id), :class => 'btn btn-primary'
+      =link_to 'Comment', new_comment_path(post_id: @post.id), class: 'btn btn-primary'

--- a/app/views/posts/show.rss.haml
+++ b/app/views/posts/show.rss.haml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-%rss{:version => 2.0}
+%rss{version: 2.0}
   %channel
     %title Recent comments on #{@post.subject} (#{ENV['GROWSTUFF_SITE_NAME']})
     %link= post_url(@post)

--- a/app/views/products/_form.html.haml
+++ b/app/views/products/_form.html.haml
@@ -13,10 +13,10 @@
     = f.label :description
     = f.text_area :description, class: 'form-control'
   .field
-    = f.label :min_price, "Minimum price (in cents)"
+    = f.label :min_price, 'Minimum price (in cents)'
     = f.text_field :min_price
   .field
-    = f.label :recommended_price, "Recommended price (in cents)"
+    = f.label :recommended_price, 'Recommended price (in cents)'
     = f.text_field :recommended_price
   .field
     = f.label :account_type

--- a/app/views/products/_form.html.haml
+++ b/app/views/products/_form.html.haml
@@ -8,10 +8,10 @@
 
   .field
     = f.label :name
-    = f.text_field :name, :class => 'form-control'
+    = f.text_field :name, class: 'form-control'
   .field
     = f.label :description
-    = f.text_area :description, :class => 'form-control'
+    = f.text_area :description, class: 'form-control'
   .field
     = f.label :min_price, "Minimum price (in cents)"
     = f.text_field :min_price
@@ -21,7 +21,7 @@
   .field
     = f.label :account_type
     = collection_select(:product, :account_type_id, AccountType.all, :id,
-        :name, :selected => @product.account_type_id )
+        :name, selected: @product.account_type_id )
   .field
     = f.label :paid_months
     = f.text_field :paid_months

--- a/app/views/products/edit.html.haml
+++ b/app/views/products/edit.html.haml
@@ -1,4 +1,4 @@
-- content_for :title, "Editing product"
+- content_for :title, 'Editing product'
 
 = render 'form'
 

--- a/app/views/products/index.html.haml
+++ b/app/views/products/index.html.haml
@@ -22,7 +22,7 @@
       %td= product.paid_months
       %td= link_to 'Show', product
       %td= link_to 'Edit', edit_product_path(product)
-      %td= link_to 'Destroy', product, :method => :delete, :data => { :confirm => 'Are you sure?' }
+      %td= link_to 'Destroy', product, method: :delete, data: { confirm: 'Are you sure?' }
 
 %br
 

--- a/app/views/products/index.html.haml
+++ b/app/views/products/index.html.haml
@@ -1,4 +1,4 @@
-- content_for :title, "Listing products"
+- content_for :title, 'Listing products'
 
 %table
   %tr
@@ -18,7 +18,7 @@
       %td= product.description
       %td= product.min_price
       %td= product.recommended_price
-      %td= product.account_type ? product.account_type.name : ""
+      %td= product.account_type ? product.account_type.name : ''
       %td= product.paid_months
       %td= link_to 'Show', product
       %td= link_to 'Edit', edit_product_path(product)

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -1,4 +1,4 @@
-- content_for :title, "New product"
+- content_for :title, 'New product'
 
 = render 'form'
 

--- a/app/views/roles/edit.html.haml
+++ b/app/views/roles/edit.html.haml
@@ -1,4 +1,4 @@
-- content_for :title, "Editing role"
+- content_for :title, 'Editing role'
 
 = render 'form'
 

--- a/app/views/roles/index.html.haml
+++ b/app/views/roles/index.html.haml
@@ -1,4 +1,4 @@
-- content_for :title, "Listing roles"
+- content_for :title, 'Listing roles'
 
 - if can? :create, Role
   %p= link_to 'New Role', new_role_path, class: 'btn btn-primary'

--- a/app/views/roles/index.html.haml
+++ b/app/views/roles/index.html.haml
@@ -1,7 +1,7 @@
 - content_for :title, "Listing roles"
 
 - if can? :create, Role
-  %p= link_to 'New Role', new_role_path, :class => 'btn btn-primary'
+  %p= link_to 'New Role', new_role_path, class: 'btn btn-primary'
 
 %table
   %tr
@@ -16,6 +16,6 @@
       %td= link_to role.name, role
       %td= role.description
       - if can? :edit, role
-        %td= link_to 'Edit', edit_role_path(role), :class => 'btn btn-default btn-xs'
+        %td= link_to 'Edit', edit_role_path(role), class: 'btn btn-default btn-xs'
       - if can? :destroy, role
-        %td= link_to 'Delete', role, method: :delete, data: { confirm: 'Are you sure?' }, :class => 'btn btn-default btn-xs'
+        %td= link_to 'Delete', role, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-default btn-xs'

--- a/app/views/roles/new.html.haml
+++ b/app/views/roles/new.html.haml
@@ -1,4 +1,4 @@
-- content_for :title, "New role"
+- content_for :title, 'New role'
 
 = render 'form'
 

--- a/app/views/roles/show.html.haml
+++ b/app/views/roles/show.html.haml
@@ -7,6 +7,6 @@
   %b Description:
   = @role.description
 
-= link_to 'Edit', edit_role_path(@role), :class => 'btn btn-default btn-xs'
+= link_to 'Edit', edit_role_path(@role), class: 'btn btn-default btn-xs'
 \|
 = link_to 'Back', roles_path

--- a/app/views/scientific_names/_form.html.haml
+++ b/app/views/scientific_names/_form.html.haml
@@ -1,4 +1,4 @@
-= form_for @scientific_name, html: {class: 'form-horizontal', role: "form"} do |f|
+= form_for @scientific_name, html: {class: 'form-horizontal', role: 'form'} do |f|
   - if @scientific_name.errors.any?
     #error_explanation
       %h2= "#{pluralize(@scientific_name.errors.size, "error")} prohibited this scientific_name from being saved:"

--- a/app/views/scientific_names/_form.html.haml
+++ b/app/views/scientific_names/_form.html.haml
@@ -1,4 +1,4 @@
-= form_for @scientific_name, :html => {:class => 'form-horizontal', :role => "form"} do |f|
+= form_for @scientific_name, html: {class: 'form-horizontal', role: "form"} do |f|
   - if @scientific_name.errors.any?
     #error_explanation
       %h2= "#{pluralize(@scientific_name.errors.size, "error")} prohibited this scientific_name from being saved:"
@@ -13,13 +13,13 @@
       on the Growstuff wiki.
 
   .form-group
-    = f.label :crop_id, :class => 'control-label col-md-2'
+    = f.label :crop_id, class: 'control-label col-md-2'
     .col-md-8
-      = collection_select(:scientific_name, :crop_id, Crop.all, :id, :name, { :selected => @scientific_name.crop_id || @crop.id }, :class => 'form-control')
+      = collection_select(:scientific_name, :crop_id, Crop.all, :id, :name, { selected: @scientific_name.crop_id || @crop.id }, class: 'form-control')
   .form-group
-    = f.label :scientific_name, :class => 'control-label col-md-2'
+    = f.label :scientific_name, class: 'control-label col-md-2'
     .col-md-8
-      = f.text_field :scientific_name, :class => 'form-control'
+      = f.text_field :scientific_name, class: 'form-control'
   .form-group
     .form-actions.col-md-offset-2.col-md-8
-      = f.submit 'Save', :class => 'btn btn-primary'
+      = f.submit 'Save', class: 'btn btn-primary'

--- a/app/views/scientific_names/_form.html.haml
+++ b/app/views/scientific_names/_form.html.haml
@@ -9,7 +9,7 @@
   %p
     %span.help-block
       For detailed crop wrangling guidelines, please consult the
-      =link_to "crop wrangling guide", "http://wiki.growstuff.org/index.php/Crop_wrangling"
+      =link_to 'crop wrangling guide', 'http://wiki.growstuff.org/index.php/Crop_wrangling'
       on the Growstuff wiki.
 
   .form-group

--- a/app/views/scientific_names/edit.html.haml
+++ b/app/views/scientific_names/edit.html.haml
@@ -1,4 +1,4 @@
-- content_for :title, "Edit scientific name"
+- content_for :title, 'Edit scientific name'
 
 %p
   Added by

--- a/app/views/scientific_names/index.html.haml
+++ b/app/views/scientific_names/index.html.haml
@@ -1,4 +1,4 @@
-- content_for :title, "Listing scientific names"
+- content_for :title, 'Listing scientific names'
 
 - if can? :create, ScientificName
   %p= link_to 'New Scientific name', new_scientific_name_path, class: 'btn btn-primary'

--- a/app/views/scientific_names/index.html.haml
+++ b/app/views/scientific_names/index.html.haml
@@ -1,7 +1,7 @@
 - content_for :title, "Listing scientific names"
 
 - if can? :create, ScientificName
-  %p= link_to 'New Scientific name', new_scientific_name_path, :class => 'btn btn-primary'
+  %p= link_to 'New Scientific name', new_scientific_name_path, class: 'btn btn-primary'
 
 %table
   %tr
@@ -17,7 +17,7 @@
       %td= link_to 'Show', scientific_name
       %td
         - if can? :edit, scientific_name
-          = link_to 'Edit', edit_scientific_name_path(scientific_name), :class => 'btn btn-default btn-xs'
+          = link_to 'Edit', edit_scientific_name_path(scientific_name), class: 'btn btn-default btn-xs'
       %td
         - if can? :destroy, scientific_name
-          = link_to 'Delete', scientific_name, method: :delete, data: { confirm: 'Are you sure?' }, :class => 'btn btn-default btn-xs'
+          = link_to 'Delete', scientific_name, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-default btn-xs'

--- a/app/views/scientific_names/new.html.haml
+++ b/app/views/scientific_names/new.html.haml
@@ -1,3 +1,3 @@
-- content_for :title, "New scientific name"
+- content_for :title, 'New scientific name'
 
 = render 'form'

--- a/app/views/scientific_names/show.html.haml
+++ b/app/views/scientific_names/show.html.haml
@@ -1,6 +1,6 @@
 %p#notice= notice
 
-= render :partial => 'crops/approval_status_message', :locals => { :crop => @scientific_name.crop }
+= render partial: 'crops/approval_status_message', locals: { crop: @scientific_name.crop }
 
 %p
   %b Scientific name:
@@ -11,6 +11,6 @@
 
 
 - if can? :edit, @scientific_name
-  = link_to 'Edit', edit_scientific_name_path(@scientific_name), :class => 'btn btn-default btn-xs'
+  = link_to 'Edit', edit_scientific_name_path(@scientific_name), class: 'btn btn-default btn-xs'
   \|
 = link_to 'Back', scientific_names_path

--- a/app/views/seeds/_form.html.haml
+++ b/app/views/seeds/_form.html.haml
@@ -1,6 +1,6 @@
 = required_field_help_text
 
-= form_for(@seed, html: {class: "form-horizontal", role: "form"}) do |f|
+= form_for(@seed, html: {class: 'form-horizontal', role: 'form'}) do |f|
   - if @seed.errors.any?
     #error_explanation
       %h2= "#{pluralize(@seed.errors.size, "error")} prohibited this seed from being saved:"

--- a/app/views/seeds/_form.html.haml
+++ b/app/views/seeds/_form.html.haml
@@ -14,7 +14,7 @@
       = auto_suggest @seed, :crop, class: 'form-control', default: @crop
       %span.help-inline
         Can't find what you're looking for?
-        = link_to "Request new crops.", new_crop_path
+        = link_to 'Request new crops.', new_crop_path
   .form-group
     = f.label :quantity, 'Quantity:', class: 'control-label col-md-2', placeholder: 'optional'
     .col-md-2
@@ -65,13 +65,13 @@
       %span.help_inline
         - if current_member.location.blank?
           Don't forget to
-          =succeed "." do
-            =link_to "set your location", edit_member_registration_path
+          =succeed '.' do
+            =link_to 'set your location', edit_member_registration_path
         - else
           from
-          =succeed "." do
+          =succeed '.' do
             = link_to current_member.location, place_path(current_member.location)
-          =link_to "Change your location.", edit_member_registration_path
+          =link_to 'Change your location.', edit_member_registration_path
   .form-group
     .form-actions.col-md-offset-2.col-md-8
       = f.submit 'Save', class: 'btn btn-primary'

--- a/app/views/seeds/_form.html.haml
+++ b/app/views/seeds/_form.html.haml
@@ -1,6 +1,6 @@
 = required_field_help_text
 
-= form_for(@seed, :html => {:class => "form-horizontal", :role => "form"}) do |f|
+= form_for(@seed, html: {class: "form-horizontal", role: "form"}) do |f|
   - if @seed.errors.any?
     #error_explanation
       %h2= "#{pluralize(@seed.errors.size, "error")} prohibited this seed from being saved:"
@@ -9,47 +9,47 @@
           %li= msg
 
   .form-group.required
-    = f.label :crop, 'Crop:', :class => 'control-label col-md-2'
+    = f.label :crop, 'Crop:', class: 'control-label col-md-2'
     .col-md-8
-      = auto_suggest @seed, :crop, :class => 'form-control', :default => @crop
+      = auto_suggest @seed, :crop, class: 'form-control', default: @crop
       %span.help-inline
         Can't find what you're looking for?
         = link_to "Request new crops.", new_crop_path
   .form-group
-    = f.label :quantity, 'Quantity:', :class => 'control-label col-md-2', :placeholder => 'optional'
+    = f.label :quantity, 'Quantity:', class: 'control-label col-md-2', placeholder: 'optional'
     .col-md-2
-      = f.number_field :quantity, :class => 'form-control', placeholder: 'optional'
+      = f.number_field :quantity, class: 'form-control', placeholder: 'optional'
   .form-group
-    = f.label :plant_before, 'Plant before:', :class => 'control-label col-md-2'
+    = f.label :plant_before, 'Plant before:', class: 'control-label col-md-2'
     .col-md-2
-      = f.text_field :plant_before, :class => 'add-datepicker form-control', :value => @seed.plant_before ? @seed.plant_before.to_s(:ymd) : '', placeholder: 'optional'
+      = f.text_field :plant_before, class: 'add-datepicker form-control', value: @seed.plant_before ? @seed.plant_before.to_s(:ymd) : '', placeholder: 'optional'
   .form-group
-    = f.label :days_until_maturity_min, 'Days until maturity:', :class => 'control-label col-md-2', :placeholder => 'optional'
+    = f.label :days_until_maturity_min, 'Days until maturity:', class: 'control-label col-md-2', placeholder: 'optional'
     %fieldset
       .col-md-2
-        = f.number_field :days_until_maturity_min, :class => 'form-control', placeholder: 'optional'
+        = f.number_field :days_until_maturity_min, class: 'form-control', placeholder: 'optional'
       .col-md-1
-        = f.label :days_until_maturity_max, 'to', :class => 'control-label'
+        = f.label :days_until_maturity_max, 'to', class: 'control-label'
       .col-md-2
-        = f.number_field :days_until_maturity_max, :class => 'form-control', placeholder: 'optional'
+        = f.number_field :days_until_maturity_max, class: 'form-control', placeholder: 'optional'
       .col-md-1
-        = f.label :dummy, 'days', :class => 'control-label'
+        = f.label :dummy, 'days', class: 'control-label'
   .form-group.required
-    = f.label :organic, 'Organic?', :class => 'control-label col-md-2'
+    = f.label :organic, 'Organic?', class: 'control-label col-md-2'
     .col-md-8
-      = f.select(:organic, Seed::ORGANIC_VALUES, {}, :class => 'form-control', :default => 'unknown')
+      = f.select(:organic, Seed::ORGANIC_VALUES, {}, class: 'form-control', default: 'unknown')
   .form-group.required
-    = f.label :gmo, 'GMO?', :class => 'control-label col-md-2'
+    = f.label :gmo, 'GMO?', class: 'control-label col-md-2'
     .col-md-8
-      = f.select(:gmo, Seed::GMO_VALUES, {}, :class => 'form-control', :default => 'unknown')
+      = f.select(:gmo, Seed::GMO_VALUES, {}, class: 'form-control', default: 'unknown')
   .form-group.required
-    = f.label :heirloom, 'Heirloom?', :class => 'control-label col-md-2'
+    = f.label :heirloom, 'Heirloom?', class: 'control-label col-md-2'
     .col-md-8
-      = f.select(:heirloom, Seed::HEIRLOOM_VALUES, {}, :class => 'form-control', :default => 'unknown')
+      = f.select(:heirloom, Seed::HEIRLOOM_VALUES, {}, class: 'form-control', default: 'unknown')
   .form-group
-    = f.label :description, 'Description:', :class => 'control-label col-md-2'
+    = f.label :description, 'Description:', class: 'control-label col-md-2'
     .col-md-8
-      = f.text_area :description, :rows => 6, :class => 'form-control', :placeholder => 'optional'
+      = f.text_area :description, rows: 6, class: 'form-control', placeholder: 'optional'
   .form-group
     .col-md-offset-2.col-md-8
       %span.help-block
@@ -59,9 +59,9 @@
         contact you to request seeds.  You can list any conditions or
         other information in the description, above.
   .form-group.required
-    = f.label :tradable_to, 'Will trade:', :class => 'control-label col-md-2'
+    = f.label :tradable_to, 'Will trade:', class: 'control-label col-md-2'
     .col-md-8
-      = f.select(:tradable_to, Seed::TRADABLE_TO_VALUES, {}, :class => 'form-control')
+      = f.select(:tradable_to, Seed::TRADABLE_TO_VALUES, {}, class: 'form-control')
       %span.help_inline
         - if current_member.location.blank?
           Don't forget to
@@ -74,4 +74,4 @@
           =link_to "Change your location.", edit_member_registration_path
   .form-group
     .form-actions.col-md-offset-2.col-md-8
-      = f.submit 'Save', :class => 'btn btn-primary'
+      = f.submit 'Save', class: 'btn btn-primary'

--- a/app/views/seeds/_thumbnail.html.haml
+++ b/app/views/seeds/_thumbnail.html.haml
@@ -3,7 +3,7 @@
     %h3.panel-title
       = link_to "#{seed.owner.login_name}'s seed", seed
       - if can? :edit, seed
-        %a.pull-right{href: edit_seed_path(seed), role: "button", id: "edit_seed_glyphicon"}
+        %a.pull-right{href: edit_seed_path(seed), role: 'button', id: 'edit_seed_glyphicon'}
           %span.glyphicon.glyphicon-pencil{title: 'Edit'}
   .panel-body
     .row

--- a/app/views/seeds/_thumbnail.html.haml
+++ b/app/views/seeds/_thumbnail.html.haml
@@ -3,12 +3,12 @@
     %h3.panel-title
       = link_to "#{seed.owner.login_name}'s seed", seed
       - if can? :edit, seed
-        %a.pull-right{:href => edit_seed_path(seed), :role => "button", :id => "edit_seed_glyphicon"}
-          %span.glyphicon.glyphicon-pencil{:title => "Edit"}
+        %a.pull-right{href: edit_seed_path(seed), role: "button", id: "edit_seed_glyphicon"}
+          %span.glyphicon.glyphicon-pencil{title: "Edit"}
   .panel-body
     .row
       .col-md-4
-        = link_to image_tag((seed.crop.default_photo ?  seed.crop.default_photo.thumbnail_url : 'placeholder_150.png'), :alt => seed.crop.name, :class => 'img'), seed.crop
+        = link_to image_tag((seed.crop.default_photo ?  seed.crop.default_photo.thumbnail_url : 'placeholder_150.png'), alt: seed.crop.name, class: 'img'), seed.crop
       .col-md-8
         %dl.dl-horizontal
           %dt Crop : 

--- a/app/views/seeds/_thumbnail.html.haml
+++ b/app/views/seeds/_thumbnail.html.haml
@@ -4,7 +4,7 @@
       = link_to "#{seed.owner.login_name}'s seed", seed
       - if can? :edit, seed
         %a.pull-right{href: edit_seed_path(seed), role: "button", id: "edit_seed_glyphicon"}
-          %span.glyphicon.glyphicon-pencil{title: "Edit"}
+          %span.glyphicon.glyphicon-pencil{title: 'Edit'}
   .panel-body
     .row
       .col-md-4

--- a/app/views/seeds/edit.html.haml
+++ b/app/views/seeds/edit.html.haml
@@ -1,3 +1,3 @@
-- content_for :title, "Editing seeds"
+- content_for :title, 'Editing seeds'
 
 = render 'form'

--- a/app/views/seeds/index.html.haml
+++ b/app/views/seeds/index.html.haml
@@ -11,14 +11,14 @@
     - if @owner
       %p
         - if @owner == current_member
-          = link_to 'Add seeds', new_seed_path, :class => 'btn btn-primary'
-        = link_to "View everyone's seeds", seeds_path, :class => 'btn btn-default'
+          = link_to 'Add seeds', new_seed_path, class: 'btn btn-primary'
+        = link_to "View everyone's seeds", seeds_path, class: 'btn btn-default'
     - else # everyone's seeds
-      = link_to 'Add seeds', new_seed_path, :class => 'btn btn-primary'
+      = link_to 'Add seeds', new_seed_path, class: 'btn btn-primary'
       - if current_member
-        = link_to 'View your seeds', seeds_by_owner_path(:owner => current_member.slug), :class => 'btn btn-default'
+        = link_to 'View your seeds', seeds_by_owner_path(owner: current_member.slug), class: 'btn btn-default'
   - else
-    = render :partial => 'shared/signin_signup', :locals => { :to => 'add seeds to your stash' }
+    = render partial: 'shared/signin_signup', locals: { to: 'add seeds to your stash' }
 
 %div.pagination
   = page_entries_info @seeds
@@ -27,7 +27,7 @@
   - if @seeds.size > 0
     - @seeds.each do |seed|
       .col-md-6
-        =render :partial => 'seeds/thumbnail', :locals => {:seed => seed}
+        =render partial: 'seeds/thumbnail', locals: {seed: seed}
 
 %div.pagination
   = page_entries_info @seeds
@@ -36,10 +36,10 @@
 %ul.list-inline
   %li The data on this page is available in the following formats:
   - if @owner
-    %li= link_to "CSV", seeds_by_owner_path(@owner, :format => 'csv')
-    %li= link_to "JSON", seeds_by_owner_path(@owner, :format => 'json')
-    %li= link_to "RSS", seeds_by_owner_path(@owner, :format => 'rss')
+    %li= link_to "CSV", seeds_by_owner_path(@owner, format: 'csv')
+    %li= link_to "JSON", seeds_by_owner_path(@owner, format: 'json')
+    %li= link_to "RSS", seeds_by_owner_path(@owner, format: 'rss')
   - else
-    %li= link_to "CSV", seeds_path(:format => 'csv')
-    %li= link_to "JSON", seeds_path(:format => 'json')
-    %li= link_to "RSS", seeds_path(:format => 'rss')
+    %li= link_to "CSV", seeds_path(format: 'csv')
+    %li= link_to "JSON", seeds_path(format: 'json')
+    %li= link_to "RSS", seeds_path(format: 'rss')

--- a/app/views/seeds/index.html.haml
+++ b/app/views/seeds/index.html.haml
@@ -36,10 +36,10 @@
 %ul.list-inline
   %li The data on this page is available in the following formats:
   - if @owner
-    %li= link_to "CSV", seeds_by_owner_path(@owner, format: 'csv')
-    %li= link_to "JSON", seeds_by_owner_path(@owner, format: 'json')
-    %li= link_to "RSS", seeds_by_owner_path(@owner, format: 'rss')
+    %li= link_to 'CSV', seeds_by_owner_path(@owner, format: 'csv')
+    %li= link_to 'JSON', seeds_by_owner_path(@owner, format: 'json')
+    %li= link_to 'RSS', seeds_by_owner_path(@owner, format: 'rss')
   - else
-    %li= link_to "CSV", seeds_path(format: 'csv')
-    %li= link_to "JSON", seeds_path(format: 'json')
-    %li= link_to "RSS", seeds_path(format: 'rss')
+    %li= link_to 'CSV', seeds_path(format: 'csv')
+    %li= link_to 'JSON', seeds_path(format: 'json')
+    %li= link_to 'RSS', seeds_path(format: 'rss')

--- a/app/views/seeds/index.rss.haml
+++ b/app/views/seeds/index.rss.haml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-%rss{:version => 2.0}
+%rss{version: 2.0}
   %channel
     %title
       Recent seeds from #{ @owner ? @owner : 'all members' } (#{ENV['GROWSTUFF_SITE_NAME']})

--- a/app/views/seeds/new.html.haml
+++ b/app/views/seeds/new.html.haml
@@ -1,3 +1,3 @@
-- content_for :title, "Add seeds"
+- content_for :title, 'Add seeds'
 
 = render 'form'

--- a/app/views/seeds/show.html.haml
+++ b/app/views/seeds/show.html.haml
@@ -6,7 +6,7 @@
       %b Owner:
       = link_to @seed.owner, @seed.owner
       &mdash;
-      = link_to "view all #{@seed.owner}'s seeds", seeds_by_owner_path(:owner => @seed.owner.slug)
+      = link_to "view all #{@seed.owner}'s seeds", seeds_by_owner_path(owner: @seed.owner.slug)
     %p
       %b Quantity:
       = @seed.quantity.blank? ? "not specified" : @seed.quantity
@@ -15,7 +15,7 @@
       = @seed.plant_before.to_s
     %p
       %b Days until maturity:
-      = render :partial => 'days_until_maturity', :locals => { :seed => @seed }
+      = render partial: 'days_until_maturity', locals: { seed: @seed }
     %p
       %b Organic?
       = @seed.organic
@@ -31,7 +31,7 @@
       - if @seed.owner.location.blank?
         (from unspecified location)
         - if current_member == @seed.owner
-          = link_to "Set Location", edit_registration_path(current_member), :class => 'btn btn-default btn-xs'
+          = link_to "Set Location", edit_registration_path(current_member), class: 'btn btn-default btn-xs'
       - else
         (from
         = succeed ")" do
@@ -44,19 +44,19 @@
 
     - if current_member
       - if @seed.tradable? && current_member != @seed.owner
-        %p= link_to "Request seeds", new_notification_path(:recipient_id => @seed.owner.id, :subject => "Interested in your #{@seed.crop} seeds"), :class => 'btn btn-primary'
+        %p= link_to "Request seeds", new_notification_path(recipient_id: @seed.owner.id, subject: "Interested in your #{@seed.crop} seeds"), class: 'btn btn-primary'
     - else
-      = render :partial => 'shared/signin_signup', :locals => { :to => 'request seeds' }
+      = render partial: 'shared/signin_signup', locals: { to: 'request seeds' }
 
     - if can? :edit, @seed or can? :destroy, @seed
       %p
       - if can? :edit, @seed
-        =link_to 'Edit', edit_seed_path(@seed), :class => 'btn btn-default btn-xs'
+        =link_to 'Edit', edit_seed_path(@seed), class: 'btn btn-default btn-xs'
       - if can? :destroy, @seed
-        =link_to 'Delete', @seed, method: :delete, data: { confirm: 'Are you sure?' }, :class => 'btn btn-default btn-xs'
+        =link_to 'Delete', @seed, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-default btn-xs'
 
   .col-md-6
-    = render :partial => "crops/index_card", :locals => { :crop => @seed.crop }
+    = render partial: "crops/index_card", locals: { crop: @seed.crop }
     - if @seed.owner.location
       %p
         %small

--- a/app/views/seeds/show.html.haml
+++ b/app/views/seeds/show.html.haml
@@ -40,7 +40,7 @@
     %p
       %b Description:
       :growstuff_markdown
-        #{ @seed.description != "" ? @seed.description : "No description given." }
+        #{ @seed.description != '' ? @seed.description : 'No description given.' }
 
     - if current_member
       - if @seed.tradable? && current_member != @seed.owner

--- a/app/views/seeds/show.html.haml
+++ b/app/views/seeds/show.html.haml
@@ -9,7 +9,7 @@
       = link_to "view all #{@seed.owner}'s seeds", seeds_by_owner_path(owner: @seed.owner.slug)
     %p
       %b Quantity:
-      = @seed.quantity.blank? ? "not specified" : @seed.quantity
+      = @seed.quantity.blank? ? 'not specified' : @seed.quantity
     %p
       %b Plant before:
       = @seed.plant_before.to_s
@@ -31,11 +31,11 @@
       - if @seed.owner.location.blank?
         (from unspecified location)
         - if current_member == @seed.owner
-          = link_to "Set Location", edit_registration_path(current_member), class: 'btn btn-default btn-xs'
+          = link_to 'Set Location', edit_registration_path(current_member), class: 'btn btn-default btn-xs'
       - else
         (from
-        = succeed ")" do
-          = link_to @seed.owner.location, place_path(@seed.owner.location, anchor: "seeds")
+        = succeed ')' do
+          = link_to @seed.owner.location, place_path(@seed.owner.location, anchor: 'seeds')
 
     %p
       %b Description:
@@ -56,9 +56,9 @@
         =link_to 'Delete', @seed, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-default btn-xs'
 
   .col-md-6
-    = render partial: "crops/index_card", locals: { crop: @seed.crop }
+    = render partial: 'crops/index_card', locals: { crop: @seed.crop }
     - if @seed.owner.location
       %p
         %small
           View other seeds, members and more near
-          = link_to @seed.owner.location, place_path(@seed.owner.location, anchor: "seeds")
+          = link_to @seed.owner.location, place_path(@seed.owner.location, anchor: 'seeds')

--- a/app/views/seeds/show.html.haml
+++ b/app/views/seeds/show.html.haml
@@ -44,7 +44,7 @@
 
     - if current_member
       - if @seed.tradable? && current_member != @seed.owner
-        %p= link_to "Request seeds", new_notification_path(recipient_id: @seed.owner.id, subject: "Interested in your #{@seed.crop} seeds"), class: 'btn btn-primary'
+        %p= link_to 'Request seeds', new_notification_path(recipient_id: @seed.owner.id, subject: "Interested in your #{@seed.crop} seeds"), class: 'btn btn-primary'
     - else
       = render partial: 'shared/signin_signup', locals: { to: 'request seeds' }
 

--- a/app/views/shared/_account_status.html.haml
+++ b/app/views/shared/_account_status.html.haml
@@ -10,4 +10,4 @@
     = current_member.account.paid_until_string
 
 - if !current_member.is_paid?
-  = link_to "Upgrade and support #{ENV['GROWSTUFF_SITE_NAME']}", shop_path, :class => 'btn btn-primary'
+  = link_to "Upgrade and support #{ENV['GROWSTUFF_SITE_NAME']}", shop_path, class: 'btn btn-primary'

--- a/app/views/shared/_signin_signup.html.haml
+++ b/app/views/shared/_signin_signup.html.haml
@@ -2,5 +2,5 @@
 or
 =link_to 'sign up', new_member_registration_path
 to
-= succeed "." do
+= succeed '.' do
   = to

--- a/app/views/shop/index.html.haml
+++ b/app/views/shop/index.html.haml
@@ -24,7 +24,7 @@
 
   %p You currently have a paid membership, and can't buy another one at this time.
 
-  = render "shared/account_status"
+  = render 'shared/account_status'
 
 - elsif @order and @order.order_items.size > 0
   %h2 Your current order
@@ -37,9 +37,9 @@
       = price_with_currency(@most_recent_item.price)
 
   %p
-    = link_to "View order and checkout", order_path(@order)
+    = link_to 'View order and checkout', order_path(@order)
     or
-    =succeed "." do
+    =succeed '.' do
       = link_to 'delete this order', @order, method: :delete, |
         data: { confirm: 'Are you sure?' }
 
@@ -53,12 +53,12 @@
 
     %p
       Pay what you want, starting at
-      =succeed "." do
+      =succeed '.' do
         =price_with_currency(p.min_price)
         =forex_link(p.min_price)
       - if p.recommended_price
         Recommended price:
-        =succeed "." do
+        =succeed '.' do
           =price_with_currency(p.recommended_price)
           =forex_link(p.recommended_price)
 
@@ -77,9 +77,9 @@
 
       - else
         Please
-        =link_to "sign in", new_member_session_path
+        =link_to 'sign in', new_member_session_path
         or
-        =link_to "sign up", new_member_registration_path
+        =link_to 'sign up', new_member_registration_path
         to purchase.
 
 

--- a/app/views/shop/index.html.haml
+++ b/app/views/shop/index.html.haml
@@ -67,13 +67,13 @@
 
         = form_for @order_item do |f|
           .field
-            = f.text_field :price, :value => price_in_dollars(p.recommended_price || p.min_price)
+            = f.text_field :price, value: price_in_dollars(p.recommended_price || p.min_price)
           .field
-            = f.hidden_field :product_id, :value => p.id
+            = f.hidden_field :product_id, value: p.id
           .field
-            = f.hidden_field :quantity, :value => 1
+            = f.hidden_field :quantity, value: 1
           .actions
-            = f.submit 'Buy', :class => 'btn btn-primary'
+            = f.submit 'Buy', class: 'btn btn-primary'
 
       - else
         Please

--- a/app/views/shop/index.html.haml
+++ b/app/views/shop/index.html.haml
@@ -10,7 +10,7 @@
 %p
   We are currently developing a number of advanced features for paid
   members.  We will announce our progress on these in our
-  = link_to "Feedback and Support forum", "http://www.growstuff.org/forums/growstuff-feedback-support"
+  = link_to 'Feedback and Support forum', 'http://www.growstuff.org/forums/growstuff-feedback-support'
   as well as via other channels.
 
 %p

--- a/spec/controllers/notifications_controller_spec.rb
+++ b/spec/controllers/notifications_controller_spec.rb
@@ -81,8 +81,8 @@ describe NotificationsController do
 
   describe "GET reply" do
     it "marks notifications as read" do
-      notification = FactoryGirl.create(:notification, :recipient_id => subject.current_member.id)
-      get :reply, {:id => notification.to_param}
+      notification = FactoryGirl.create(:notification, recipient_id: subject.current_member.id)
+      get :reply, {id: notification.to_param}
       # we need to fetch it from the db again, can't test against the old one
       n = Notification.find(notification.id)
       n.read.should eq true


### PR DESCRIPTION
Annoyingly, Rubocop can't auto-correct HAML errors, [and won't gain this ability any time soon](https://github.com/brigade/haml-lint/issues/15).

About 1500 out of the 2633 problems found were "don't use double-quotes where single-quotes will do" warnings. I fixed these using the script and procedure at https://gist.github.com/pozorvlak/af43fed67c698b7e255b2feb91731acb.

The following also ought to be fixable in a (semi)-automated manner:
- [ ] SpaceBeforeScript: The - symbol should have one space separating it from code
- [ ] SpaceBeforeScript: The = symbol should have one space separating it from code
- [ ] RuboCop: Space inside { missing.
- [ ] RuboCop: Space inside } missing.
- [ ] RuboCop: Use `&&` instead of `and`.
- [ ] RuboCop: Use `||` instead of `or`.
- [ ] RuboCop: Surrounding space missing for operator `+`.
- [ ] RuboCop: Operator `?` should be surrounded by a single space.
- [ ] SpaceInsideHashAttributes: Hash attribute should start with one space after the opening brace
- [ ] SpaceInsideHashAttributes: Hash attribute should end with one space before the closing brace
- [ ] ImplicitDiv: `%div.pagination` can be written as `.pagination` since `%div` is implicit

Of the remaining problems, 364 are "LineLength: Line is too long", which I think will have to be fixed manually.

Fixes #902, or will eventually.
