### PR TITLE
Inactive plantings show as tiny thumbnails

### DIFF
--- a/app/controllers/gardens_controller.rb
+++ b/app/controllers/gardens_controller.rb
@@ -10,13 +10,18 @@ class GardensController < ApplicationController
     @owner = Member.find_by(slug: params[:owner])
     @show_all = params[:all] == '1'
     @gardens = gardens
-
     respond_with(@gardens)
   end
 
   # GET /gardens/1
   # GET /gardens/1.json
   def show
+    @current_plantings = @garden.plantings.current
+      .includes(:crop, :owner)
+      .order(planted_at: :desc)
+    @finished_plantings = @garden.plantings.finished
+      .includes(:crop)
+      .order(finished_at: :desc)
     respond_with(@garden)
   end
 

--- a/app/models/garden.rb
+++ b/app/models/garden.rb
@@ -5,7 +5,7 @@ class Garden < ActiveRecord::Base
   friendly_id :garden_slug, use: [:slugged, :finders]
 
   belongs_to :owner, class_name: 'Member', foreign_key: 'owner_id', counter_cache: true
-  has_many :plantings, -> { order(created_at: :desc) }, dependent: :destroy
+  has_many :plantings, dependent: :destroy
   has_many :crops, through: :plantings
 
   # set up geocoding

--- a/app/models/planting.rb
+++ b/app/models/planting.rb
@@ -124,7 +124,7 @@ class Planting < ActiveRecord::Base
   end
 
   def start_to_finish_diff
-    (finished_at - planted_at).to_i
+    (finished_at - planted_at).to_i if finished_at && planted_at
   end
 
   def self.mean_days_until_maturity(plantings)

--- a/app/models/planting.rb
+++ b/app/models/planting.rb
@@ -11,7 +11,6 @@ class Planting < ActiveRecord::Base
   default_scope { order(created_at: :desc) }
   scope :finished, -> { where(finished: true) }
   scope :current, -> { where(finished: false) }
