### PR TITLE
allow registration and signin/out on the API

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -71,3 +71,4 @@ submit the change with your pull request.
 - Lucas Nogueira / [lucasnogueira](https://github.com/lucasnogueira)
 - Charley Lewittes / [ctlewitt](https://github.com/ctlewitt)
 - Kristine Nicole Polvoriza / [polveenomials](https://github.com/polveenomials)
+- Brenda Walalce / [br3nda](http://github.com/br3nda)

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,4 +1,5 @@
 class RegistrationsController < Devise::RegistrationsController
+  respond_to :json
 
   def edit
     @twitter_auth  = current_member.auth('twitter')

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,6 @@
 class SessionsController < Devise::SessionsController
+  respond_to :json
+
   def create
     super do |resource|
       if Crop.pending_approval.present? && current_member.has_role?(:crop_wrangler)


### PR DESCRIPTION
I wanted to sign in/out over the json API. I told devise to allow repsonding in json in both registration and session controller.

There might be another way to do this already, but the API docs link in the readme is all 404-ed pages.

