### PR TITLE
Fixes #1450 Adds a more prominent add photo button to garden and planting show views

### DIFF
--- a/app/views/gardens/_actions.html.haml
+++ b/app/views/gardens/_actions.html.haml
@@ -21,3 +21,8 @@
               class: 'btn btn-default', id: 'delete_garden_link' do
       %span.glyphicon.glyphicon-trash{ title: "Delete" }
       Delete
+  - if can?(:edit, @garden) && can?(:create, Photo)
+    = link_to new_photo_path(type: "garden", id: @garden.id),
+    class: 'btn btn-primary' do
+      %span.glyphicon.glyphicon-camera{ title: "Add Photo" }
+      Add Photo

--- a/app/views/gardens/_actions.html.haml
+++ b/app/views/gardens/_actions.html.haml
@@ -23,6 +23,6 @@
       Delete
   - if can?(:edit, @garden) && can?(:create, Photo)
     = link_to new_photo_path(type: "garden", id: @garden.id),
-    class: 'btn btn-primary' do
+              class: 'btn btn-primary' do
       %span.glyphicon.glyphicon-camera{ title: "Add Photo" }
       Add Photo

--- a/app/views/gardens/show.html.haml
+++ b/app/views/gardens/show.html.haml
@@ -12,6 +12,12 @@
 .row
   .col-md-9
     %p.btn-group= render 'gardens/actions', garden: @garden
+    - if can?(:edit, @garden) && can?(:create, Photo)
+      %p
+        = link_to new_photo_path(type: "garden", id: @garden.id),
+        class: 'btn btn-primary' do
+          %span.glyphicon.glyphicon-camera{ title: "Add Photo" }
+          Add Photo
 
     - unless @garden.active
       .alert.alert-warning

--- a/app/views/gardens/show.html.haml
+++ b/app/views/gardens/show.html.haml
@@ -12,12 +12,6 @@
 .row
   .col-md-9
     %p.btn-group= render 'gardens/actions', garden: @garden
-    - if can?(:edit, @garden) && can?(:create, Photo)
-      %p
-        = link_to new_photo_path(type: "garden", id: @garden.id),
-        class: 'btn btn-primary' do
-          %span.glyphicon.glyphicon-camera{ title: "Add Photo" }
-          Add Photo
 
     - unless @garden.active
       .alert.alert-warning

--- a/app/views/plantings/show.html.haml
+++ b/app/views/plantings/show.html.haml
@@ -67,9 +67,8 @@
     %p= render 'plantings/progress', planting: @planting, show_explanation: true
 
     = render 'plantings/actions', planting: @planting
-    - if !@planting.photos.empty? || (can?(:edit, @planting) && can?(:create, Photo))
-      - if can?(:create, Photo) && can?(:edit, @planting)
-        = link_to "Add photo", new_photo_path(type: "planting", id: @planting.id), class: 'btn btn-primary btn-xs'
+    - if can?(:create, Photo) && can?(:edit, @planting)
+      = link_to "Add photo", new_photo_path(type: "planting", id: @planting.id), class: 'btn btn-primary btn-xs'
 
   .col-md-6
     = render partial: "crops/index_card", locals: { crop: @planting.crop }

--- a/app/views/plantings/show.html.haml
+++ b/app/views/plantings/show.html.haml
@@ -67,6 +67,9 @@
     %p= render 'plantings/progress', planting: @planting, show_explanation: true
 
     = render 'plantings/actions', planting: @planting
+    - if !@planting.photos.empty? || (can?(:edit, @planting) && can?(:create, Photo))
+      - if can?(:create, Photo) && can?(:edit, @planting)
+        = link_to "Add photo", new_photo_path(type: "planting", id: @planting.id), class: 'btn btn-primary btn-xs'
 
   .col-md-6
     = render partial: "crops/index_card", locals: { crop: @planting.crop }

--- a/spec/features/photos/new_photo_spec.rb
+++ b/spec/features/photos/new_photo_spec.rb
@@ -13,7 +13,7 @@ feature "new photo page" do
 
       scenario "add photo" do
         visit planting_path(planting)
-        click_link "Add photo"
+        click_link('Add photo', match: :first)
         expect(page).to have_text planting.crop.name
       end
     end

--- a/spec/views/gardens/show.html.haml_spec.rb
+++ b/spec/views/gardens/show.html.haml_spec.rb
@@ -50,6 +50,10 @@ describe "gardens/show" do
       rendered.should have_content "Plant something"
     end
 
+    it "shows an 'add photo' button" do
+      rendered.should have_content "Add photo"
+    end
+
     it "links to the right crop in the planting link" do
       assert_select("a[href='#{new_planting_path}?garden_id=#{@garden.id}']")
     end


### PR DESCRIPTION
In the planting and garden show views, I added an extra 'Add photo' button next to the other actions. I didn't get rid of the original add photo buttons as I thought it would be easier for users just to have another option. I'm definitely open to styling or button placement changes.

fixes #1450