### PR TITLE
 Swap to geocoder 1.1.9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,9 +60,7 @@ gem 'friendly_id', '~> 5.0.4'
 gem 'gravatar-ultimate'
 
 # For geolocation
-gem 'geocoder',
-  :git => 'https://github.com/alexreisner/geocoder.git',
-  :ref => '104d46'
+gem 'geocoder', '1.1.9'
 
 # For easy calendar selection
 gem 'bootstrap-datepicker-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: https://github.com/alexreisner/geocoder.git
-  revision: 104d466ba7097b7dce5ba19f8e4091b7f69ccdf6
-  ref: 104d46
-  specs:
-    geocoder (1.1.8)
-
 PATH
   remote: vendor/gems/active_utils-1.0.5
   specs:
@@ -178,6 +171,7 @@ GEM
     formatador (0.2.5)
     friendly_id (5.0.5)
       activerecord (>= 4.0.0)
+    geocoder (1.1.9)
     gibbon (1.2.0)
       httparty
       multi_json (>= 1.9.0)
@@ -465,7 +459,7 @@ DEPENDENCIES
   flickraw
   font-awesome-sass
   friendly_id (~> 5.0.4)
-  geocoder!
+  geocoder (= 1.1.9)
   gibbon (~> 1.2.0)
   gravatar-ultimate
   guard
@@ -502,9 +496,6 @@ DEPENDENCIES
   unicorn
   webrat
   will_paginate (~> 3.0)
-
-RUBY VERSION
-   ruby 2.1.8p440
 
 BUNDLED WITH
    1.12.4


### PR DESCRIPTION
Fixes #953

This is the release just after what we had previously pinned

https://github.com/alexreisner/geocoder/commit/104d46 is roughly release 1.1.9