### PR TITLE
Fix gardens actions, and add specs

### DIFF
--- a/app/views/gardens/_actions.html.haml
+++ b/app/views/gardens/_actions.html.haml
@@ -21,8 +21,8 @@
               class: 'btn btn-default', id: 'delete_garden_link' do
       %span.glyphicon.glyphicon-trash{ title: "Delete" }
       Delete
-  - if can?(:edit, @garden) && can?(:create, Photo)
-    = link_to new_photo_path(type: "garden", id: @garden.id),
+  - if can?(:edit, garden) && can?(:create, Photo)
+    = link_to new_photo_path(type: "garden", id: garden.id),
               class: 'btn btn-primary' do
       %span.glyphicon.glyphicon-camera{ title: "Add Photo" }
       Add Photo

--- a/app/views/plantings/_actions.html.haml
+++ b/app/views/plantings/_actions.html.haml
@@ -1,16 +1,27 @@
 - if can?(:edit, planting) || can?(:destroy, planting)
   - if can? :edit, planting
     = link_to edit_planting_path(planting), class: 'btn btn-default btn-xs' do
-      %span.glyphicon.glyphicon-pencil{ title: "Edit garden" }
+      %span.glyphicon.glyphicon-pencil{ title: "Edit" }
       Edit
   - if can? :destroy, planting
     = link_to planting, method: :delete,
-              data: { confirm: 'Are you sure?' },
-                  class: 'btn btn-default btn-xs' do
+              data: { confirm: 'Are you sure?' }, class: 'btn btn-default btn-xs' do
       %span.glyphicon.glyphicon-trash{ title: "Delete" }
       Delete
+
     - unless planting.finished
-      = link_to "Mark as finished", planting_path(planting, planting: { finished: 1 }),
-                method: :put, class: 'btn btn-default btn-xs append-date'
-  - if can? :create, Harvest
-    = link_to 'Harvest', new_planting_harvest_path(planting), class: 'btn btn-default btn-xs'
+      = link_to planting_path(planting, planting: { finished: 1 }),
+                method: :put, class: 'btn btn-default btn-xs append-date' do
+
+        %span.glyphicon.glyphicon-ok{ title: "Finished" }
+        Mark as finished
+
+  - if can?(:create, Harvest)
+    = link_to new_planting_harvest_path(planting), class: 'btn btn-default btn-xs' do
+      %span.glyphicon.glyphicon-leaf{ title: "Harvest" }
+      Harvest
+
+  - if can?(:edit, planting) && can?(:create, Photo)
+    = link_to new_photo_path(id: planting.id, type: 'planting'), class: 'btn btn-default btn-xs' do
+      %span.glyphicon.glyphicon-camera{ title: "Add photo" }
+      Add photo

--- a/app/views/plantings/show.html.haml
+++ b/app/views/plantings/show.html.haml
@@ -67,8 +67,6 @@
     %p= render 'plantings/progress', planting: @planting, show_explanation: true
 
     = render 'plantings/actions', planting: @planting
-    - if can?(:create, Photo) && can?(:edit, @planting)
-      = link_to "Add photo", new_photo_path(type: "planting", id: @planting.id), class: 'btn btn-primary btn-xs'
 
   .col-md-6
     = render partial: "crops/index_card", locals: { crop: @planting.crop }

--- a/spec/features/gardens/gardens_index_spec.rb
+++ b/spec/features/gardens/gardens_index_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+require 'custom_matchers'
+
+feature "Gardens#index", :js do
+  context "Logged in as member" do
+    let(:member) { FactoryBot.create :member }
+
+    background { login_as member }
+
+    context "with 10 gardens" do
+      before do
+        FactoryBot.create_list :garden, 10, owner: member
+        visit gardens_path(member: member)
+      end
+
+      it "displays each of the gardens" do
+        member.gardens.each do |garden|
+          expect(page).to have_text garden.name
+        end
+      end
+      it "links to each garden" do
+        member.gardens.each do |garden|
+          expect(page).to have_link(garden.name, href: garden_path(garden))
+        end
+      end
+    end
+
+    context "with inactive gardens" do
+      let!(:active_garden) { FactoryBot.create :garden, name: "My active garden", owner: member }
+      let!(:inactive_garden) { FactoryBot.create :inactive_garden, name: "retired garden", owner: member }
+
+      before { visit gardens_path(member: member) }
+
+      it "show active garden" do
+        expect(page).to have_text active_garden.name
+      end
+      it "should not show inactive garden" do
+        expect(page).not_to have_text inactive_garden.name
+      end
+      it "links to active garden" do
+        expect(page).to have_link(active_garden.name, href: garden_path(active_garden))
+      end
+      it "does not link to inactive gardens" do
+        expect(page).not_to have_link(inactive_garden.name, href: garden_path(inactive_garden))
+      end
+    end
+
+    context 'with plantings' do
+      let(:maize) { FactoryBot.create(:maize) }
+      let(:tomato) { FactoryBot.create(:tomato) }
+
+      let!(:planting) do
+        FactoryBot.create :planting, owner: member, crop: maize, garden: member.gardens.first
+      end
+      let!(:finished_planting) do
+        FactoryBot.create :finished_planting, owner: member, crop: tomato, garden: member.gardens.first
+      end
+
+      before do
+        visit gardens_path(member: member)
+      end
+      it "shows planting in garden" do
+        expect(page).to have_link(planting.crop.name, href: planting_path(planting))
+      end
+      it "does not show finished planting" do
+        expect(page).not_to have_text(finished_planting.crop.name)
+      end
+    end
+  end
+end


### PR DESCRIPTION
A bug slipped into all garden display pages - and there were no tests that caught it.
This adds feature specs for gardens#index, which would have detected the un-initialised
variable in haml