### PR TITLE
WIP: package the app + databases in Docker containers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+.env
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,15 @@ FROM ruby:2.3.1-slim
 
 # Install essential Linux packages
 # We need nodejs for coffee-rails :-(
-RUN apt-get update -qq && apt-get install -y build-essential libpq-dev postgresql-client nodejs
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev postgresql-client nodejs wget
+
+# Install phantomjs for feature testing
+RUN wget https://assets.membergetmember.co/software/phantomjs-2.1.1-linux-x86_64.tar.bz2
+RUN tar xjf phantomjs-2.1.1-linux-x86_64.tar.bz2
+RUN cp phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/bin
 
 # Define where our application will live inside the image
-ENV RAILS_ROOT /var/www/docker_example
+ENV RAILS_ROOT /var/www/growstuff
 
 # Create application home. App server will need the pids dir so just create everything in one shot
 RUN mkdir -p $RAILS_ROOT/tmp/pids

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+# Base our image on an official, minimal image of our preferred Ruby
+FROM ruby:2.3.1-slim
+
+# Install essential Linux packages
+# We need nodejs for coffee-rails :-(
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev postgresql-client nodejs
+
+# Define where our application will live inside the image
+ENV RAILS_ROOT /var/www/docker_example
+
+# Create application home. App server will need the pids dir so just create everything in one shot
+RUN mkdir -p $RAILS_ROOT/tmp/pids
+
+# Set our working directory inside the image
+WORKDIR $RAILS_ROOT
+
+# Use the Gemfiles as Docker cache markers. Always bundle before copying app src.
+# (the src likely changed and we don't want to invalidate Docker's cache too early)
+# http://ilikestuffblog.com/2014/01/06/how-to-skip-bundle-install-when-deploying-a-rails-app-to-docker/
+COPY Gemfile Gemfile
+
+COPY Gemfile.lock Gemfile.lock
+
+# Prevent bundler warnings; ensure that the bundler version executed is >= that which created Gemfile.lock
+RUN gem install bundler
+
+# Finish establishing our Ruby enviornment
+RUN bundle install
+
+# Copy the Rails application into place
+COPY . .
+
+# Define the script we want run once the container boots
+# Use the "exec" form of CMD so our script shuts down gracefully on SIGTERM (i.e. `docker stop`)
+CMD [ "config/containers/app_cmd.sh" ]

--- a/config/containers/app_cmd.sh
+++ b/config/containers/app_cmd.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# Prefix `bundle` with `exec` so unicorn shuts down gracefully on SIGTERM (i.e. `docker stop`)
+exec bundle exec unicorn -c config/containers/unicorn.rb -E $RAILS_ENV;

--- a/config/containers/app_cmd.sh
+++ b/config/containers/app_cmd.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 
 # Prefix `bundle` with `exec` so unicorn shuts down gracefully on SIGTERM (i.e. `docker stop`)
+exec bundle exec rake db:create
+exec bundle exec rake db:seed
 exec bundle exec unicorn -c config/containers/unicorn.rb -E $RAILS_ENV;

--- a/config/containers/unicorn.rb
+++ b/config/containers/unicorn.rb
@@ -1,0 +1,59 @@
+app_path = ENV['RAILS_ROOT']
+ 
+# Set the server's working directory
+working_directory app_path
+ 
+# Define where Unicorn should write its PID file
+pid "#{app_path}/tmp/pids/unicorn.pid"
+ 
+# Bind Unicorn to the container's default route, at port 3000
+listen "0.0.0.0:3000"
+ 
+# Define where Unicorn should write its log files
+stderr_path "#{app_path}/log/unicorn.stderr.log"
+stdout_path "#{app_path}/log/unicorn.stdout.log"
+ 
+# Define the number of workers Unicorn should spin up.
+# A new Rails app just needs one. You would scale this 
+# higher in the future once your app starts getting traffic.
+# See https://unicorn.bogomips.org/TUNING.html
+worker_processes 1
+ 
+# Make sure we use the correct Gemfile on restarts
+before_exec do |server|
+  ENV['BUNDLE_GEMFILE'] = "#{app_path}/Gemfile"
+end
+ 
+# Speeds up your workers.
+# See https://unicorn.bogomips.org/TUNING.html
+preload_app true
+ 
+#
+# Below we define how our workers should be spun up. 
+# See https://unicorn.bogomips.org/Unicorn/Configurator.html
+#
+ 
+before_fork do |server, worker|
+  # the following is highly recomended for Rails + "preload_app true"
+  # as there's no need for the master process to hold a connection
+  if defined?(ActiveRecord::Base)
+    ActiveRecord::Base.connection.disconnect!
+  end
+ 
+  # Before forking, kill the master process that belongs to the .oldbin PID.
+  # This enables 0 downtime deploys.
+  old_pid = "#{server.config[:pid]}.oldbin"
+  if File.exists?(old_pid) && server.pid != old_pid
+    begin
+      Process.kill("QUIT", File.read(old_pid).to_i)
+    rescue Errno::ENOENT, Errno::ESRCH
+      # someone else did our job for us
+    end
+  end
+end
+ 
+after_fork do |server, worker|
+  if defined?(ActiveRecord::Base)
+    ActiveRecord::Base.establish_connection
+  end
+end

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,16 +1,18 @@
-development:
+default: &default
   adapter: postgresql
