### PR TITLE
Photo ui

### DIFF
--- a/app/controllers/photo_associations_controller.rb
+++ b/app/controllers/photo_associations_controller.rb
@@ -4,10 +4,14 @@ class PhotoAssociationsController < ApplicationController
 
   def destroy
     @photo = Photo.find(params[:photo_id])
-    if params[:type] == 'planting'
-      @planting = Planting.find(params[:planting_id])
-      @photo.plantings.delete(@planting) if @planting.owner == current_member && @photo.owner == current_member
-    end
+    collection = Growstuff::Constants::PhotoModels.get_relation(@photo, params[:type])
+    item_class = Growstuff::Constants::PhotoModels.get_item(params[:type])
+    @item = item_class.find_by!(id: params[:id], owner_id: current_member.id)
+    collection.delete(@item) if owner_matches?
     respond_with(@photo)
+  end
+
+  def owner_matches?
+    @photo.owner == current_member && @item.owner == current_member
   end
 end

--- a/app/controllers/photo_associations_controller.rb
+++ b/app/controllers/photo_associations_controller.rb
@@ -6,7 +6,7 @@ class PhotoAssociationsController < ApplicationController
     @photo = Photo.find(params[:photo_id])
     if params[:type] == 'planting'
       @planting = Planting.find(params[:planting_id])
-      @photo.plantings.delete(@planting) if @planting.owner == current_user && @photo.owner == current_user
+      @photo.plantings.delete(@planting) if @planting.owner == current_member && @photo.owner == current_member
     end
     respond_with(@photo)
   end

--- a/app/controllers/photo_associations_controller.rb
+++ b/app/controllers/photo_associations_controller.rb
@@ -10,8 +10,4 @@ class PhotoAssociationsController < ApplicationController
     collection.delete(@item)
     respond_with(@photo)
   end
-
-  def owner_matches?
-    @photo.owner == current_member && @item.owner == current_member
-  end
 end

--- a/app/controllers/photo_associations_controller.rb
+++ b/app/controllers/photo_associations_controller.rb
@@ -1,0 +1,13 @@
+class PhotoAssociationsController < ApplicationController
+  before_action :authenticate_member!
+  respond_to :json, :html
+
+  def destroy
+    @photo = Photo.find(params[:photo_id])
+    if params[:type] == 'planting'
+      @planting = Planting.find(params[:planting_id])
+      @photo.plantings.delete(@planting) if @planting.owner == current_user && @photo.owner == current_user
+    end
+    respond_with(@photo)
+  end
+end

--- a/app/controllers/photo_associations_controller.rb
+++ b/app/controllers/photo_associations_controller.rb
@@ -3,11 +3,11 @@ class PhotoAssociationsController < ApplicationController
   respond_to :json, :html
 
   def destroy
-    @photo = Photo.find(params[:photo_id])
+    @photo = Photo.find_by!(id: params[:photo_id], owner: current_member)
     collection = Growstuff::Constants::PhotoModels.get_relation(@photo, params[:type])
     item_class = Growstuff::Constants::PhotoModels.get_item(params[:type])
     @item = item_class.find_by!(id: params[:id], owner_id: current_member.id)
-    collection.delete(@item) if owner_matches?
+    collection.delete(@item)
     respond_with(@photo)
   end
 

--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -34,13 +34,23 @@ class Photo < ActiveRecord::Base
     licenses = flickr.photos.licenses.getInfo
     license = licenses.find { |l| l.id == info.license }
     {
-      title: info.title || "Untitled",
+      title: calculate_title(info),
       license_name: license.name,
       license_url: license.url,
       thumbnail_url: FlickRaw.url_q(info),
       fullsize_url: FlickRaw.url_z(info),
       link_url: FlickRaw.url_photopage(info)
     }
+  end
+
+  def calculate_title(info)
+    if id && title # already has a title saved
+      title
+    elsif info.title # use title from flickr
+      info.title
+    else
+      'untitled'
+    end
   end
 
   def set_flickr_metadata

