### PR TITLE
Gardens order

### DIFF
--- a/app/controllers/gardens_controller.rb
+++ b/app/controllers/gardens_controller.rb
@@ -63,7 +63,6 @@ class GardensController < ApplicationController
   def gardens
     g = @owner ? @owner.gardens : Garden.all
     g = g.active unless @show_all
-    g = g.includes(:owner).order(:name)
-    g.paginate(page: params[:page])
+    g.includes(:owner).order(:updated_at).paginate(page: params[:page])
   end
 end


### PR DESCRIPTION
This page is linked to from the front page: 
http://www.growstuff.org/gardens

and shows all gardens

it is ordered by name - and the first page is gardens that haven't been planting in for 4 years.

This PR changes that to order by :updated_at, resulting in a page full of active gardens.
