### PR TITLE
Improve unit test coverage for models

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -239,9 +239,8 @@ class Member < ActiveRecord::Base
     end
   end
 
-  def newsletter_subscribe(testing = false)
+  def newsletter_subscribe(gb = Gibbon::API.new, testing = false)
     return true if (Rails.env.test? && !testing)
-    gb = Gibbon::API.new
     gb.lists.subscribe({
                          id: Growstuff::Application.config.newsletter_list_id,
                          email: { email: email },
@@ -250,9 +249,8 @@ class Member < ActiveRecord::Base
                        })
   end
 
-  def newsletter_unsubscribe(testing = false)
+  def newsletter_unsubscribe(gb = Gibbon::API.new, testing = false)
     return true if (Rails.env.test? && !testing)
-    gb = Gibbon::API.new
     gb.lists.unsubscribe({
                            id: Growstuff::Application.config.newsletter_list_id,
                            email: { email: email }

--- a/lib/geocodable.rb
+++ b/lib/geocodable.rb
@@ -5,13 +5,6 @@ module Geocodable
 
   private
 
-  def geocode
-    unless self.location.blank?
-      self.latitude, self.longitude =
-        Geocoder.coordinates(location, params: { limit: 1 })
-    end
-  end
-
   def empty_unwanted_geocodes
     if self.location.blank?
       self.latitude = nil

--- a/spec/features/signin_spec.rb
+++ b/spec/features/signin_spec.rb
@@ -6,6 +6,15 @@ feature "signin", js: true do
   let(:wrangler) { create :crop_wrangling_member }
   let(:notification) { create :notification }
 
+  scenario "via email address" do
+    visit crops_path # some random page
+    click_link 'Sign in'
+    fill_in 'Login', with: member.email
+    fill_in 'Password', with: member.password
+    click_button 'Sign in'
+    expect(page).to have_content("Sign out")
+  end
+
   scenario "redirect to previous page after signin" do
     visit crops_path # some random page
     click_link 'Sign in'

--- a/spec/models/crop_spec.rb
+++ b/spec/models/crop_spec.rb
@@ -578,6 +578,17 @@ describe Crop do
       expect(loaded.parent).to eq parent
     end
 
+    it "loads a crop with a missing parent" do
+      tomato_row = "tomato,http://en.wikipedia.org/wiki/Tomato,parent"
+
+      CSV.parse(tomato_row) do |row|
+        Crop.create_from_csv(row)
+      end
+
+      loaded = Crop.last
+      expect(loaded.parent).to be_nil
+    end
+
     it "doesn't add unnecessary duplicate crops" do
       tomato_row = "tomato,http://en.wikipedia.org/wiki/Tomato,,Solanum lycopersicum"
 

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -5,10 +5,10 @@ describe 'member' do
     let(:member) { FactoryGirl.create(:member) }
 
     it 'should be fetchable from the database' do
-      @member2 = Member.find(member.id)
-      @member2.should be_an_instance_of Member
-      @member2.login_name.should match(/member\d+/)
-      @member2.encrypted_password.should_not be_nil
+      member2 = Member.find(member.id)
+      member2.should be_an_instance_of Member
+      member2.login_name.should match(/member\d+/)
+      member2.encrypted_password.should_not be_nil
     end
 
     it 'should have a friendly slug' do
@@ -43,8 +43,8 @@ describe 'member' do
     end
 
     it 'should be able to fetch posts' do
-      @post = FactoryGirl.create(:post, author: member)
-      member.posts.should eq [@post]
+      post = FactoryGirl.create(:post, author: member)
+      member.posts.should eq [post]
     end
 
     it 'should be able to fetch gardens' do
@@ -52,19 +52,19 @@ describe 'member' do
     end
 
     it 'has many plantings' do
-      @planting = FactoryGirl.create(:planting, owner: member)
+      planting = FactoryGirl.create(:planting, owner: member)
       member.plantings.size.should eq 1
     end
 
     it "has many comments" do
-      @comment1 = FactoryGirl.create(:comment, author: member)
-      @comment2 = FactoryGirl.create(:comment, author: member)
+      comment1 = FactoryGirl.create(:comment, author: member)
+      comment2 = FactoryGirl.create(:comment, author: member)
       member.comments.size.should == 2
     end
 
     it "has many forums" do
-      @forum1 = FactoryGirl.create(:forum, owner: member)
-      @forum2 = FactoryGirl.create(:forum, owner: member)
+      forum1 = FactoryGirl.create(:forum, owner: member)
+      forum2 = FactoryGirl.create(:forum, owner: member)
       member.forums.size.should == 2
     end
 
@@ -101,10 +101,10 @@ describe 'member' do
 
   context 'newsletter scope' do
     it 'finds newsletter recipients' do
-      @member1 = FactoryGirl.create(:member)
-      @member2 = FactoryGirl.create(:newsletter_recipient_member)
-      Member.wants_newsletter.should include @member2
-      Member.wants_newsletter.should_not include @member1
+      member1 = FactoryGirl.create(:member)
+      member2 = FactoryGirl.create(:newsletter_recipient_member)
+      Member.wants_newsletter.should include member2
+      Member.wants_newsletter.should_not include member1
     end
   end
 
@@ -198,22 +198,22 @@ describe 'member' do
     end
 
     it 'sets up roles in factories' do
-      @admin = FactoryGirl.create(:admin_member)
-      @admin.has_role?(:admin).should eq true
+      admin = FactoryGirl.create(:admin_member)
+      admin.has_role?(:admin).should eq true
     end
 
     it 'converts role names properly' do
       # need to make sure spaces get turned to underscores
-      @role = FactoryGirl.create(:role, name: "a b c")
-      member.roles << @role
+      role = FactoryGirl.create(:role, name: "a b c")
+      member.roles << role
       member.has_role?(:a_b_c).should eq true
     end
   end
 
   context 'confirmed scope' do
     before(:each) do
-      @member1 = FactoryGirl.create(:member)
-      @member2 = FactoryGirl.create(:member)
+      FactoryGirl.create(:member)
+      FactoryGirl.create(:member)
     end
 
     it 'sees confirmed members' do
@@ -221,7 +221,7 @@ describe 'member' do
     end
 
     it 'ignores unconfirmed members' do
-      @member3 = FactoryGirl.create(:unconfirmed_member)
+      FactoryGirl.create(:unconfirmed_member)
       Member.confirmed.size.should == 2
     end
   end
@@ -229,29 +229,29 @@ describe 'member' do
   context 'located scope' do
     # located members must have location, lat, long
     it 'finds members who have locations' do
-      @london_member = FactoryGirl.create(:london_member)
-      Member.located.should include @london_member
+      london_member = FactoryGirl.create(:london_member)
+      Member.located.should include london_member
     end
 
     it 'ignores members with blank locations' do
-      @nowhere_member = FactoryGirl.create(:member)
-      Member.located.should_not include @nowhere_member
+      nowhere_member = FactoryGirl.create(:member)
+      Member.located.should_not include nowhere_member
     end
 
     it 'ignores members with blank lat/long' do
-      @london_member = FactoryGirl.create(:london_member)
-      @london_member.latitude = nil
-      @london_member.longitude = nil
-      @london_member.save(validate: false)
-      Member.located.should_not include @london_member
+      london_member = FactoryGirl.create(:london_member)
+      london_member.latitude = nil
+      london_member.longitude = nil
+      london_member.save(validate: false)
+      Member.located.should_not include london_member
     end
   end
 
   context 'near location' do
     it 'finds nearby members and sorts them' do
-      @edinburgh_member = FactoryGirl.create(:edinburgh_member)
-      @london_member = FactoryGirl.create(:london_member)
-      Member.nearest_to('Greenwich, UK').should eq [@london_member, @edinburgh_member]
+      edinburgh_member = FactoryGirl.create(:edinburgh_member)
+      london_member = FactoryGirl.create(:london_member)
+      Member.nearest_to('Greenwich, UK').should eq [london_member, edinburgh_member]
     end
   end
 
@@ -263,38 +263,38 @@ describe 'member' do
     # 4) ordered by the most recent sign in
 
     it 'finds interesting members' do
-      @member1 = FactoryGirl.create(:london_member)
-      @member2 = FactoryGirl.create(:london_member)
-      @member3 = FactoryGirl.create(:london_member)
-      @member4 = FactoryGirl.create(:unconfirmed_member) # !1
-      @member5 = FactoryGirl.create(:london_member)  # 1, 2, !3
-      @member6 = FactoryGirl.create(:member)         # 1, !2, 3
+      member1 = FactoryGirl.create(:london_member)
+      member2 = FactoryGirl.create(:london_member)
+      member3 = FactoryGirl.create(:london_member)
+      member4 = FactoryGirl.create(:unconfirmed_member) # !1
+      member5 = FactoryGirl.create(:london_member)  # 1, 2, !3
+      member6 = FactoryGirl.create(:member)         # 1, !2, 3
 
-      [@member1, @member2, @member3, @member4, @member6].each do |m|
+      [member1, member2, member3, member4, member6].each do |m|
         FactoryGirl.create(:planting, owner: m)
       end
 
-      @member1.updated_at = 3.days.ago
-      @member2.updated_at = 2.days.ago
-      @member3.updated_at = 1.day.ago
+      member1.updated_at = 3.days.ago
+      member2.updated_at = 2.days.ago
+      member3.updated_at = 1.day.ago
 
-      Member.interesting.should eq [@member3, @member2, @member1]
+      Member.interesting.should eq [member3, member2, member1]
     end
   end
 
   context 'orders' do
     it 'finds the current order' do
-      @member = FactoryGirl.create(:member)
-      @order1 = FactoryGirl.create(:completed_order, member: @member)
-      @order2 = FactoryGirl.create(:order, member: @member)
-      @member.current_order.should eq @order2
+      member = FactoryGirl.create(:member)
+      order1 = FactoryGirl.create(:completed_order, member: member)
+      order2 = FactoryGirl.create(:order, member: member)
+      member.current_order.should eq order2
     end
 
     it "copes if there's no current order" do
-      @member = FactoryGirl.create(:member)
-      @order1 = FactoryGirl.create(:completed_order, member: @member)
-      @order2 = FactoryGirl.create(:completed_order, member: @member)
-      @member.current_order.should be_nil
+      member = FactoryGirl.create(:member)
+      order1 = FactoryGirl.create(:completed_order, member: member)
+      order2 = FactoryGirl.create(:completed_order, member: member)
+      member.current_order.should be_nil
     end
   end
 
@@ -302,39 +302,39 @@ describe 'member' do
     let(:member) { FactoryGirl.create(:member) }
 
     it "recognises a permanent paid account" do
-      @account_type = FactoryGirl.create(:account_type,
+      account_type = FactoryGirl.create(:account_type,
         is_paid: true, is_permanent_paid: true)
-      member.account.account_type = @account_type
+      member.account.account_type = account_type
       member.is_paid?.should be(true)
     end
 
     it "recognises a current paid account" do
-      @account_type = FactoryGirl.create(:account_type,
+      account_type = FactoryGirl.create(:account_type,
         is_paid: true, is_permanent_paid: false)
-      member.account.account_type = @account_type
+      member.account.account_type = account_type
       member.account.paid_until = Time.zone.now + 1.month
       member.is_paid?.should be(true)
     end
 
     it "recognises an expired paid account" do
-      @account_type = FactoryGirl.create(:account_type,
+      account_type = FactoryGirl.create(:account_type,
         is_paid: true, is_permanent_paid: false)
-      member.account.account_type = @account_type
+      member.account.account_type = account_type
       member.account.paid_until = Time.zone.now - 1.minute
       member.is_paid?.should be(false)
     end
 
     it "recognises a free account" do
-      @account_type = FactoryGirl.create(:account_type,
+      account_type = FactoryGirl.create(:account_type,
         is_paid: false, is_permanent_paid: false)
-      member.account.account_type = @account_type
+      member.account.account_type = account_type
       member.is_paid?.should be(false)
     end
 
     it "recognises a free account even with paid_until set" do
-      @account_type = FactoryGirl.create(:account_type,
+      account_type = FactoryGirl.create(:account_type,
         is_paid: false, is_permanent_paid: false)
-      member.account.account_type = @account_type
+      member.account.account_type = account_type
       member.account.paid_until = Time.zone.now + 1.month
       member.is_paid?.should be(false)
     end

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -52,19 +52,19 @@ describe 'member' do
     end
 
     it 'has many plantings' do
-      planting = FactoryGirl.create(:planting, owner: member)
+      FactoryGirl.create(:planting, owner: member)
       member.plantings.size.should eq 1
     end
 
     it "has many comments" do
-      comment1 = FactoryGirl.create(:comment, author: member)
-      comment2 = FactoryGirl.create(:comment, author: member)
+      FactoryGirl.create(:comment, author: member)
+      FactoryGirl.create(:comment, author: member)
       member.comments.size.should == 2
     end
 
     it "has many forums" do
-      forum1 = FactoryGirl.create(:forum, owner: member)
-      forum2 = FactoryGirl.create(:forum, owner: member)
+      FactoryGirl.create(:forum, owner: member)
+      FactoryGirl.create(:forum, owner: member)
       member.forums.size.should == 2
     end
 
@@ -263,37 +263,37 @@ describe 'member' do
     # 4) ordered by the most recent sign in
 
     it 'finds interesting members' do
-      member1 = FactoryGirl.create(:london_member)
-      member2 = FactoryGirl.create(:london_member)
-      member3 = FactoryGirl.create(:london_member)
-      member4 = FactoryGirl.create(:unconfirmed_member) # !1
-      member5 = FactoryGirl.create(:london_member)  # 1, 2, !3
-      member6 = FactoryGirl.create(:member)         # 1, !2, 3
+      members = [
+        :london_member, :london_member, :london_member,
+        :unconfirmed_member, # !1
+        :london_member,      # 1, 2, !3
+        :member              # 1, !2, 3
+      ].collect { |m| FactoryGirl.create(m) }
 
-      [member1, member2, member3, member4, member6].each do |m|
-        FactoryGirl.create(:planting, owner: m)
+      [0, 1, 2, 3, 5].each do |i|
+        FactoryGirl.create(:planting, owner: members[i])
       end
 
-      member1.updated_at = 3.days.ago
-      member2.updated_at = 2.days.ago
-      member3.updated_at = 1.day.ago
+      members[0].updated_at = 3.days.ago
+      members[1].updated_at = 2.days.ago
+      members[2].updated_at = 1.day.ago
 
-      Member.interesting.should eq [member3, member2, member1]
+      Member.interesting.should eq [members[2], members[1], members[0]]
     end
   end
 
   context 'orders' do
     it 'finds the current order' do
       member = FactoryGirl.create(:member)
-      order1 = FactoryGirl.create(:completed_order, member: member)
+      FactoryGirl.create(:completed_order, member: member)
       order2 = FactoryGirl.create(:order, member: member)
       member.current_order.should eq order2
     end
 
     it "copes if there's no current order" do
       member = FactoryGirl.create(:member)
-      order1 = FactoryGirl.create(:completed_order, member: member)
-      order2 = FactoryGirl.create(:completed_order, member: member)
+      FactoryGirl.create(:completed_order, member: member)
+      FactoryGirl.create(:completed_order, member: member)
       member.current_order.should be_nil
     end
   end

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -401,4 +401,19 @@ describe 'member' do
       end
     end
   end
+
+  context 'subscriptions' do
+    let(:member) { FactoryGirl.create(:member) }
+    let(:gb) { instance_double("Gibbon::API.new") }
+
+    it 'subscribes to the newsletter' do
+      expect(gb).to receive_message_chain('lists.subscribe')
+      member.newsletter_subscribe(gb, true)
+    end
+
+    it 'unsubscribes from the newsletter' do
+      expect(gb).to receive_message_chain('lists.unsubscribe')
+      member.newsletter_unsubscribe(gb, true)
+    end
+  end
 end

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -266,9 +266,11 @@ describe 'member' do
       @member1 = FactoryGirl.create(:london_member)
       @member2 = FactoryGirl.create(:london_member)
       @member3 = FactoryGirl.create(:london_member)
-      @member4 = FactoryGirl.create(:unconfirmed_member)
+      @member4 = FactoryGirl.create(:unconfirmed_member) # !1
+      @member5 = FactoryGirl.create(:london_member)  # 1, 2, !3
+      @member6 = FactoryGirl.create(:member)         # 1, !2, 3
 
-      [@member1, @member2, @member3, @member4].each do |m|
+      [@member1, @member2, @member3, @member4, @member6].each do |m|
         FactoryGirl.create(:planting, owner: m)
       end
 

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -76,7 +76,7 @@ describe Post do
       Time.stub(now: Time.now)
     end
 
-    let(:post) { FactoryGirl.create(:post, created_at: 1.day.ago) }
+    let!(:post) { FactoryGirl.create(:post, created_at: 1.day.ago) }
 
     it "sets recent activity to post time" do
       post.recent_activity.to_i.should eq post.created_at.to_i
@@ -90,14 +90,17 @@ describe Post do
 
     it "shiny new post is recently active" do
       # create a shiny new post
-      @post2 = FactoryGirl.create(:post, created_at: 1.minute.ago)
-      Post.recently_active.first.should eq @post2
+      post2 = FactoryGirl.create(:post, created_at: 1.minute.ago)
+      Post.recently_active.first.should eq post2
+      Post.recently_active.second.should eq post
     end
 
     it "new comment on old post is recently active" do
       # now comment on an older post
-      @comment2 = FactoryGirl.create(:comment, post: post, created_at: 1.second.ago)
+      post2 = FactoryGirl.create(:post, created_at: 1.minute.ago)
+      FactoryGirl.create(:comment, post: post, created_at: 1.second.ago)
       Post.recently_active.first.should eq post
+      Post.recently_active.second.should eq post2
     end
   end
 

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -107,9 +107,15 @@ describe Post do
   context "notifications" do
     let(:member2) { FactoryGirl.create(:member) }
 
-    it "sends a notification when a member is mentioned" do
+    it "sends a notification when a member is mentioned using @-syntax" do
       expect {
         FactoryGirl.create(:post, author: member, body: "Hey @" << member2.login_name)
+      }.to change(Notification, :count).by(1)
+    end
+
+    it "sends a notification when a member is mentioned using [](member) syntax" do
+      expect {
+        FactoryGirl.create(:post, author: member, body: "Hey [#{member2}](member)")
       }.to change(Notification, :count).by(1)
     end
 

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -29,22 +29,22 @@ describe Post do
 
   it "has many comments" do
     post = FactoryGirl.create(:post, author: member)
-    comment1 = FactoryGirl.create(:comment, post: post)
-    comment2 = FactoryGirl.create(:comment, post: post)
+    FactoryGirl.create(:comment, post: post)
+    FactoryGirl.create(:comment, post: post)
     post.comments.size.should == 2
   end
 
   it "supports counting comments" do
     post = FactoryGirl.create(:post, author: member)
-    comment1 = FactoryGirl.create(:comment, post: post)
-    comment2 = FactoryGirl.create(:comment, post: post)
+    FactoryGirl.create(:comment, post: post)
+    FactoryGirl.create(:comment, post: post)
     post.comment_count.should == 2
   end
 
   it "destroys comments when deleted" do
     post = FactoryGirl.create(:post, author: member)
-    comment1 = FactoryGirl.create(:comment, post: post)
-    comment2 = FactoryGirl.create(:comment, post: post)
+    FactoryGirl.create(:comment, post: post)
+    FactoryGirl.create(:comment, post: post)
     post.comments.size.should == 2
     all = Comment.count
     post.destroy
@@ -124,7 +124,7 @@ describe Post do
       n = Notification.first
       n.sender.should eq member
       n.recipient.should eq member2
-      n.subject.should match /mentioned you in their post/
+      n.subject.should match(/mentioned you in their post/)
       n.body.should eq p.body
     end
 

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -34,6 +34,13 @@ describe Post do
     @post.comments.size.should == 2
   end
 
+  it "supports counting comments" do
+    @post = FactoryGirl.create(:post, author: member)
+    @comment1 = FactoryGirl.create(:comment, post: @post)
+    @comment2 = FactoryGirl.create(:comment, post: @post)
+    @post.comment_count.should == 2
+  end
+
   it "destroys comments when deleted" do
     @post = FactoryGirl.create(:post, author: member)
     @comment1 = FactoryGirl.create(:comment, post: @post)

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -18,57 +18,57 @@ describe Post do
   end
 
   it "should have a slug" do
-    @post = FactoryGirl.create(:post, author: member)
-    @time = @post.created_at
-    @datestr = @time.strftime("%Y%m%d")
+    post = FactoryGirl.create(:post, author: member)
+    time = post.created_at
+    datestr = time.strftime("%Y%m%d")
     # 2 digit day and month, full-length years
     # Counting digits using Math.log is not precise enough!
-    @datestr.size.should == 4 + @time.year.to_s.size
-    @post.slug.should == "#{member.login_name}-#{@datestr}-a-post"
+    datestr.size.should == 4 + time.year.to_s.size
+    post.slug.should == "#{member.login_name}-#{datestr}-a-post"
   end
 
   it "has many comments" do
-    @post = FactoryGirl.create(:post, author: member)
-    @comment1 = FactoryGirl.create(:comment, post: @post)
-    @comment2 = FactoryGirl.create(:comment, post: @post)
-    @post.comments.size.should == 2
+    post = FactoryGirl.create(:post, author: member)
+    comment1 = FactoryGirl.create(:comment, post: post)
+    comment2 = FactoryGirl.create(:comment, post: post)
+    post.comments.size.should == 2
   end
 
   it "supports counting comments" do
-    @post = FactoryGirl.create(:post, author: member)
-    @comment1 = FactoryGirl.create(:comment, post: @post)
-    @comment2 = FactoryGirl.create(:comment, post: @post)
-    @post.comment_count.should == 2
+    post = FactoryGirl.create(:post, author: member)
+    comment1 = FactoryGirl.create(:comment, post: post)
+    comment2 = FactoryGirl.create(:comment, post: post)
+    post.comment_count.should == 2
   end
 
   it "destroys comments when deleted" do
-    @post = FactoryGirl.create(:post, author: member)
-    @comment1 = FactoryGirl.create(:comment, post: @post)
-    @comment2 = FactoryGirl.create(:comment, post: @post)
-    @post.comments.size.should == 2
+    post = FactoryGirl.create(:post, author: member)
+    comment1 = FactoryGirl.create(:comment, post: post)
+    comment2 = FactoryGirl.create(:comment, post: post)
+    post.comments.size.should == 2
     all = Comment.count
-    @post.destroy
+    post.destroy
     Comment.count.should == all - 2
   end
 
   it "belongs to a forum" do
-    @post = FactoryGirl.create(:forum_post)
-    @post.forum.should be_an_instance_of Forum
+    post = FactoryGirl.create(:forum_post)
+    post.forum.should be_an_instance_of Forum
   end
 
   it "doesn't allow a nil subject" do
-    @post = FactoryGirl.build(:post, subject: nil)
-    @post.should_not be_valid
+    post = FactoryGirl.build(:post, subject: nil)
+    post.should_not be_valid
   end
 
   it "doesn't allow a blank subject" do
-    @post = FactoryGirl.build(:post, subject: "")
-    @post.should_not be_valid
+    post = FactoryGirl.build(:post, subject: "")
+    post.should_not be_valid
   end
 
   it "doesn't allow a subject with only spaces" do
-    @post = FactoryGirl.build(:post, subject: "    ")
-    @post.should_not be_valid
+    post = FactoryGirl.build(:post, subject: "    ")
+    post.should_not be_valid
   end
 
   context "recent activity" do
@@ -83,9 +83,9 @@ describe Post do
     end
 
     it "sets recent activity to comment time" do
-      @comment = FactoryGirl.create(:comment, post: post,
-                                              created_at: 1.hour.ago)
-      post.recent_activity.to_i.should eq @comment.created_at.to_i
+      comment = FactoryGirl.create(:comment, post: post,
+                                             created_at: 1.hour.ago)
+      post.recent_activity.to_i.should eq comment.created_at.to_i
     end
 
     it "shiny new post is recently active" do
@@ -120,12 +120,12 @@ describe Post do
     end
 
     it "sets the notification field" do
-      @p = FactoryGirl.create(:post, author: member, body: "Hey @#{member2}")
-      @n = Notification.first
-      @n.sender.should eq member
-      @n.recipient.should eq member2
-      @n.subject.should match /mentioned you in their post/
-      @n.body.should eq @p.body
+      p = FactoryGirl.create(:post, author: member, body: "Hey @#{member2}")
+      n = Notification.first
+      n.sender.should eq member
+      n.recipient.should eq member2
+      n.subject.should match /mentioned you in their post/
+      n.body.should eq p.body
     end
 
     it "sends notifications to all members mentioned" do

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -109,7 +109,7 @@ describe Post do
 
     it "sends a notification when a member is mentioned using @-syntax" do
       expect {
-        FactoryGirl.create(:post, author: member, body: "Hey @" << member2.login_name)
+        FactoryGirl.create(:post, author: member, body: "Hey @#{member2}")
       }.to change(Notification, :count).by(1)
     end
 
@@ -120,7 +120,7 @@ describe Post do
     end
 
     it "sets the notification field" do
-      @p = FactoryGirl.create(:post, author: member, body: "Hey @" << member2.login_name)
+      @p = FactoryGirl.create(:post, author: member, body: "Hey @#{member2}")
       @n = Notification.first
       @n.sender.should eq member
       @n.recipient.should eq member2
@@ -129,15 +129,15 @@ describe Post do
     end
 
     it "sends notifications to all members mentioned" do
-      @member3 = FactoryGirl.create(:member)
+      member3 = FactoryGirl.create(:member)
       expect {
-        FactoryGirl.create(:post, author: member, body: "Hey @" << member2.login_name << " & @" << @member3.login_name)
+        FactoryGirl.create(:post, author: member, body: "Hey @#{member2} & @#{member3}")
       }.to change(Notification, :count).by(2)
     end
 
     it "doesn't send notifications if you mention yourself" do
       expect {
-        FactoryGirl.create(:post, author: member, body: "@" << member.login_name)
+        FactoryGirl.create(:post, author: member, body: "@#{member}")
       }.to change(Notification, :count).by(0)
     end
   end


### PR DESCRIPTION
Adds some unit tests for posts and crops, and does some slight cleanup of the existing tests there. Also adds one feature test for "sign-in using email address rather than username", because that works by implementing a callback for Devise to use, and it didn't seem that unit-testing the callback was very worthwhile: the callback is trivial, the question is whether it matches Devise's expectations.

The two models with big coverage gaps are Member and Photo, because of the code to talk to Gibbon and Flickr. We could (and perhaps should) get those coverage numbers up with some judicious mocking. **Edit**: I've made a start at this.

The directory with the worst coverage is hands-down `app/controllers`, some of whose members have *dire* coverage. We deprecated controller tests a while back in favour of feature tests; in view of our problems with flaky CI, I think we should revisit that decision.