--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -10,6 +10,10 @@ class Photo < ActiveRecord::Base
 
   default_scope { order("created_at desc") }
 
+  def associations?
+    plantings.any? || harvests.any? || gardens.any? || seeds.any?
+  end
+
   def all_associations
     associations = []
     Growstuff::Constants::PhotoModels.relations.each do |association_name|

--- a/app/views/photos/_photo_association_delete.haml
+++ b/app/views/photos/_photo_association_delete.haml
@@ -1,0 +1,4 @@
+- if can? :edit, photo
+  = link_to photo_associations_path(photo_id: photo.id, type: type, id: thing.id),
+    method: 'delete', class: 'btn btn-default btn-xs' do
+    %span.glyphicon.glyphicon-remove{ title: "Remove link" }

--- a/app/views/photos/_photo_associations.html.haml
+++ b/app/views/photos/_photo_associations.html.haml
@@ -1,0 +1,21 @@
+%h4 This photo depicts:
+%ul
+  - @photo.plantings.each do |planting|
+    %li
+      = link_to t('photos.show.planting', planting: planting.to_s, owner: planting.owner.to_s), planting_path(planting)
+      = render partial: "photo_association_delete", locals: { photo: @photo, type: 'planting', thing: planting }
+
+  - @photo.harvests.each do |harvest|
+    %li
+      = link_to t('photos.show.harvest', crop: harvest.crop.name, owner: harvest.owner.to_s), harvest_path(harvest)
+      = render partial: "photo_association_delete", locals: { photo: @photo, type: 'harvest', thing: harvest }
+
+  - @photo.gardens.each do |garden|
+    %li
+      = link_to t('photos.show.garden', garden: garden.to_s, owner: garden.owner.to_s), garden_path(garden)
+      = render partial: "photo_association_delete", locals: { photo: @photo, type: 'garden', thing: garden }
+
+  - @photo.seeds.each do |seed|
+    %li
+      = link_to t('photos.show.seed', seed: seed.to_s, owner: seed.owner.to_s), seed_path(seed)
+      = render partial: "photo_association_delete", locals: { photo: @photo, type: 'seed', thing: seed }

--- a/app/views/photos/edit.html.haml
+++ b/app/views/photos/edit.html.haml
@@ -1,2 +1,5 @@
 - content_for :title, "Edit Photo"
-
+= form_for(@photo) do |f|
+  = f.label :title
+  = f.text_field :title, placeholder: "title"
+  = f.submit

--- a/app/views/photos/show.html.haml
+++ b/app/views/photos/show.html.haml
@@ -33,24 +33,5 @@
           = @photo.license_name
 
     %p= link_to "View on Flickr", @photo.link_url
-
     - if @photo.associations?
-      %h4 This photo depicts:
-      %ul
-        - @photo.plantings.each do |p|
-          %li
-            = link_to t('.planting', planting: p.to_s, owner: p.owner.to_s), planting_path(p)
-            - if can? :edit, @photo
-              = link_to photo_associations_path(photo_id: @photo.id,
-                type: 'planting', planting_id: p.id), method: 'delete',
-                class: 'btn btn-default btn-xs' do
-                %span.glyphicon.glyphicon-remove{ title: "Remove link" }
-
-        - @photo.harvests.each do |h|
-          %li= link_to t('.harvest', crop: h.crop.name, owner: h.owner.to_s), harvest_path(h)
-
-        - @photo.gardens.each do |g|
-          %li= link_to t('.garden', garden: g.to_s, owner: g.owner.to_s), garden_path(g)
-
-        - @photo.seeds.each do |s|
-          %li= link_to t('.seed', seed: s.to_s, owner: s.owner.to_s), seed_path(s)
+      = render "photo_associations", locals: { photo: @photo }

--- a/app/views/photos/show.html.haml
+++ b/app/views/photos/show.html.haml
@@ -9,7 +9,7 @@
 
 .row
   .col-md-8
-    %p= image_tag(@photo.fullsize_url, alt: @photo.title, class: 'img')
+    %p= image_tag(@photo.fullsize_url, alt: @photo.title, class: 'img img-responsive')
 
   .col-md-4
     %p

