### PR TITLE
Block external URLs in feature tests

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -101,4 +101,14 @@ RSpec.configure do |config|
 
   # Allow just create(:factory) instead of needing to specify FactoryGirl.create(:factory)
   config.include FactoryGirl::Syntax::Methods
+
+  # Prevent Poltergeist from fetching external URLs during feature tests
+  config.before(:each, js: true) do
+    page.driver.browser.url_blacklist = [
+      'gravatar.com',
+      'mapbox.com',
+      'okfn.org',
+      'googlecode.com',
+    ]
+  end
 end


### PR DESCRIPTION
[StackOverflow](http://stackoverflow.com/a/36003988) and [GitHub commenters](https://github.com/teampoltergeist/poltergeist/issues/375#issuecomment-42620085) suggested that this might help with our intermittent "Request to http://localhost:8081 failed to reach server, check DNS and/or server status" errors in CI - the theory being that the error message is misleading, and it's actually a daughter request to an external service timing out. Seems worth a shot. It also ought to speed up testing, but the effect is slight (10s out of 3.5 minutes) on my machine.

I've blacklisted the URLs I could find in app/views or by tcpdumping a test run, because I couldn't get URL whitelisting to work.