### PR TITLE
Yet another wikipedia url char added to regex

### DIFF
--- a/app/models/crop.rb
+++ b/app/models/crop.rb
@@ -42,7 +42,7 @@ class Crop < ActiveRecord::Base # rubocop:disable Metrics/ClassLength
   ## Wikipedia urls are only necessary when approving a crop
   validates :en_wikipedia_url,
     format: {
-      with: /\Ahttps?:\/\/en\.wikipedia\.org\/wiki\/[[:alnum:]%_()-]+\z/,
+      with: /\Ahttps?:\/\/en\.wikipedia\.org\/wiki\/[[:alnum:]%_\.()-]+\z/,
       message: 'is not a valid English Wikipedia URL'
     },
     if: :approved?


### PR DESCRIPTION
wikipedia urls can have a fullstop on them. Infact we have one in our db:seeds
https://en.wikipedia.org/wiki/Capsicum_annuum_var._glabriusculum

