### PR TITLE
don't override our environment email settings with plain old sendmail

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -82,12 +82,6 @@ module Growstuff
       g.javascripts      false
     end
 
-    config.action_mailer.delivery_method = :sendmail
-      config.action_mailer.sendmail_settings = {
-        location: '/usr/sbin/sendmail',
-        arguments: '-i -t',
-        openssl_verify_mode: 'none'
-      }
 
     # Growstuff-specific configuration variables
     config.currency = 'AUD'


### PR DESCRIPTION
We were actually trying to send from the local server instance's install of sendmail