### PR TITLE
issue #1006: change "Freenode" to "irc.freenode.net" in README.md

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -69,3 +69,4 @@ submit the change with your pull request.
 - DV Dasari / [dv2](https://github.com/dv2)
 - Eric Tillberg / [Thrillberg](https://github.com/Thrillberg)
 - Lucas Nogueira / [lucasnogueira](https://github.com/lucasnogueira)
+- Charley Lewittes / [ctlewitt](https://github.com/ctlewitt)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ encourage participation from people of all backgrounds and skill levels.
 * [Issues](http://github.com/Growstuff/growstuff/issues) (features we're
   working on, known bugs, etc)
 * [Discussion forums](http://talk.growstuff.org/) (design ideas, planning releases)
-* IRC: #growstuff on irc.freenode.net (general chat, brainstorming and troubleshooting) or [Gitter](https://gitter.im/Growstuff/growstuff)
+* [IRC](https://webchat.freenode.net/) growstuff channel (general chat, brainstorming and troubleshooting) or [Gitter](https://gitter.im/Growstuff/growstuff)
 * [Wiki](http://wiki.growstuff.org/) (general documentation, currently down but should be fixed soon)
 
 ## For coders

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ encourage participation from people of all backgrounds and skill levels.
 * [Issues](http://github.com/Growstuff/growstuff/issues) (features we're
   working on, known bugs, etc)
 * [Discussion forums](http://talk.growstuff.org/) (design ideas, planning releases)
-* IRC: #growstuff on Freenode (general chat, brainstorming and troubleshooting) or [Gitter](https://gitter.im/Growstuff/growstuff)
+* IRC: #growstuff on irc.freenode.net (general chat, brainstorming and troubleshooting) or [Gitter](https://gitter.im/Growstuff/growstuff)
 * [Wiki](http://wiki.growstuff.org/) (general documentation, currently down but should be fixed soon)
 
 ## For coders


### PR DESCRIPTION
Changed reference to "Freenode" to "irc.freenode.net" in README.md for clarification for newcomers to IRC.  