### PR TITLE
Fix SimpleCov Deprecation Warning

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,10 +4,10 @@ require 'simplecov'
 require 'coveralls'
 
 # output coverage locally AND send it to coveralls
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
   SimpleCov::Formatter::HTMLFormatter,
   Coveralls::SimpleCov::Formatter
-]
+])
 
 # fail if there's a significant test coverage drop
 SimpleCov.maximum_coverage_drop 1


### PR DESCRIPTION
Plain and simple. Removing the deprecation warning while running tests:

 `<top (required)>': [DEPRECATION] ::[] is deprecated. Use ::new instead.`