-  database: growstuff_dev
-  host: localhost
+  encoding: unicode
+  host: db
+  port: 5432
   user: postgres
-  password: postgres
+  password: <%= ENV['POSTGRES_PASSWORD'] %>
+
+development:
+  <<: *default
+  database: growstuff_dev
 
 test:
-  adapter: postgresql
+  <<: *default
   database: growstuff_test
-  host: localhost
-  user: postgres
-  password: postgres
 
 production:
   adapter: postgresql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+# service configuration for our dockerized Rails app
+app:
+  # use the Dockerfile next to this file
+  build: .
+  # sources environment variable configuration for our app
+  env_file: .env
+  # rely on the RAILS_ENV value of the host machine
+  environment:
+    RAILS_ENV: $RAILS_ENV
+  # makes the app container aware of the DB container
+  links:
+    - db
+  # expose the port we configured Unicorn to bind to
+  ports:
+    - "3000:3000"
+
+# service configuration for our database
+db:
+  # use the preferred version of the official Postgres image
+  # see https://hub.docker.com/_/postgres/
+  image: postgres:9.4.5
+  # persist the database between containers by storing it in a volume
+  volumes:
+    - growstuff-postgres:/var/lib/postgresql/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,10 @@ app:
   build: .
   # sources environment variable configuration for our app
   env_file: .env
-  # rely on the RAILS_ENV value of the host machine
+  # hard-code RAILS_ENV for testing
   environment:
-    RAILS_ENV: $RAILS_ENV
+    RAILS_ENV: development
+    POSTGRES_PASSWORD: docker
   # makes the app container aware of the DB container
   links:
     - db
@@ -23,6 +24,9 @@ db:
   # persist the database between containers by storing it in a volume
   volumes:
     - postgres-data:/var/lib/postgresql/data
+  environment:
+    POSTGRES_PASSWORD: docker
+    POSTGRES_USER: postgres
 
 # Elasticsearch full-text search engine
 elasticsearch:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ app:
   # makes the app container aware of the DB container
   links:
     - db
+    - elasticsearch
   # expose the port we configured Unicorn to bind to
   ports:
     - "3000:3000"
@@ -21,4 +22,10 @@ db:
   image: postgres:9.4.5
   # persist the database between containers by storing it in a volume
   volumes:
-    - growstuff-postgres:/var/lib/postgresql/data
+    - postgres-data:/var/lib/postgresql/data
+
+# Elasticsearch full-text search engine
+elasticsearch:
+  image: elasticsearch:1.4.5
+  volumes:
+    - elasticsearch-data:/usr/share/elasticsearch/data

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,7 +4,7 @@ require 'simplecov'
 require 'coveralls'
 
 # output coverage locally AND send it to coveralls
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+SimpleCov.formatters = [
   SimpleCov::Formatter::HTMLFormatter,
   Coveralls::SimpleCov::Formatter
 ]


### PR DESCRIPTION
I've been following the instructions at http://chrisstump.online/2016/02/20/docker-existing-rails-application/. Currently failing, as follows:

```
$ docker-compose run app rake db:create
Starting growstuff_db_1...
Cannot start container
c3e8a1db75bb6d02b6dfddf1e00157b9445db29625994eeadbb76d9eeb89156e: Cannot
link to a non running container: /growstuff_db_1 AS
/growstuff_app_run_6/db

$ docker-compose up db
Recreating growstuff_db_1...
Attaching to
[hangs forever]
```

I'm running docker-compose version 1.2.0 and docker version 1.8.2-fc22. My version of docker-compose is quite old, but it's the one that came from `dnf install` (on Fedora 22), and it would be annoying if we had to depend on a version that's more recent than the one in OS packages - the point of this is to make setup easy :-(

Good news: commit   7ea7fab should fix the "fatal: not a git repository" errors we've been seeing in deployment, and it's orthogonal to the rest of this PR. I'll split it out into its own PR later.
