### PR TITLE
Fix coverage calculations

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,9 +1,5 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV["RAILS_ENV"] ||= 'test'
-require 'spec_helper'
-require File.expand_path("../../config/environment", __FILE__)
-require 'rspec/rails'
-# Add additional requires below this line. Rails is not loaded until this point!
 require 'simplecov'
 require 'coveralls'
 
@@ -20,6 +16,12 @@ SimpleCov.start :rails do
   add_filter 'spec/'
   add_filter 'vendor/'
 end
+
+require 'spec_helper'
+require File.expand_path("../../config/environment", __FILE__)
+require 'rspec/rails'
+# Add additional requires below this line. Rails is not loaded until this point!
+Rails.application.eager_load!
 
 require 'capybara'
 require 'capybara/poltergeist'


### PR DESCRIPTION
SimpleCov was reporting 0% coverage for any files loaded before `SimpleCov.start` was called, even if they were fully tested. This patch loads the application *after* starting SimpleCov, leading to more accurate coverage figures.