### PR TITLE
hide inactive gardens by default

### DIFF
--- a/app/controllers/gardens_controller.rb
+++ b/app/controllers/gardens_controller.rb
@@ -6,11 +6,8 @@ class GardensController < ApplicationController
   # GET /gardens.json
   def index
     @owner = Member.find_by(slug: params[:owner])
-    @gardens = if @owner
-                 @owner.gardens.paginate(page: params[:page])
-               else
-                 Garden.paginate(page: params[:page])
-               end
+    @show_all = params[:all] == '1'
+    @gardens = gardens
 
     respond_to do |format|
       format.html # index.html.erb
@@ -92,5 +89,13 @@ class GardensController < ApplicationController
   def garden_params
     params.require(:garden).permit(:name, :slug, :owner_id, :description, :active,
       :location, :latitude, :longitude, :area, :area_unit)
+  end
+
+  def gardens
+    g = @owner ? @owner.gardens : Garden.all
+    g = g.active unless @show_all
+    g = g.includes(:owner).order(:name)
+    g = g.paginate(page: params[:page])
+    g
   end
 end

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -30,6 +30,7 @@ class MembersController < ApplicationController
     @flickr_auth   = @member.auth('flickr')
     @facebook_auth = @member.auth('facebook')
     @posts         = @member.posts
+    @gardens       = @member.gardens.active.order(:name)
     # The garden form partial is called from the "New Garden" tab;
     # it requires a garden to be passed in @garden.
     # The new garden is not persisted unless Garden#save is called.

--- a/app/views/gardens/_nav.haml
+++ b/app/views/gardens/_nav.haml
@@ -1,0 +1,18 @@
+- content_for :buttonbar do
+  - if current_member
+    = link_to 'My Gardens', gardens_by_owner_path(owner: current_member.slug), class: 'btn btn-default'
+
+  = link_to "Everyone's gardens", gardens_path, class: 'btn btn-default'
+
+  - if owner
+    - path = gardens_by_owner_path(owner: @owner.slug, all: show_all ? '' : 1)
+  - else
+    - path = gardens_path(all: show_all ? '' : 1)
+  = link_to path do
+    = check_box_tag 'active', 'all', show_all
+    include in-active
+
+- if can?(:create, Garden)
+  = link_to 'Add a garden', new_garden_path, class: 'btn btn-primary'
+- unless current_member
+  = render partial: 'shared/signin_signup', locals: { to: 'add a new garden' }

--- a/app/views/gardens/index.html.haml
+++ b/app/views/gardens/index.html.haml
@@ -1,18 +1,6 @@
 - content_for :title, @owner ? "#{@owner}'s gardens" : "Everyone's gardens"
 
-%p
-  - if can? :create, Garden
-    - if @owner
-      %p
-        - if @owner == current_member
-          = link_to 'Add a garden', new_garden_path, :class => 'btn btn-primary'
-        = link_to "View everyone's gardens", gardens_path, :class => 'btn btn-default'
-    - else # everyone's gardens
-      = link_to 'Add a garden', new_garden_path, :class => 'btn btn-primary'
-      - if current_member
-        = link_to 'View your gardens', gardens_by_owner_path(:owner => current_member.slug), :class => 'btn btn-default'
-  - else
-    = render :partial => 'shared/signin_signup', :locals => { :to => 'add a new garden' }
+= render 'nav', owner: @owner, show_all: @show_all
 
 %div.pagination
   = page_entries_info @gardens

--- a/app/views/members/_gardens.html.haml
+++ b/app/views/members/_gardens.html.haml
@@ -2,7 +2,7 @@
 .tabbable
   %ul.nav.nav-tabs
     - first_garden = true
-    - member.gardens.each do |g|
+    - gardens.each do |g|
       %li{:class => first_garden ? 'active' : '' }
         - first_garden = false
         = link_to display_garden_name(g), "#garden#{g.id}", 'data-toggle' => 'tab'
@@ -12,7 +12,7 @@
           Add New Garden
   .tab-content{style: "padding-top: 1em"}
     - first_garden = true
-    - member.gardens.each do |g|
+    - gardens.each do |g|
 
       %div{:class => ['tab-pane', first_garden ? 'active' : ''], :id => "garden#{g.id}"}
         - first_garden = false

--- a/app/views/members/show.html.haml
+++ b/app/views/members/show.html.haml
@@ -28,11 +28,9 @@
 .row
 
   .col-md-9
-
-    = render :partial => "map", :locals => { :member => @member }
-    = render :partial => "bio", :locals => { :member => @member }
-    = render :partial => "gardens", :locals => { :member => @member }
-
+    = render partial: "map", locals: { member: @member }
+    = render partial: "bio", locals: { member: @member }
+    = render partial: "gardens", locals: { member: @member, gardens: @gardens }
   .col-md-3
     = render :partial => "avatar", :locals => { :member => @member }
     = render :partial => "account", :locals => { :member => @member }

--- a/app/views/plantings/_nav.haml
+++ b/app/views/plantings/_nav.haml
@@ -19,4 +19,3 @@
     = link_to 'Plant something', new_planting_path, :class => 'btn btn-primary'
 - else
   = render :partial => 'shared/signin_signup', :locals => { :to => "track what you've planted" }
-

--- a/spec/features/gardens_spec.rb
+++ b/spec/features/gardens_spec.rb
@@ -28,6 +28,13 @@ feature "Planting a crop", js: true do
     expect(page).not_to have_content "Mark as inactive"
   end
 
+  scenario "List only active gardens" do
+    visit garden_path(garden)
+    click_link "Mark as inactive"
+    visit gardens_path
+    expect(page).not_to have_link garden_path(garden)
+  end
+
   scenario "Create new garden" do
     visit new_garden_path
     fill_in "Name", with: "New garden"

--- a/spec/features/gardens_spec.rb
+++ b/spec/features/gardens_spec.rb
@@ -13,9 +13,9 @@ feature "Planting a crop", js: true do
   scenario "View gardens" do
     visit gardens_path
     expect(page).to have_content "Everyone's gardens"
-    click_link "View your gardens"
+    click_link "My Gardens"
     expect(page).to have_content "#{garden.owner.login_name}'s gardens"
-    click_link "View everyone's gardens"
+    click_link "Everyone's gardens"
     expect(page).to have_content "Everyone's gardens"
   end
 


### PR DESCRIPTION
same as #1141 
Show active gardens by default (unless the show inactive is checked)

This also changes the button labels to match plantings more.. e.g "Everyone's gardens" instead of "View everyone's gardens".

 