### PR TITLE
ignore the minified bootstrap accessibility file for code climate checks

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -38,3 +38,4 @@ exclude_paths:
 - db/
 - spec/
 - public/
+- app/assets/stylesheets/bootstrap-accessibility.css


### PR DESCRIPTION
Code Climate really doesn't like that it's minified