### PR TITLE
Precompile assets in test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ before_install:
   - phantomjs --version
 before_script:
   - bundle exec rake db:create db:migrate db:test:prepare
+  - bundle exec rake assets:precompile
 script:
   - bundle exec rubocop --display-cop-names --rails
   - script/gemfile_check

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -6,6 +6,10 @@ Growstuff::Application.configure do
   # preloads Rails for running tests, you may have to set it to true.
   config.eager_load = false
 
+  # Do not compile assets on-demand. On-demand compilation slows down the test
+  # suite and causes random test failures.
+  config.assets.compile = false
+
   # The test environment is used exclusively to run your application's
   # test suite. You never need to work with it otherwise. Remember that
   # your test database is "scratch space" for the test suite and is wiped


### PR DESCRIPTION
According to https://github.com/teampoltergeist/poltergeist/issues/677#issuecomment-222919584, a possible cause of the "Request failed to reach server" problem (#901) is that assets are being compiled on-demand, causing enough of a slowdown for PhantomJS to think the connection has failed. This PR turns off lazy asset compilation in the test environment and precompiles assets before testing on Travis.

We should also turn off lazy asset compilation in production - see http://stackoverflow.com/questions/8821864/config-assets-compile-true-in-rails-production-why-not Our Heroku deployments already run `rake assets:precompile`.