-  scope :with_dates, -> { where.not(planted_at: nil) }
 
   scope :interesting, -> { has_photos.one_per_owner }
   scope :one_per_owner, lambda {

--- a/app/models/planting.rb
+++ b/app/models/planting.rb
@@ -6,11 +6,12 @@ class Planting < ActiveRecord::Base
   belongs_to :garden
   belongs_to :owner, class_name: 'Member', counter_cache: true
   belongs_to :crop, counter_cache: true
-  has_many :harvests, -> { order(harvested_at: :desc) }, dependent: :destroy
+  has_many :harvests, dependent: :destroy
 
   default_scope { order(created_at: :desc) }
   scope :finished, -> { where(finished: true) }
   scope :current, -> { where(finished: false) }
+  scope :with_dates, -> { where.not(planted_at: nil) }
 
   scope :interesting, -> { has_photos.one_per_owner }
   scope :one_per_owner, lambda {

--- a/app/views/gardens/show.html.haml
+++ b/app/views/gardens/show.html.haml
@@ -63,13 +63,13 @@
         .col-md-12
           %p Nothing is currently planted here.
     %h3 Previously planted in this garden
-    - if @finished_plantings.size.positive?
-      .row
+    .row
+      - if @finished_plantings.size.positive?
         - @finished_plantings.each do |planting|
           .col-xs-6.col-md-2
             = render partial: "plantings/thumbnail", locals: { planting: planting }
-    - else
-      %p Nothing has been planted here.
+      - else
+        %p Nothing has been planted here.
   .col-md-3
     %h4 About this garden
     %p

--- a/app/views/gardens/show.html.haml
+++ b/app/views/gardens/show.html.haml
@@ -55,18 +55,18 @@
 
     %h3 What's planted here?
     .row
-      - if @garden.plantings.size.positive?
-        - @garden.plantings.current.includes(:crop, :owner, :garden).each do |planting|
+      - if @current_plantings.size.positive?
+        - @current_plantings.each do |planting|
           .col-xs-12.col-md-6
-            = render partial: "plantings/thumbnail", locals: { planting: planting }
+            = render partial: "plantings/card", locals: { planting: planting }
       - else
         .col-md-12
           %p Nothing is currently planted here.
     %h3 Previously planted in this garden
-    - if @garden.plantings.finished.size.positive?
+    - if @finished_plantings.size.positive?
       .row
-        - @garden.plantings.finished.includes(:crop, :owner, :garden).each do |planting|
-          .col-xs-12.col-md-6
+        - @finished_plantings.each do |planting|
+          .col-xs-6.col-md-2
             = render partial: "plantings/thumbnail", locals: { planting: planting }
     - else
       %p Nothing has been planted here.

--- a/app/views/members/_gardens.html.haml
+++ b/app/views/members/_gardens.html.haml
@@ -49,7 +49,7 @@
             - unless g.featured_plantings.empty?
               - g.featured_plantings.each.with_index do |planting|
                 .col-xs-12.col-lg-6
-                  = render partial: "plantings/thumbnail", locals: { planting: planting }
+                  = render partial: "plantings/card", locals: { planting: planting }
 
           %p
             = link_to "More about this garden...", url_for(g)

--- a/app/views/places/show.html.haml
+++ b/app/views/places/show.html.haml
@@ -44,7 +44,7 @@
     .row
       - plantings.first(10).each.with_index do |planting, index|
         .col-xs-12.col-lg-6
-          = render partial: "plantings/thumbnail", locals: { planting: planting, index: index }
+          = render partial: "plantings/card", locals: { planting: planting, index: index }
     = link_to "View all plantings >>", plantings_path
   - else
     %p No nearby plantings found

--- a/app/views/plantings/_card.html.haml
+++ b/app/views/plantings/_card.html.haml
@@ -1,6 +1,10 @@
 .panel.panel-success.planting-thumbnail
   .panel-heading
-    %h3.panel-title= link_to planting.crop.name, planting_path(planting)
+    %h3.panel-title
+      = link_to planting.crop.name, planting_path(planting)
+      - if can? :edit, planting
+        %a.pull-right{ href: edit_planting_path(planting), role: "button", id: "edit_garden_glyphicon" }
+          %span.glyphicon.glyphicon-pencil{ title: "Edit" }
   .panel-body
     .row
       .col-xs-12.col-md-5
@@ -38,11 +42,6 @@
 
     = link_to 'Details', planting_path(planting),
       class: 'btn btn-default btn-xs'
-
-    - if can? :edit, planting
-      = link_to edit_planting_path(planting),
-        class: 'btn btn-default btn-xs' do
-        %span.glyphicon.glyphicon-pencil{ title: "Edit" }
 
     - if can?(:edit, planting) && can?(:create, Harvest)
       = link_to 'Harvest', new_planting_harvest_path(planting),

--- a/app/views/plantings/_card.html.haml
+++ b/app/views/plantings/_card.html.haml
@@ -1,0 +1,62 @@
+.panel.panel-success.planting-thumbnail
+  .panel-heading
+    %h3.panel-title= link_to planting.crop.name, planting_path(planting)
+  .panel-body
+    .row
+      .col-xs-12.col-md-5
+        = link_to image_tag((planting.default_photo ? planting.default_photo.thumbnail_url : 'placeholder_150.png'),
+                  alt: planting.crop_id, class: 'img img-responsive'),
+                  planting
+      .col-xs-12.col-md-7
+        %dl.dl-horizontal.planting-attributes
+          %dt Owner:
+          %dd= link_to planting.owner.login_name, planting.owner
+          %dt Garden:
+          %dd= link_to planting.garden.name, planting.garden
+          %dt Planted on:
+          %dd= planting.planted_at
+          - if planting.quantity
+            %dt Quantity:
+            %dd= display_planting_quantity(planting)
+          - if planting.finished?
+            %dt Finished on:
+            %dd= display_finished(planting)
+          %dt Sun/shade?:
+          %dd
+            - sunniness = planting.sunniness.blank? ? "not specified" : planting.sunniness
+            = image_tag("sunniness_#{sunniness}.png", size: "25x25", alt: sunniness, title: sunniness)
+            = " (#{sunniness})"
+          %dt Planted from:
+          %dd= display_planted_from(planting)
+
+          %dt Mature in:
+          %dd
+            = display_days_before_maturity(planting)
+            days
+
+    %p= render partial: 'plantings/planting_progress', locals: { planting: planting }
+
+    = link_to 'Details', planting_path(planting),
+      class: 'btn btn-default btn-xs'
+
+    - if can? :edit, planting
+      = link_to edit_planting_path(planting),
+        class: 'btn btn-default btn-xs' do
+        %span.glyphicon.glyphicon-pencil{ title: "Edit" }
+
+    - if can?(:edit, planting) && can?(:create, Harvest)
+      = link_to 'Harvest', new_planting_harvest_path(planting),
+        class: 'btn btn-default btn-xs'
+
+    - if can?(:edit, planting) && !planting.finished
+      = link_to "Mark as finished",
+                    planting_path(planting, planting: { finished: 1 }),
+                    method: :put,
+                    class: 'btn btn-default btn-xs append-date'
+
+    - if can? :destroy, planting
+      = link_to planting, method: :delete,
+                  data: { confirm: 'Are you sure?' },
+                  class: 'btn btn-default btn-xs' do
+        %span.glyphicon.glyphicon-trash{ title: "Delete" }
+

--- a/app/views/plantings/_thumbnail.html.haml
+++ b/app/views/plantings/_thumbnail.html.haml
@@ -1,62 +1,11 @@
-.panel.panel-success.planting-thumbnail
-  .panel-heading
-    %h3.panel-title= link_to planting.crop.name, planting_path(planting)
-  .panel-body
-    .row
-      .col-xs-12.col-md-5
-        = link_to image_tag((planting.default_photo ? planting.default_photo.thumbnail_url : 'placeholder_150.png'),
-                  alt: planting.crop_id, class: 'img img-responsive'),
-                  planting
-      .col-xs-12.col-md-7
-        %dl.dl-horizontal.planting-attributes
-          %dt Owner:
-          %dd= link_to planting.owner.login_name, planting.owner
-          %dt Garden:
-          %dd= link_to planting.garden.name, planting.garden
-          %dt Planted on:
-          %dd= planting.planted_at
-          - if planting.quantity
-            %dt Quantity:
-            %dd= display_planting_quantity(planting)
-          - if planting.finished?
-            %dt Finished on:
-            %dd= display_finished(planting)
-          %dt Sun/shade?:
-          %dd
-            - sunniness = planting.sunniness.blank? ? "not specified" : planting.sunniness
-            = image_tag("sunniness_#{sunniness}.png", size: "25x25", alt: sunniness, title: sunniness)
-            = " (#{sunniness})"
-          %dt Planted from:
-          %dd= display_planted_from(planting)
-
-          %dt Mature in:
-          %dd
-            = display_days_before_maturity(planting)
-            days
-
-    %p= render partial: 'plantings/planting_progress', locals: { planting: planting }
-
-    = link_to 'Details', planting_path(planting),
-      class: 'btn btn-default btn-xs'
-
-    - if can? :edit, planting
-      = link_to edit_planting_path(planting),
-        class: 'btn btn-default btn-xs' do
-        %span.glyphicon.glyphicon-pencil{ title: "Edit" }
-
-    - if can?(:edit, planting) && can?(:create, Harvest)
-      = link_to 'Harvest', new_planting_harvest_path(planting),
-        class: 'btn btn-default btn-xs'
-
-    - if can?(:edit, planting) && !planting.finished
-      = link_to "Mark as finished",
-                    planting_path(planting, planting: { finished: 1 }),
-                    method: :put,
-                    class: 'btn btn-default btn-xs append-date'
-
-    - if can? :destroy, planting
-      = link_to planting, method: :delete,
-                  data: { confirm: 'Are you sure?' },
-                  class: 'btn btn-default btn-xs' do
-        %span.glyphicon.glyphicon-trash{ title: "Delete" }
-
+.thumbnail
+  .planting-thumbnail
+    - if planting
+      = link_to image_tag((planting.default_photo ? planting.default_photo.thumbnail_url : 'placeholder_150.png'),
+                          alt: planting.crop.name, class: 'img'),
+                          planting
+      .plantinginfo
+        .planting-name
+          = link_to planting.crop.name, planting
+        %small.planting-date
+          = display_finished(planting)

--- a/app/views/plantings/index.html.haml
+++ b/app/views/plantings/index.html.haml
@@ -13,7 +13,7 @@
   - unless @plantings.empty?
     - @plantings.each.with_index do |planting|
       .col-xs-12.col-lg-6
-        = render partial: "plantings/thumbnail", locals: { planting: planting }
+        = render partial: "plantings/card", locals: { planting: planting }
 
 .pagination
   = page_entries_info @plantings

--- a/spec/views/gardens/show.html.haml_spec.rb
+++ b/spec/views/gardens/show.html.haml_spec.rb
@@ -19,6 +19,8 @@ describe "gardens/show" do
     @garden   = FactoryGirl.create(:garden, owner: @owner)
     @planting = FactoryGirl.create(:planting, garden: @garden)
     assign(:garden, @garden)
+    assign(:current_plantings, [@planting])
+    assign(:finished_plantings, [])
     render
   end
 


### PR DESCRIPTION
Shrink the inactive plantings down to thumbnails

![image](https://cloud.githubusercontent.com/assets/12266/26526267/18965bdc-43c9-11e7-8042-53c5cbfa8689.png)

![image](https://cloud.githubusercontent.com/assets/12266/26526331/422e56a0-43cb-11e7-928c-c9068256df13.png)


This renames the existing "plantings/thumbnail" to be "plantings/card". This makes more sense to me, because it wasn't really a thumbnail.