--- a/app/views/photos/show.html.haml
+++ b/app/views/photos/show.html.haml
@@ -8,7 +8,10 @@
   = tag("meta", property: "og:site_name", content: ENV['GROWSTUFF_SITE_NAME'])
 
 .row
-  .col-md-6
+  .col-md-8
+    %p= image_tag(@photo.fullsize_url, alt: @photo.title, class: 'img')
+
+  .col-md-4
     %p
       %strong Posted by:
       = link_to @photo.owner, @photo.owner
@@ -19,19 +22,20 @@
       - else
         = succeed "." do
           = @photo.license_name
-    %p
-      = link_to "View on Flickr", @photo.link_url
+
+    %p= link_to "View on Flickr", @photo.link_url
 
     - if can? :destroy, @photo
-      %p= link_to 'Delete Photo',
-          @photo,
-          method: :delete,
+      = link_to 'delete',
+          @photo, method: :delete,
           data: { confirm: 'Are you sure?' },
           class: 'btn btn-default btn-xs'
+    - if can? :edit, @photo
+      = link_to 'edit', edit_photo_path(@photo), class: 'btn btn-default btn-xs'
 
-  .col-md-6
-    - unless @photo.plantings.empty? && @photo.harvests.empty? && @photo.gardens.empty? && @photo.seeds.empty?
-      %p This photo depicts:
+
+    - if @photo.associations?
+      %h4 This photo depicts:
       %ul
         - @photo.plantings.each do |p|
           %li= link_to t('.planting', planting: p.to_s, owner: p.owner.to_s), planting_path(p)
@@ -41,8 +45,4 @@
           %li= link_to t('.garden', garden: g.to_s, owner: g.owner.to_s), garden_path(g)
         - @photo.seeds.each do |s|
           %li= link_to t('.seed', seed: s.to_s, owner: s.owner.to_s), seed_path(s)
-
-.row
-  .col-md-12
-    %p= image_tag(@photo.fullsize_url, alt: @photo.title, class: 'img')
 

--- a/app/views/photos/show.html.haml
+++ b/app/views/photos/show.html.haml
@@ -13,6 +13,15 @@
 
   .col-md-4
     %p
+      - if can? :destroy, @photo
+        = link_to @photo, method: :delete,
+          data: { confirm: 'Are you sure?' }, class: 'btn btn-default btn-xs' do
+          %span.glyphicon.glyphicon-trash{ title: "Delete" }
+
+      - if can? :edit, @photo
+        = link_to edit_photo_path(@photo), class: 'btn btn-default btn-xs' do
+          %span.glyphicon.glyphicon-pencil{ title: "Edit" }
+    %p
       %strong Posted by:
       = link_to @photo.owner, @photo.owner
     %p
@@ -25,24 +34,23 @@
 
     %p= link_to "View on Flickr", @photo.link_url
 
-    - if can? :destroy, @photo
-      = link_to 'delete',
-          @photo, method: :delete,
-          data: { confirm: 'Are you sure?' },
-          class: 'btn btn-default btn-xs'
-    - if can? :edit, @photo
-      = link_to 'edit', edit_photo_path(@photo), class: 'btn btn-default btn-xs'
-
-
     - if @photo.associations?
       %h4 This photo depicts:
       %ul
         - @photo.plantings.each do |p|
-          %li= link_to t('.planting', planting: p.to_s, owner: p.owner.to_s), planting_path(p)
+          %li
+            = link_to t('.planting', planting: p.to_s, owner: p.owner.to_s), planting_path(p)
+            - if can? :edit, @photo
+              = link_to photo_associations_path(photo_id: @photo.id,
+                type: 'planting', planting_id: p.id), method: 'delete',
+                class: 'btn btn-default btn-xs' do
+                %span.glyphicon.glyphicon-remove{ title: "Remove link" }
+
         - @photo.harvests.each do |h|
           %li= link_to t('.harvest', crop: h.crop.name, owner: h.owner.to_s), harvest_path(h)
