### PR TITLE
DRY up photo & model interaction

### DIFF
--- a/app/constants/photo_models.rb
+++ b/app/constants/photo_models.rb
@@ -1,0 +1,37 @@
+module Growstuff
+  module Constants
+    class PhotoModels
+      PLANTING = { type: 'planting', class: 'Planting', relation: 'plantings' }.freeze
+      HARVEST = { type: 'harvest', class: 'Harvest', relation: 'harvests' }.freeze
+      GARDEN = { type: 'garden', class: 'Garden', relation: 'gardens' }.freeze
+
+      ALL = [PLANTING, HARVEST, GARDEN].freeze
+
+      def self.types
+        ALL.map do |model|
+          model[:type]
+        end
+      end
+
+      def self.relations
+        ALL.map do |model|
+          model[:relation]
+        end
+      end
+
+      def self.get_relation(object, type)
+        relation = ALL.select do |model|
+          model[:type] == type
+        end[0][:relation]
+        object.send(relation)
+      end
+
+      def self.get_item(type)
+        class_name = ALL.select do |model|
+          model[:type] == type
+        end[0][:class]
+        class_name.constantize
+      end
+    end
+  end
+end

--- a/app/controllers/photos_controller.rb
+++ b/app/controllers/photos_controller.rb
@@ -114,11 +114,11 @@ class PhotosController < ApplicationController
   end
 
   def add_photo_to_collection
-    raise "Missing or invalid type provided" unless Growstuff::Constants::PhotoModels::types.include?(params[:type])
+    raise "Missing or invalid type provided" unless Growstuff::Constants::PhotoModels.types.include?(params[:type])
     raise "No item id provided" unless item_id?
-    collection = Growstuff::Constants::PhotoModels::get_relation(@photo, params[:type])
+    collection = Growstuff::Constants::PhotoModels.get_relation(@photo, params[:type])
 
-    item_class = Growstuff::Constants::PhotoModels::get_item(params[:type])
+    item_class = Growstuff::Constants::PhotoModels.get_item(params[:type])
     item = item_class.find_by!(id: params[:id], owner_id: current_member.id)
     raise "Could not find this item owned by you" unless item
 

--- a/app/models/concerns/photo_capable.rb
+++ b/app/models/concerns/photo_capable.rb
@@ -2,7 +2,7 @@ module PhotoCapable
   extend ActiveSupport::Concern
 
   included do
-    has_and_belongs_to_many :photos
+    has_and_belongs_to_many :photos # rubocop:disable Rails/HasAndBelongsToMany
 
     before_destroy :remove_from_list
   end

--- a/app/models/concerns/photo_capable.rb
+++ b/app/models/concerns/photo_capable.rb
@@ -1,0 +1,18 @@
+module PhotoCapable
+  extend ActiveSupport::Concern
+
+  included do
+    has_and_belongs_to_many :photos
+
+    before_destroy :remove_from_list
+  end
+
+  def remove_from_list
+    photolist = self.photos.to_a # save a temp copy of the photo list
+    self.photos.clear # clear relationship b/w object and photo
+
+    photolist.each do |photo|
+      photo.destroy_if_unused
+    end
+  end
+end

--- a/app/models/concerns/photo_capable.rb
+++ b/app/models/concerns/photo_capable.rb
@@ -8,11 +8,9 @@ module PhotoCapable
   end
 
   def remove_from_list
-    photolist = self.photos.to_a # save a temp copy of the photo list
-    self.photos.clear # clear relationship b/w object and photo
+    photolist = photos.to_a # save a temp copy of the photo list
+    photos.clear # clear relationship b/w object and photo
 
-    photolist.each do |photo|
-      photo.destroy_if_unused
-    end
+    photolist.each(&:destroy_if_unused)
   end
 end

--- a/app/models/garden.rb
+++ b/app/models/garden.rb
@@ -1,22 +1,12 @@
 class Garden < ActiveRecord::Base
-  include Geocodable
   extend FriendlyId
+  include Geocodable
+  include PhotoCapable
   friendly_id :garden_slug, use: [:slugged, :finders]
 
   belongs_to :owner, class_name: 'Member', foreign_key: 'owner_id'
   has_many :plantings, -> { order(created_at: :desc) }, dependent: :destroy
   has_many :crops, through: :plantings
-
-  has_and_belongs_to_many :photos
-
-  before_destroy do |garden|
-    photolist = garden.photos.to_a # save a temp copy of the photo list
-    garden.photos.clear # clear relationship b/w garden and photo
-
-    photolist.each do |photo|
-      photo.destroy_if_unused
-    end
-  end
 
   # set up geocoding
   geocoded_by :location

--- a/app/models/harvest.rb
+++ b/app/models/harvest.rb
@@ -8,7 +8,6 @@ class Harvest < ActiveRecord::Base
   belongs_to :owner, class_name: 'Member'
   belongs_to :plant_part
 
-
   default_scope { order('created_at DESC') }
 
   validates :crop, approved: true

