### PR TITLE
Add links to google, gardenate (for planting reminders)

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,7 +21,8 @@ module ApplicationHelper
     link = "http://www.wolframalpha.com/input/?i=#{pid}+#{currency}"
     return link_to "(convert)",
       link,
-      target: "_blank"
+      target: "_blank",
+      rel: "noopener noreferrer"
   end 
 
   # Produces a cache key for uniquely identifying cached fragments.

--- a/app/views/crops/show.html.haml
+++ b/app/views/crops/show.html.haml
@@ -91,9 +91,9 @@
 
     %h4 Learn more about #{ @crop.name.pluralize }
     %ul
-      %li= link_to 'Wikipedia (English)', @crop.en_wikipedia_url, target: "_blank"
+      %li= link_to 'Wikipedia (English)', @crop.en_wikipedia_url, target: "_blank", rel: "noopener noreferrer"
       %li 
-        = link_to "Gardenate - Planting reminders", "http://www.gardenate.com/plant/#{URI.escape @crop.name}", target: "_blank"
+        = link_to "Gardenate - Planting reminders", "http://www.gardenate.com/plant/#{URI.escape @crop.name}", target: "_blank", rel: "noopener noreferrer"
       %li
         - if current_member && current_member.location
           = link_to "Google", "http://www.google.com/search?q=#{URI.escape ["Growing", @crop.name, current_member.location].join(" ")}", target: "_blank", rel: "noopener noreferrer"

--- a/app/views/crops/show.html.haml
+++ b/app/views/crops/show.html.haml
@@ -91,4 +91,9 @@
 
     %h4 Learn more about #{ @crop.name.pluralize }
     %ul
-      %li= link_to 'Wikipedia (English)', @crop.en_wikipedia_url
+      %li= link_to 'Wikipedia (English)', @crop.en_wikipedia_url, target: "_blank"
+      %li 
+        = link_to "Gardenate - Planting reminders", "http://www.gardenate.com/plant/#{URI.escape @crop.name}", target: "_blank"
+      %li
+        - if current_member && current_member.location
+          = link_to "Google", "http://www.google.com/search?q=#{URI.escape ["Growing", @crop.name, current_member.location].join(" ")}", target: "_blank"

--- a/app/views/crops/show.html.haml
+++ b/app/views/crops/show.html.haml
@@ -96,4 +96,4 @@
         = link_to "Gardenate - Planting reminders", "http://www.gardenate.com/plant/#{URI.escape @crop.name}", target: "_blank"
       %li
         - if current_member && current_member.location
-          = link_to "Google", "http://www.google.com/search?q=#{URI.escape ["Growing", @crop.name, current_member.location].join(" ")}", target: "_blank"
+          = link_to "Google", "http://www.google.com/search?q=#{URI.escape ["Growing", @crop.name, current_member.location].join(" ")}", target: "_blank", rel: "noopener noreferrer"

--- a/spec/features/crops/crop_detail_page_spec.rb
+++ b/spec/features/crops/crop_detail_page_spec.rb
@@ -135,7 +135,9 @@ feature "crop detail page", js: true do
         expect(page).to have_content "Learn more about #{ crop.name }"
         expect(page).to have_link "Wikipedia (English)", href: crop.en_wikipedia_url
       end
-
+      scenario "has a link to gardenate" do
+        expect(page).to have_link "Gardenate - Planting reminders", href: "http://www.gardenate.com/plant/#{URI.escape crop.name}"
+      end
     end
   end
 


### PR DESCRIPTION
Fixes #864 

While we could go and capture all of this data for ourselves/build similar features, for a lot less effort and an extra tool for users it's simpler to link to existing resources.