### PR TITLE
Fix PlantingHelper.display_days_before_maturity

### DIFF
--- a/app/helpers/plantings_helper.rb
+++ b/app/helpers/plantings_helper.rb
@@ -3,11 +3,11 @@ module PlantingsHelper
     if planting.finished?
       0
     elsif !planting.finished_at.nil?
-      ((p = planting.finished_at - DateTime.now).to_i) <= 0 ? 0 : p.to_i
+      ((p = planting.finished_at - Date.current).to_i) <= 0 ? 0 : p.to_i
     elsif planting.planted_at.nil? || planting.days_before_maturity.nil?
       "unknown"
     else
-      ((p = (planting.planted_at + planting.days_before_maturity) - DateTime.now).to_i <= 0) ? 0 : p.to_i
+      ((p = (planting.planted_at + planting.days_before_maturity) - Date.current).to_i <= 0) ? 0 : p.to_i
     end
   end
 

--- a/app/helpers/plantings_helper.rb
+++ b/app/helpers/plantings_helper.rb
@@ -1,13 +1,13 @@
 module PlantingsHelper
   def display_days_before_maturity(planting)
     if planting.finished?
-      0
+      "0"
     elsif !planting.finished_at.nil?
-      ((p = planting.finished_at - Date.current).to_i) <= 0 ? 0 : p.to_i
+      ((p = planting.finished_at - Date.current).to_i) <= 0 ? "0" : p.to_i.to_s
     elsif planting.planted_at.nil? || planting.days_before_maturity.nil?
       "unknown"
     else
-      ((p = (planting.planted_at + planting.days_before_maturity) - Date.current).to_i <= 0) ? 0 : p.to_i
+      ((p = (planting.planted_at + planting.days_before_maturity) - Date.current).to_i <= 0) ? "0" : p.to_i.to_s
     end
   end
 

--- a/spec/helpers/plantings_helper_spec.rb
+++ b/spec/helpers/plantings_helper_spec.rb
@@ -21,13 +21,13 @@ describe PlantingsHelper do
         days_before_maturity: 17
       )
       result = helper.display_days_before_maturity(planting)
-      expect(result).to eq 17
+      expect(result).to eq "17"
     end
 
     it "handles completed plantings" do
       planting = FactoryGirl.build(:planting, finished: true)
       result = helper.display_days_before_maturity(planting)
-      expect(result).to eq 0
+      expect(result).to eq "0"
     end
 
     it "handles plantings that should have finished" do
@@ -35,10 +35,10 @@ describe PlantingsHelper do
         quantity: 5,
         planted_at: Date.new(0, 1, 1),
         finished_at: nil,
-        days_before_maturity: 17
+        days_before_maturity: "17"
       )
       result = helper.display_days_before_maturity(planting)
-      expect(result).to eq 0
+      expect(result).to eq "0"
     end
 
     it "handles nil d_b_m and nil finished_at" do
@@ -60,7 +60,7 @@ describe PlantingsHelper do
         days_before_maturity: nil
       )
       result = helper.display_days_before_maturity(planting)
-      expect(result).to eq 5
+      expect(result).to eq "5"
     end
   end
 

--- a/spec/helpers/plantings_helper_spec.rb
+++ b/spec/helpers/plantings_helper_spec.rb
@@ -1,6 +1,69 @@
 require 'rails_helper'
 
 describe PlantingsHelper do
+  describe "display_days_before_maturity" do
+    it "handles nil planted_at, nil finished_at, non-nil days_until_maturity" do
+      planting = FactoryGirl.build(:planting,
+        quantity: 5,
+        planted_at: nil,
+        finished_at: nil,
+        days_before_maturity: 17
+      )
+      result = helper.display_days_before_maturity(planting)
+      expect(result).to eq "unknown"
+    end
+
+    it "handles non-nil planted_at and d_b_m, nil finished_at" do
+      planting = FactoryGirl.build(:planting,
+        quantity: 5,
+        planted_at: Date.current,
+        finished_at: nil,
+        days_before_maturity: 17
+      )
+      result = helper.display_days_before_maturity(planting)
+      expect(result).to eq 16
+    end
+
+    it "handles completed plantings" do
+      planting = FactoryGirl.build(:planting, finished: true)
+      result = helper.display_days_before_maturity(planting)
+      expect(result).to eq 0
+    end
+
+    it "handles plantings that should have finished" do
+      planting = FactoryGirl.build(:planting,
+        quantity: 5,
+        planted_at: Date.new(0, 1, 1),
+        finished_at: nil,
+        days_before_maturity: 17
+      )
+      result = helper.display_days_before_maturity(planting)
+      expect(result).to eq 0
+    end
+
+    it "handles nil d_b_m and nil finished_at" do
+      planting = FactoryGirl.build(:planting,
+        quantity: 5,
+        planted_at: Date.new(2012, 5, 12),
+        finished_at: nil,
+        days_before_maturity: nil
+      )
+      result = helper.display_days_before_maturity(planting)
+      expect(result).to eq "unknown"
+    end
+
+    it "handles finished_at dates in the future" do
+      planting = FactoryGirl.build(:planting,
+        quantity: 5,
+        planted_at: Date.current,
+        finished_at: Date.current + 5,
+        days_before_maturity: nil
+      )
+      result = helper.display_days_before_maturity(planting)
+      expect(result).to eq 4
+    end
+  end
+
   describe "display_planting" do
     let!(:member) { FactoryGirl.build(:member, login_name: 'crop_lady') }
 

--- a/spec/helpers/plantings_helper_spec.rb
+++ b/spec/helpers/plantings_helper_spec.rb
@@ -21,7 +21,7 @@ describe PlantingsHelper do
         days_before_maturity: 17
       )
       result = helper.display_days_before_maturity(planting)
-      expect(result).to eq 16
+      expect(result).to eq 17
     end
 
     it "handles completed plantings" do
@@ -60,7 +60,7 @@ describe PlantingsHelper do
         days_before_maturity: nil
       )
       result = helper.display_days_before_maturity(planting)
-      expect(result).to eq 4
+      expect(result).to eq 5
     end
   end
 


### PR DESCRIPTION
 - fixes the bug that caused #1079
 - fixes an off-by-one error in the calculation
 - always return a string from the helper.

I'm not totally sold on 589a31d; it's possible I've spent too much time coding in statically-typed languages recently and that this isn't an issue in Ruby. But it tripped me up while working on the other two commits.