--- a/app/models/harvest.rb
+++ b/app/models/harvest.rb
@@ -1,22 +1,13 @@
 class Harvest < ActiveRecord::Base
-  include ActionView::Helpers::NumberHelper
   extend FriendlyId
+  include ActionView::Helpers::NumberHelper
+  include PhotoCapable
   friendly_id :harvest_slug, use: [:slugged, :finders]
 
   belongs_to :crop
   belongs_to :owner, class_name: 'Member'
   belongs_to :plant_part
 
-  has_and_belongs_to_many :photos
-
-  before_destroy do |harvest|
-    photolist = harvest.photos.to_a # save a temp copy of the photo list
-    harvest.photos.clear # clear relationship b/w harvest and photo
-
-    photolist.each do |photo|
-      photo.destroy_if_unused
-    end
-  end
 
   default_scope { order('created_at DESC') }
 

--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -1,7 +1,7 @@
 class Photo < ActiveRecord::Base
   belongs_to :owner, class_name: 'Member'
 
-  Growstuff::Constants::PhotoModels::relations.each do |relation|
+  Growstuff::Constants::PhotoModels.relations.each do |relation|
     has_and_belongs_to_many relation.to_sym
   end
 
@@ -11,7 +11,7 @@ class Photo < ActiveRecord::Base
 
   def all_associations
     associations = []
-    Growstuff::Constants::PhotoModels::relations.each do |association_name|
+    Growstuff::Constants::PhotoModels.relations.each do |association_name|
       associations << self.send(association_name.to_s).to_a
     end
     associations.flatten!

--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -1,5 +1,5 @@
 class Photo < ActiveRecord::Base
-  ON_MODELS = %w(plantings harvests gardens)
+  ON_MODELS = %w(plantings harvests gardens).freeze
   belongs_to :owner, class_name: 'Member'
 
   ON_MODELS.each do |relation|
@@ -13,7 +13,7 @@ class Photo < ActiveRecord::Base
   def relationships
     associations = []
     ON_MODELS.each do |association_name, _reflection|
-      associations << self.send("#{association_name}").to_a
+      associations << self.send(association_name.to_s).to_a
     end
     associations.flatten!
   end

--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -1,26 +1,24 @@
 class Photo < ActiveRecord::Base
-  ON_MODELS = %w(plantings harvests gardens).freeze
   belongs_to :owner, class_name: 'Member'
 
-  ON_MODELS.each do |relation|
+  Growstuff::Constants::PhotoModels::relations.each do |relation|
     has_and_belongs_to_many relation.to_sym
   end
 
-  before_destroy { relationships.clear }
+  before_destroy { all_associations.clear }
 
   default_scope { order("created_at desc") }
 
-  def relationships
+  def all_associations
     associations = []
-    ON_MODELS.each do |association_name, _reflection|
+    Growstuff::Constants::PhotoModels::relations.each do |association_name|
       associations << self.send(association_name.to_s).to_a
     end
     associations.flatten!
   end
 
-  # remove photos that aren't used by anything
   def destroy_if_unused
-    self.destroy unless relationships.size > 0
+    self.destroy unless all_associations.size > 0
   end
 
   # This is split into a side-effect free method and a side-effecting method

--- a/app/models/planting.rb
+++ b/app/models/planting.rb
@@ -1,21 +1,11 @@
 class Planting < ActiveRecord::Base
   extend FriendlyId
+  include PhotoCapable
   friendly_id :planting_slug, use: [:slugged, :finders]
 
   belongs_to :garden
   belongs_to :owner, class_name: 'Member', counter_cache: true
   belongs_to :crop, counter_cache: true
-
-  has_and_belongs_to_many :photos
-
-  before_destroy do |planting|
-    photolist = planting.photos.to_a # save a temp copy of the photo list
-    planting.photos.clear # clear relationship b/w planting and photo
-
-    photolist.each do |photo|
-      photo.destroy_if_unused
-    end
-  end
 
   default_scope { order("created_at desc") }
   scope :finished, -> { where(finished: true) }

--- a/spec/models/photo_spec.rb
+++ b/spec/models/photo_spec.rb
@@ -85,11 +85,13 @@ describe Photo do
 
         planting.destroy # photo is still used by harvest and garden
         photo.reload
+
         expect(photo.plantings.size).to eq 0
         expect(photo.harvests.size).to eq 1
 
         harvest.destroy
         garden.destroy # photo is now no longer used by anything
+        photo.reload
 
         expect(photo.plantings.size).to eq 0
         expect(photo.harvests.size).to eq 0


### PR DESCRIPTION
 * move stuff in models into a concern
 * create combined collection for all models that have photos

I'm marking this WIP because I think a constants file that maps garden/gardens/Garden would make it possible to minimize repetition in `photos_controller.rb` too. I want to minimize how many places we need to touch on adding a new model-that-uses-photos because I know missing a copy&paste has introduced bugs before. (The particular past bug I'm thinking of is handled by this commit, though, with the `self.destroy unless relationships.size > 0`)