### PR TITLE
Fix comment-style weirdness

### DIFF
--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :comment do
     post
     author
-    sequence(:body) { |n| "OMG LOL #{n}" } # because our commenters are more
-    # polite than YouTube's
+    sequence(:body) { |n| "OMG LOL #{n}" }
+    # because our commenters are more polite than YouTube's
   end
 end


### PR DESCRIPTION
We had an inline comment that had been split over two lines; whitespace fixes made this look very weird.

Followup to #1072.