### PR TITLE
Fix SimpleCov deprecation warning

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,7 +4,7 @@ require 'simplecov'
 require 'coveralls'
 
 # output coverage locally AND send it to coveralls
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+SimpleCov.formatters = [
   SimpleCov::Formatter::HTMLFormatter,
   Coveralls::SimpleCov::Formatter
 ]


### PR DESCRIPTION
It used to say
```
/var/www/growstuff/spec/rails_helper.rb:7:in `<top (required)>':
[DEPRECATION] ::[] is deprecated. Use ::new instead.
```
at the start of every test run. This did not enhance my calm.