### PR TITLE
Display seeds for trade, on homepage, as thumbnails.

### DIFF
--- a/app/models/seed.rb
+++ b/app/models/seed.rb
@@ -31,7 +31,8 @@ class Seed < ActiveRecord::Base
     allow_nil: true
 
   scope :tradable, -> { where("tradable_to != 'nowhere'") }
-
+  scope :interesting, -> { tradable.has_location }
+  scope :has_location, -> { joins(:owner).where.not("members.location": nil) }
   TRADABLE_TO_VALUES = %w(nowhere locally nationally internationally).freeze
   validates :tradable_to, inclusion: { in: TRADABLE_TO_VALUES,
                                        message: "You may only trade seed nowhere, "\
@@ -75,27 +76,6 @@ class Seed < ActiveRecord::Base
     else
       true
     end
-  end
-
-  def interesting?
-    # assuming we're passed something that's already known to be tradable
-    # eg. from Seed.tradable scope
-    return false if owner.location.blank? # don't want unspecified locations
-    true
-  end
-
-  # Seed.interesting
-  # returns a list of interesting seeds, for use on the homepage etc
-  def self.interesting
-    howmany = 12 # max number to find
-    interesting_seeds = []
-
-    Seed.tradable.each do |s|
-      break if interesting_seeds.size == howmany
-      interesting_seeds.push(s) if s.interesting?
-    end
-
-    interesting_seeds
   end
 
   def seed_slug

--- a/app/models/seed.rb
+++ b/app/models/seed.rb
@@ -9,6 +9,8 @@ class Seed < ActiveRecord::Base
   default_scope { order(created_at: :desc) }
 
   validates :crop, approved: true
+  delegate :name, to: :crop
+  delegate :default_photo, to: :crop
 
   validates :crop, presence: { message: "must be present and exist in our database" }
   validates :quantity,

--- a/app/views/home/_seeds.html.haml
+++ b/app/views/home/_seeds.html.haml
@@ -1,28 +1,21 @@
-- seeds = Seed.interesting.first(6)
-- if seeds.present?
+- cache cache_key_for(Seed, 'interesting'), expires_in: 1.day do
   %h2= t('.title')
-  - cache cache_key_for(Seed) do
-    %table.table.table-striped
-      %tr
-        %th= t('.owner')
-        %th= t('.crop')
-        %th.hidden-xs.hidden-sm= t('.description')
-        %th= t('.trade_to')
-        %th= t('.from')
-        %th
-
-      - seeds.each do |seed|
-        %tr
-          %td= link_to seed.owner.login_name, seed.owner
-          %td= link_to seed.crop.name, seed.crop
-          %td.hidden-xs.hidden-sm= truncate(seed.description, length: 40, separator: ' ')
-          %td= seed.tradable? ? seed.tradable_to : ''
-          %td
-            - if seed.tradable? && seed.owner.location.blank?
-              = t('.unspecified')
-            - elsif seed.tradable?
-              = truncate(seed.owner.location, length: 25, separator: ', ')
-          %td= link_to t('.details'), seed, class: 'btn btn-default btn-xs'
-
-  %p.text-right
-    = link_to "#{t('.view_all')} »", seeds_path
+  .row
+    .col-md-8
+      - Seed.includes(:owner, crop: :photos).interesting.first(6).each do |seed|
+        .col-md-3
+          .thumbnail
+            - cache cache_key_for(Crop, seed.id) do
+              = link_to image_tag((seed.default_photo ? seed.default_photo.thumbnail_url : 'placeholder_150.png'),
+                                  alt: seed.crop.name, class: 'img'),
+                                  seed
+              .seedinfo
+                = link_to seed.crop.name, seed
+                .trade-to
+                  %p= seed.owner.location
+                  %p
+                    Will trade to:
+                    %br/
+                    #{seed.tradable_to}
+%p.text-right
+  = link_to "#{t('.view_all')} »", seeds_path

--- a/spec/views/home/_seeds.html.haml_spec.rb
+++ b/spec/views/home/_seeds.html.haml_spec.rb
@@ -24,11 +24,8 @@ describe 'home/_seeds.html.haml', type: "view" do
   end
 
   it 'lists seeds' do
-    assert_select "table"
-    assert_select 'a', href: crop_path(@seed.crop)
-    assert_select 'a', href: crop_path(@seed.owner)
-    assert_select 'td', @seed.tradable_to
-    assert_select 'td', @seed.owner.location
+    rendered.should have_content @seed.tradable_to
+    rendered.should have_content @seed.owner.location
     assert_select 'a', href: seed_path(@seed)
   end
 end


### PR DESCRIPTION
Display seeds for trade, on homepage, as thumbnails.
Note: there is an existing seeds/_thumbnails template, but it's not really a thumbnail.

Fixed #1334  for seeds