### PR TITLE
Bugfix: Link to garden, not member

### DIFF
--- a/app/views/gardens/_thumbnail.html.haml
+++ b/app/views/gardens/_thumbnail.html.haml
@@ -1,7 +1,7 @@
 .panel.panel-success
   .panel-heading
     %h3.panel-title
-      = link_to "#{garden.owner.login_name}'s garden", garden.owner
+      = link_to "#{garden.owner.login_name}'s garden", garden
       - if can? :edit, garden
         %a.pull-right{:href => edit_garden_path(garden), :role => "button", :id => "edit_garden_glyphicon"}
           %span.glyphicon.glyphicon-pencil{:title => "Edit"}


### PR DESCRIPTION
"[Member]'s garden" should link to the garden, not the member

![image](https://cloud.githubusercontent.com/assets/12266/20643957/6e009966-b48b-11e6-9e44-210b555d6aed.png)
