### PR TITLE
Run tests with `rake` when DB does not yet exist

### DIFF
--- a/lib/tasks/testing.rake
+++ b/lib/tasks/testing.rake
@@ -2,7 +2,7 @@ require 'rake'
 begin
   require 'rspec/core/rake_task'
   task(:spec).clear
-  RSpec::Core::RakeTask.new(spec: 'db:test:prepare') do |t|
+  RSpec::Core::RakeTask.new(spec: ['db:create', 'db:test:prepare']) do |t|
     t.verbose = false
   end
 rescue LoadError


### PR DESCRIPTION
Previously, `rake spec` ran the tests whether or not the `growstuff_test` database existed or not, but `rake` crashed unless it had already been created. The problem was that `rake` was trying to load the environment, which required the presence of a DB; `rake spec` was running this with the `dev` environment, so succeeded if `growstuff_dev` existed, but `rake` was running everything with the `test` environment, so would fail if `growstuff_test` did not exist.

This patch adds `db:create` to the dependencies of the `spec` task, forcing an unadorned `rake` to create all necessary databases first.

tl;dr you should now be able to just type `rake` to run specs locally.