### PR TITLE
Add links to ebay, which seems to have a variety of seeds to purchase…

### DIFF
--- a/app/views/crops/_find_seeds.html.haml
+++ b/app/views/crops/_find_seeds.html.haml
@@ -1,7 +1,7 @@
 %h4 Find #{ crop.name } seeds
 - if crop.seeds.empty?
   %p
-    There are no seeds available to trade.
+    There are no seeds available to trade on Growstuff right now.
 - else
   %ul
     - crop.seeds.tradable.each do |seed|
@@ -10,6 +10,8 @@
         = render :partial => 'members/location', :locals => { :member => seed.owner }
   %p
     = link_to "View all #{crop.name} seeds", seeds_by_crop_path(crop)
+%p
+  = link_to "Purchase seeds via Ebay", "http://rover.ebay.com/rover/1/705-53470-19255-0/1?icep_ff3=9&pub=5575213277&toolid=10001&campid=5337940151&customid=&icep_uq=#{URI.escape crop.name}&icep_sellerId=&icep_ex_kw=&icep_sortBy=12&icep_catId=181003&icep_minPrice=&icep_maxPrice=&ipn=psmain&icep_vectorid=229515&kwid=902099&mtid=824&kw=lg", target: "_blank", rel: "noopener noreferrer"
 - if crop.approved?
   - if current_member
     %p= link_to "List #{crop.name} seeds to trade", new_seed_path(:crop_id => crop.id)

--- a/app/views/crops/show.html.haml
+++ b/app/views/crops/show.html.haml
@@ -94,6 +94,6 @@
       %li= link_to 'Wikipedia (English)', @crop.en_wikipedia_url, target: "_blank", rel: "noopener noreferrer"
       %li 
         = link_to "Gardenate - Planting reminders", "http://www.gardenate.com/plant/#{URI.escape @crop.name}", target: "_blank", rel: "noopener noreferrer"
-      %li
-        - if current_member && current_member.location
+      - if current_member && current_member.location
+        %li
           = link_to "Google", "http://www.google.com/search?q=#{URI.escape ["Growing", @crop.name, current_member.location].join(" ")}", target: "_blank", rel: "noopener noreferrer"

--- a/app/views/seeds/show.html.haml
+++ b/app/views/seeds/show.html.haml
@@ -69,5 +69,9 @@
     - if @seed.owner.location
       %p
         %small
-          View other seeds, members and more near
+          View other seeds, members to trade with and more near
           = link_to @seed.owner.location, place_path(@seed.owner.location, anchor: "seeds")
+    %p
+      %small
+        Or 
+        = link_to "purchase seeds via Ebay", "http://rover.ebay.com/rover/1/705-53470-19255-0/1?icep_ff3=9&pub=5575213277&toolid=10001&campid=5337940151&customid=&icep_uq=#{URI.escape @seed.crop.name}&icep_sellerId=&icep_ex_kw=&icep_sortBy=12&icep_catId=181003&icep_minPrice=&icep_maxPrice=&ipn=psmain&icep_vectorid=229515&kwid=902099&mtid=824&kw=lg", target: "_blank", rel: "noopener noreferrer"


### PR DESCRIPTION
This adds in 1-2 links on our crop, seeds pages as per https://github.com/Growstuff/growstuff/issues/864#issuecomment-239787065

It has our affiliates id, which I set up for: maintainers@growstuff.org (password reset sent and super long password I promptly forgot used).

Fall back of my mobile number being in there. No paypal etc account hooked up yet, do that later if it magically brings in server sustaining mountains of $.

I pushed this under all of the 'find seeds to trade' links; so growstuff listings are preferred... and it should be in the right category. Couldn't get the 'distance' search to work by default; sigh.

