### PR TITLE
Add deppbot to CONTRIBUTORS.md

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -76,3 +76,7 @@ submit the change with your pull request.
 - Brenda Wallace / [br3nda](https://github.com/br3nda)
 - Jim Stallings / [jestallin](https://github.com/jestallin)
 - Alyssa Ransbury / [alran](https://github.com/alran)
+
+## Bots
+
+- Security and Dependency Updates / [deppbot](https://github.com/deppbot)


### PR DESCRIPTION
This prevents deppbot-generated pull requests from failing the "are you in CONTRIBUTORS.md?" check in CI.

I, for one, welcome our new robot overlords.