### PR TITLE
Garden thumbnail display cleanup

### DIFF
--- a/app/assets/stylesheets/overrides.sass
+++ b/app/assets/stylesheets/overrides.sass
@@ -333,3 +333,6 @@ $state-success-bg: lighten($green, 50%)
   overflow: hidden
   text-overflow: ellipsis
   white-space: nowrap
+
+ul.plantings
+  list-style-type: none

--- a/app/helpers/gardens_helper.rb
+++ b/app/helpers/gardens_helper.rb
@@ -21,13 +21,14 @@ module GardensHelper
     if plantings.blank?
       "None"
     else
-      output = ""
-      plantings.first(2).each do |planting|
+      output = '<ul class="plantings">'
+      plantings.each do |planting|
         output += "<li>"
         output += planting.quantity.nil? ? "0 " : "#{planting.quantity} "
         output += link_to planting.crop.name, planting.crop
         output += ", planted on #{planting.planted_at}</li>"
       end
+      output += '</ul>'
       output.html_safe
     end
   end

--- a/app/views/gardens/_thumbnail.html.haml
+++ b/app/views/gardens/_thumbnail.html.haml
@@ -1,7 +1,7 @@
 .panel.panel-success
   .panel-heading
     %h3.panel-title
-      = link_to display_garden_name(garden), garden
+      = link_to display_garden_name(garden), garden_path(garden)
       - if can? :edit, garden
         %a.pull-right{ href: edit_garden_path(garden), role: "button", id: "edit_garden_glyphicon" }
           %span.glyphicon.glyphicon-pencil{ title: "Edit" }
@@ -14,7 +14,7 @@
       .col-md-8
         %dl.dl-horizontal
           %dt Name :
-          %dd= link_to display_garden_name(garden), garden
+          %dd= link_to display_garden_name(garden), garden_path(garden)
           %dt Location :
           %dd
             - if garden.location.blank?
@@ -29,11 +29,9 @@
         %b
           = localize_plural(garden.plantings, Planting)
           = ":"
-        = display_garden_plantings(garden.plantings.current)
+        = display_garden_plantings(garden.plantings.current.includes(:crop).first(2))
         - if garden.plantings.size > 2
-          %br
           = link_to "See more plantings >>", garden_path(garden)
   .panel-footer
     %dt Description
-    %dd
-      = display_garden_description(garden)
+    %dd= display_garden_description(garden)

--- a/spec/helpers/gardens_helper_spec.rb
+++ b/spec/helpers/gardens_helper_spec.rb
@@ -42,10 +42,10 @@ describe GardensHelper do
       plantings = [FactoryGirl.create(:planting, quantity: 10, crop: crop)]
       result = helper.display_garden_plantings(plantings)
 
-      output = "<li>"
+      output = '<ul class="plantings"><li>'
       output += "10 " + link_to(crop.name, crop)
       output += ", planted on #{plantings.first.planted_at}"
-      output += "</li>"
+      output += "</li></ul>"
       expect(result).to eq output
     end
 
@@ -58,16 +58,16 @@ describe GardensHelper do
       crop2 = FactoryGirl.create(:crop)
       plantings << FactoryGirl.create(:planting, quantity: 10, crop: crop2)
 
-      result = helper.display_garden_plantings(plantings)
+      result = helper.display_garden_plantings(plantings.first(2))
 
-      output = "<li>"
+      output = '<ul class="plantings"><li>'
       output += "10 " + link_to(crop1.name, crop1)
       output += ", planted on #{plantings.first.planted_at}"
       output += "</li>"
       output += "<li>"
       output += "10 " + link_to(crop2.name, crop2)
       output += ", planted on #{plantings.first.planted_at}"
-      output += "</li>"
+      output += "</li></ul>"
       expect(result).to eq output
     end
 
@@ -83,16 +83,16 @@ describe GardensHelper do
       crop3 = FactoryGirl.create(:crop)
       plantings << FactoryGirl.create(:planting, quantity: 10, crop: crop3)
 
-      result = helper.display_garden_plantings(plantings)
+      result = helper.display_garden_plantings(plantings.first(2))
 
-      output = "<li>"
+      output = '<ul class="plantings"><li>'
       output += "10 " + link_to(crop1.name, crop1)
       output += ", planted on #{plantings.first.planted_at}"
       output += "</li>"
       output += "<li>"
       output += "10 " + link_to(crop2.name, crop2)
       output += ", planted on #{plantings.first.planted_at}"
-      output += "</li>"
+      output += "</li></ul>"
       expect(result).to eq output
     end
   end


### PR DESCRIPTION
Puts the `<li>` inside a `<ul>`
adds a class to the `<ul>`
turns off the bullets  in `ul.plantings`

Moves the number `2` from being in two far apart files, to instead being on subsequent lines in the same file. This is better connascence. (It's only called in this one place)

Added `.includes(:crop)` to reduce query count

Updated specs

before:
![image](https://cloud.githubusercontent.com/assets/12266/25068063/a8ef9f34-22ab-11e7-8968-ab433152a157.png)

after:
![image](https://cloud.githubusercontent.com/assets/12266/25068064/b433daae-22ab-11e7-80c4-0b0621cb1ca5.png)

