### PR TITLE
Check for "forgot to commit Gemfile.lock" in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ rvm:
 before_script:
 - psql -c 'create database growstuff_test;' -U postgres
 script:
+- script/gemfile_check
 - bundle exec rake db:migrate --trace
 - bundle exec rspec spec/
 services:

--- a/script/gemfile_check
+++ b/script/gemfile_check
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+
+require 'set'
+
+changed_file_list = `git diff --name-only --diff-filter=ACMRTUXB origin/dev...`
+files = Set.new changed_file_list.split
+if (files.include? "Gemfile") && !(files.include? "Gemfile.lock") then
+  abort "Looks like you committed changes to Gemfile but not Gemfile.lock"
+end


### PR DESCRIPTION
Quick-and-dirty script to catch an error we've missed a couple of times in code review, but which is not (AFAICT) covered by any of our existing checkers. Inspired by the following posts:

 - https://zachholman.com/posts/how-github-writes-blog-posts/
 - https://zachholman.com/talk/move-fast-break-nothing/