### PR TITLE
Narrow-ed regex on wikipedia url

### DIFF
--- a/app/models/crop.rb
+++ b/app/models/crop.rb
@@ -42,7 +42,7 @@ class Crop < ActiveRecord::Base # rubocop:disable Metrics/ClassLength
   ## Wikipedia urls are only necessary when approving a crop
   validates :en_wikipedia_url,
     format: {
-      with: /\Ahttps?:\/\/en\.wikipedia\.org\/wiki/,
+      with: /\Ahttps?:\/\/en\.wikipedia\.org\/wiki\/[[:alnum:]%_]+\z/,
       message: 'is not a valid English Wikipedia URL'
     },
     if: :approved?

--- a/spec/models/crop_spec.rb
+++ b/spec/models/crop_spec.rb
@@ -85,11 +85,43 @@ describe Crop do
     @crop.plantings.size.should eq 1
   end
 
-  it 'validates en_wikipedia_url' do
-    @crop = FactoryGirl.build(:tomato, en_wikipedia_url: 'this is not valid')
-    @crop.should_not be_valid
-    @crop = FactoryGirl.build(:tomato, en_wikipedia_url: 'http://en.wikipedia.org/wiki/SomePage')
-    @crop.should be_valid
+  context "wikipedia url" do
+    subject { FactoryGirl.build(:tomato, en_wikipedia_url: wikipedia_url) }
+
+    context 'not a url' do
+      let(:wikipedia_url) { 'this is not valid' }
+      it { expect(subject).not_to be_valid }
+    end
+
+    context 'http url' do
+      let(:wikipedia_url) { 'http://en.wikipedia.org/wiki/SomePage' }
+      it { expect(subject).to be_valid }
+    end
+
+    context 'with ssl' do
+      let(:wikipedia_url) { 'https://en.wikipedia.org/wiki/SomePage' }
+      it { expect(subject).to be_valid }
+    end
+
+    context 'with utf8 macrons' do
+      let(:wikipedia_url) { 'https://en.wikipedia.org/wiki/Māori' }
+      it { expect(subject).to be_valid }
+    end
+
+    context 'urlencoded' do
+      let(:wikipedia_url) { 'https://en.wikipedia.org/wiki/M%C4%81ori' }
+      it { expect(subject).to be_valid }
+    end
+
+    context 'with new lines in url' do
+      let(:wikipedia_url) { 'http://en.wikipedia.org/wiki/SomePage\n\nBrendaRocks' }
+      it { expect(subject).not_to be_valid }
+    end
+
+    context "with script tags in url" do
+      let(:wikipedia_url) { 'http://en.wikipedia.org/wiki/SomePage<script>alert(\'BrendaRocks\')</script>' }
+      it { expect(subject).not_to be_valid }
+    end
   end
 
   context 'varieties' do


### PR DESCRIPTION
the regexp was missing a \z t end it, so allowed anything you want afterwards. 
These are handled safely afterwards, but the regex still needed a fix.
