### PR TITLE
harvest thumbnail title linking to the harvest itself

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -71,4 +71,4 @@ submit the change with your pull request.
 - Lucas Nogueira / [lucasnogueira](https://github.com/lucasnogueira)
 - Charley Lewittes / [ctlewitt](https://github.com/ctlewitt)
 - Kristine Nicole Polvoriza / [polveenomials](https://github.com/polveenomials)
-- Brenda Walalce / [br3nda](http://github.com/br3nda)
+- Brenda Wallace / [br3nda](http://github.com/br3nda)

--- a/app/views/harvests/_thumbnail.html.haml
+++ b/app/views/harvests/_thumbnail.html.haml
@@ -1,7 +1,7 @@
 .panel.panel-success
   .panel-heading
     %h3.panel-title
-      = link_to "#{harvest.owner.login_name}'s harvest", harvest.owner
+      = link_to "#{harvest.owner.login_name}'s #{harvest.crop.name} harvest", harvest
       - if can? :edit, harvest
         %a.pull-right{:href => edit_harvest_path(harvest), :role => "button", :id => "edit_harvest_glyphicon"}
           %span.glyphicon.glyphicon-pencil{:title => "Edit"}

--- a/spec/features/harvests/browse_harvests_spec.rb
+++ b/spec/features/harvests/browse_harvests_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 feature "browse harvests" do
   let!(:member) { create :member }
+  let!(:harvest) { create :harvest, owner: member }
 
   background do
     login_as member
@@ -31,5 +32,8 @@ feature "browse harvests" do
       expect(page).to have_link "Read more"
     end
 
+    it 'links to #show' do
+      expect(page).to have_link harvest.crop.name, href: harvest_path(harvest)
+    end
   end
 end


### PR DESCRIPTION
I found it confusing that "bob's harvest" doesn't link to Bob's harvest. It instead links to Bob. I've made this mistake many times trying to get a the harvest#show from harvest#index.

This patch makes that link lead to the harvest itself.
