### PR TITLE
expand wikipedia regex to include -, (, and )

### DIFF
--- a/app/models/crop.rb
+++ b/app/models/crop.rb
@@ -42,7 +42,7 @@ class Crop < ActiveRecord::Base # rubocop:disable Metrics/ClassLength
   ## Wikipedia urls are only necessary when approving a crop
   validates :en_wikipedia_url,
     format: {
-      with: /\Ahttps?:\/\/en\.wikipedia\.org\/wiki\/[[:alnum:][:punct:]]+\z/,
+      with: /\Ahttps?:\/\/en\.wikipedia\.org\/wiki\/[[:alnum:]%_()-]+\z/,
       message: 'is not a valid English Wikipedia URL'
     },
     if: :approved?

--- a/app/models/crop.rb
+++ b/app/models/crop.rb
@@ -42,7 +42,7 @@ class Crop < ActiveRecord::Base # rubocop:disable Metrics/ClassLength
   ## Wikipedia urls are only necessary when approving a crop
   validates :en_wikipedia_url,
     format: {
-      with: /\Ahttps?:\/\/en\.wikipedia\.org\/wiki\/[[:alnum:]%_]+\z/,
+      with: /\Ahttps?:\/\/en\.wikipedia\.org\/wiki\/[[:alnum:][:punct:]]+\z/,
       message: 'is not a valid English Wikipedia URL'
     },
     if: :approved?


### PR DESCRIPTION
because some have - or () in name

example:

- https://en.wikipedia.org/wiki/Urad_(bean)
- https://en.wikipedia.org/wiki/Curry-leaf_Tree

(Fixes: #1104)