### PR TITLE
Less busy gardens page

### DIFF
--- a/app/assets/stylesheets/overrides.sass
+++ b/app/assets/stylesheets/overrides.sass
@@ -319,8 +319,11 @@ $state-success-bg: lighten($green, 50%)
     text-overflow: ellipsis
     overflow: hidden
 
-#gardens_panel_body
-  height: 20em
+.garden-plantings
+  list-style-type: none
+  font-size: 90%
+
+.gardens_panel_body
 
 .form-group.required .control-label:before
   content: "* "

--- a/app/helpers/gardens_helper.rb
+++ b/app/helpers/gardens_helper.rb
@@ -1,26 +1,21 @@
 module GardensHelper
   def display_garden_description(garden)
-    if garden.description.nil?
-      "no description provided."
-    else
-      truncate(garden.description, length: 130, separator: ' ', omission: '... ') do
-        link_to "Read more", garden_path(garden)
-      end
+    return "" unless garden.description.present?
+    truncate(garden.description, length: 130, separator: ' ', omission: '... ') do
+      link_to "Read more", garden_path(garden)
     end
   end
 
   def display_garden_plantings(plantings)
-    if plantings.blank?
-      "None"
-    else
-      output = ""
-      plantings.first(2).each do |planting|
-        output += "<li>"
-        output += planting.quantity.nil? ? "0 " : "#{planting.quantity} "
-        output += link_to planting.crop.name, planting.crop
-        output += ", planted on #{planting.planted_at}</li>"
-      end
-      output.html_safe
+    return "" unless plantings.present?
+    output = '<ul class="garden-plantings">'
+    plantings.first(6).each do |planting|
+      output += "<li>"
+      output += "#{planting.quantity} " if planting.quantity.present?
+      output += link_to planting.crop.name, planting.crop
+      output += '</li>'
     end
+    output += '</ul>'
+    output.html_safe
   end
 end

--- a/app/views/gardens/_thumbnail.html.haml
+++ b/app/views/gardens/_thumbnail.html.haml
@@ -1,36 +1,21 @@
 .panel.panel-success
   .panel-heading
     %h3.panel-title
-      = link_to "#{garden.owner.login_name}'s garden", garden
+      = link_to garden.name, garden
       - if can? :edit, garden
         %a.pull-right{:href => edit_garden_path(garden), :role => "button", :id => "edit_garden_glyphicon"}
           %span.glyphicon.glyphicon-pencil{:title => "Edit"}
-  .panel-body{:id => "gardens_panel_body"}
+  .panel-body{:class => "gardens_panel_body"}
     .row
       .col-md-4
         = link_to image_tag((garden.default_photo ?  garden.default_photo.thumbnail_url : 'placeholder_150.png'), :alt => garden.name, :class => 'img'), garden
       .col-md-8
-        %dl.dl-horizontal
-          %dt Name :
-          %dd= link_to garden.name, garden
-          %dt Location :
+        %dl
+          - if garden.location.present?
+            %dt Location:
+            %dd= link_to garden.location, place_path(garden.location, anchor: "gardens")
+          - if garden.area.present?
+            %dt Area:
+            %dd= pluralize(garden.area, garden.area_unit)
           %dd
-            - if garden.location.blank?
-              not specified
-            - else
-              = link_to garden.location, place_path(garden.location, anchor: "gardens")
-          %dt Area :
-          %dd= garden.area.nil? ? "not specified" : pluralize(garden.area, garden.area_unit)
-          %dt Active? :
-          %dd= garden.active ? "Yes" : "No"
-      .col-md-12
-        %b
-          = "#{localize_plural(garden.plantings, Planting)} : "
-        = display_garden_plantings(garden.plantings.current)
-        - if garden.plantings.size > 2
-          %br
-          = link_to "See more plantings >>", garden_path(garden)
-  .panel-footer
-    %dt Description
-    %dd
-      = display_garden_description(garden)
+            = display_garden_plantings(garden.plantings.current)

--- a/spec/helpers/gardens_helper_spec.rb
+++ b/spec/helpers/gardens_helper_spec.rb
@@ -7,7 +7,7 @@ describe GardensHelper do
         description: nil
       )
       result = helper.display_garden_description(garden)
-      expect(result).to eq "no description provided."
+      expect(result).to eq ""
     end
 
     it "is less than 130 characters long" do
@@ -38,7 +38,7 @@ describe GardensHelper do
   describe "garden plantings" do
     it "is missing" do
       result = helper.display_garden_plantings(nil)
-      expect(result).to eq "None"
+      expect(result).to eq ""
     end
 
     it "has 1 planting" do
@@ -46,10 +46,10 @@ describe GardensHelper do
       plantings = [FactoryGirl.create(:planting, quantity: 10, crop: crop)]
       result = helper.display_garden_plantings(plantings)
 
-      output = "<li>"
+      output = '<ul class="garden-plantings"><li>'
       output += "10 " + link_to(crop.name, crop)
-      output += ", planted on #{plantings.first.planted_at}"
-      output += "</li>"
+      # output += ", planted on #{plantings.first.planted_at}"
+      output += "</li></ul>"
       expect(result).to eq output
     end
 
@@ -64,14 +64,14 @@ describe GardensHelper do
 
       result = helper.display_garden_plantings(plantings)
 
-      output = "<li>"
+      output = '<ul class="garden-plantings"><li>'
       output += "10 " + link_to(crop1.name, crop1)
-      output += ", planted on #{plantings.first.planted_at}"
+      # output += ", planted on #{plantings.first.planted_at}"
       output += "</li>"
       output += "<li>"
       output += "10 " + link_to(crop2.name, crop2)
-      output += ", planted on #{plantings.first.planted_at}"
-      output += "</li>"
+      # output += ", planted on #{plantings.first.planted_at}"
+      output += "</li></ul>"
       expect(result).to eq output
     end
 
@@ -89,15 +89,14 @@ describe GardensHelper do
 
       result = helper.display_garden_plantings(plantings)
 
-      output = "<li>"
+      output = '<ul class="garden-plantings"><li>'
       output += "10 " + link_to(crop1.name, crop1)
-      output += ", planted on #{plantings.first.planted_at}"
       output += "</li>"
-      output += "<li>"
-      output += "10 " + link_to(crop2.name, crop2)
-      output += ", planted on #{plantings.first.planted_at}"
-      output += "</li>"
-      expect(result).to eq output
+      output += "<li>10 " + link_to(crop2.name, crop2) + '</li>'
+      output += "<li>10 " + link_to(crop3.name, crop3) + '</li>'
+      output += "</ul>"
+
+      expect(result).to eq(output)
     end
   end
 end


### PR DESCRIPTION
I'm expecting this to be contentious.. but...

the gardens#index page is really busy. It has lots of the attributes of a garden including all the placeholder text like "no description provided." and " not specified".
There were 3 links to every garden, the header, the name, and the "show more plantings".

I pruned lots of it - as i want it to be just an index, used to find a garden, not show it all.

