### PR TITLE
Route for flickr auth callback -- Fixes  #1106

### DIFF
--- a/app/views/photos/new.html.haml
+++ b/app/views/photos/new.html.haml
@@ -36,5 +36,5 @@
 - else
   .alert
     You must
-    = link_to "connect your account to Flickr", '/auth/flickr'
+    = link_to "connect your account to Flickr", '/members/auth/flickr'
     to add photos.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -81,6 +81,7 @@ Growstuff::Application.routes.draw do
   root to: 'home#index'
 
   get 'auth/:provider/callback' => 'authentications#create'
+  get 'members/auth/:provider/callback' => 'authentications#create'
 
   get '/shop' => 'shop#index'
   get '/shop/:action' => 'shop#:action'


### PR DESCRIPTION
This puts a route in, where omniauth-flickr seems to want it, since the release 14 gem updates that broke it.

I don't have facebook, so someone else checking the facebook auth still works is a good idea.