+
         - @photo.gardens.each do |g|
           %li= link_to t('.garden', garden: g.to_s, owner: g.owner.to_s), garden_path(g)
+
         - @photo.seeds.each do |s|
           %li= link_to t('.seed', seed: s.to_s, owner: s.owner.to_s), seed_path(s)
-

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Growstuff::Application.routes.draw do
   resources :members
 
   resources :photos
+  delete 'photo_associations' => 'photo_associations#destroy'
 
   resources :authentications, only: [:create, :destroy]
 

--- a/spec/controllers/photo_associations_controller_spec.rb
+++ b/spec/controllers/photo_associations_controller_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+describe PhotoAssociationsController do
+  login_member
+
+  describe "destroy" do
+    let(:valid_params) do
+      {
+        id: harvest.id,
+        type: 'harvest',
+        photo_id: photo.id
+      }
+    end
+
+    before { photo.harvests << harvest }
+
+    describe "my harvest my photo" do
+      let(:harvest) { FactoryGirl.create :harvest, owner: member }
+      let(:photo) { FactoryGirl.create :photo, owner: member }
+
+      it "removes link" do
+        expect { delete :destroy, valid_params }.to change { photo.harvests.count }.by(-1)
+      end
+    end
+
+    describe "another member's harvest from another member's photo" do
+      let(:harvest) { FactoryGirl.create :harvest }
+      let(:photo) { FactoryGirl.create :photo }
+      it do
+        expect do
+          begin
+            delete :destroy, valid_params
+          rescue
+            nil
+          end
+        end.not_to change { photo.harvests.count }
+      end
+      it { expect { delete :destroy, valid_params }.to raise_error(ActiveRecord::RecordNotFound) }
+    end
+  end
+end

--- a/spec/views/photos/show.html.haml_spec.rb
+++ b/spec/views/photos/show.html.haml_spec.rb
@@ -18,9 +18,18 @@ describe "photos/show" do
     controller.stub(:current_user) { @member }
   end
 
+  let(:harvest) { FactoryGirl.create :harvest, owner: @member }
+  let(:planting) { FactoryGirl.create :planting, owner: @member }
+  let(:seed) { FactoryGirl.create :seed, owner: @member }
+  let(:garden) { FactoryGirl.create :garden, owner: @member }
+
   context "CC-licensed photo" do
     before(:each) do
       @photo = assign(:photo, FactoryGirl.create(:photo, owner: @member))
+      @photo.harvests << harvest
+      @photo.plantings << planting
+      @photo.seeds << seed
+      @photo.gardens << garden
       render
     end
 
@@ -43,6 +52,19 @@ describe "photos/show" do
 
     it "has a delete button" do
       assert_select "a[href='#{photo_path(@photo)}']"
+    end
+
+    it "links to harvest" do
+      assert_select "a", href: harvest_path(harvest)
+    end
+    it "links to planting" do
+      assert_select "a", href: planting_path(planting)
+    end
+    it "links to garden" do
+      assert_select "a", href: garden_path(garden)
+    end
+    it "links to seeds" do
+      assert_select "a", href: seed_path(seed)
     end
   end
 

--- a/spec/views/photos/show.html.haml_spec.rb
+++ b/spec/views/photos/show.html.haml_spec.rb
@@ -42,7 +42,7 @@ describe "photos/show" do
     end
 
     it "has a delete button" do
-      assert_select "a[href='#{photo_path(@photo)}']", 'Delete Photo'
+      assert_select "a[href='#{photo_path(@photo)}']"
     end
   end
 


### PR DESCRIPTION
- Editing a photo's title
- Don't overwrite photo's title if we re-import from flickr later
- New functionality, we can now remove a link from an item (harvest, garden, seed, plantings). so we don't need to delete the whole photo anymore if we link to the wrong item.
- Places the photo at the top, as that is what the user is seeking on this page.
- Makes the photo size responsive, so it fits in phone screens
- Fixed bug that was pushing the menu off screen on phones

