### PR TITLE
Garden's name in link

### DIFF
--- a/app/helpers/gardens_helper.rb
+++ b/app/helpers/gardens_helper.rb
@@ -9,6 +9,10 @@ module GardensHelper
     end
   end
 
+  def display_garden_name(garden)
+    truncate(garden.name, length: 50, separator: ' ', omission: '... ')
+  end
+
   def display_garden_plantings(plantings)
     if plantings.blank?
       "None"

--- a/app/views/gardens/_thumbnail.html.haml
+++ b/app/views/gardens/_thumbnail.html.haml
@@ -1,7 +1,7 @@
 .panel.panel-success
   .panel-heading
     %h3.panel-title
-      = link_to "#{garden.owner.login_name}'s garden", garden
+      = link_to display_garden_name(garden), garden
       - if can? :edit, garden
         %a.pull-right{:href => edit_garden_path(garden), :role => "button", :id => "edit_garden_glyphicon"}
           %span.glyphicon.glyphicon-pencil{:title => "Edit"}
@@ -12,7 +12,7 @@
       .col-md-8
         %dl.dl-horizontal
           %dt Name :
-          %dd= link_to garden.name, garden
+          %dd= link_to display_garden_name(garden), garden
           %dt Location :
           %dd
             - if garden.location.blank?

--- a/app/views/members/_gardens.html.haml
+++ b/app/views/members/_gardens.html.haml
@@ -5,7 +5,7 @@
     - member.gardens.each do |g|
       %li{:class => first_garden ? 'active' : '' }
         - first_garden = false
-        = link_to g.name, "#garden#{g.id}", 'data-toggle' => 'tab'
+        = link_to display_garden_name(g), "#garden#{g.id}", 'data-toggle' => 'tab'
     - if current_member == member
       %li.navbar-right
         = link_to new_garden_path, class: 'btn' do


### PR DESCRIPTION
uses the garden's name in the link to the garden.
also truncates it to 50 chars, because really long names muck with the display on many pages.

this was one of the changes in #1123 