### PR TITLE
Revert "Changed phantomjs url to project official"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
   - export PATH=$PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH
   - >
     if [ $(phantomjs --version) != '2.1.1' ]; then
-    PHANTOM_URL=https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2;
+    PHANTOM_URL=https://assets.membergetmember.co/software/phantomjs-2.1.1-linux-x86_64.tar.bz2;
     rm -rf $PWD/travis_phantomjs;
     mkdir -p $PWD/travis_phantomjs;
     wget $PHANTOM_URL -O $PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2;


### PR DESCRIPTION
Travis is getting 403s from the phantomjs download url
it's still the same url found on the phantom project page
http://phantomjs.org/download.html

but to keep travis running, here's a revert back to the old url
