### PR TITLE
change deliver_later to deliver_now, so we don't sys.exit() crash

### DIFF
--- a/app/controllers/crops_controller.rb
+++ b/app/controllers/crops_controller.rb
@@ -138,7 +138,7 @@ class CropsController < ApplicationController
         end
         unless current_member.role? :crop_wrangler
           Role.crop_wranglers.each do |w|
-            Notifier.new_crop_request(w, @crop).deliver_later!
+            Notifier.new_crop_request(w, @crop).deliver_now!
           end
         end
 
@@ -166,8 +166,8 @@ class CropsController < ApplicationController
         if previous_status == "pending"
           requester = @crop.requester
           new_status = @crop.approval_status
-          Notifier.crop_request_approved(requester, @crop).deliver_later! if new_status == "approved"
-          Notifier.crop_request_rejected(requester, @crop).deliver_later! if new_status == "rejected"
+          Notifier.crop_request_approved(requester, @crop).deliver_now! if new_status == "approved"
+          Notifier.crop_request_rejected(requester, @crop).deliver_now! if new_status == "rejected"
         end
         format.html { redirect_to @crop, notice: 'Crop was successfully updated.' }
         format.json { head :no_content }

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -21,6 +21,6 @@ class Notification < ActiveRecord::Base
   end
 
   def send_email
-    Notifier.notify(self).deliver_later if recipient.send_notification_email
+    Notifier.notify(self).deliver_now! if recipient.send_notification_email
   end
 end

--- a/lib/tasks/growstuff.rake
+++ b/lib/tasks/growstuff.rake
@@ -53,7 +53,7 @@ namespace :growstuff do
 
     if Date.today.cwday == send_on_day and Date.today.cweek % every_n_weeks == 0
       Member.confirmed.find_each do |m|
-        Notifier.planting_reminder(m).deliver_later!
+        Notifier.planting_reminder(m).deliver_now!
       end
     end
   end


### PR DESCRIPTION
Production (and my dev) is crashing out on a sys.exit at:
* new crop request / approval
* following another user
* planting reminders

this changes to deliver_now 