### PR TITLE
Bump haml_lint and rainbow

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -142,7 +142,7 @@ group :development, :test do
   gem 'i18n-tasks'                      # adds tests for finding missing and unused translations
   gem 'jasmine'                         # javascript unit testing
   gem 'poltergeist'                     # for headless JS testing
-  gem 'rainbow', '< 2.2.0' # See https://github.com/sickill/rainbow/issues/44
+  gem 'rainbow', '< 3.1.0' # See https://github.com/sickill/rainbow/issues/44
   gem 'rspec-activemodel-mocks'
   gem 'rspec-rails' # unit testing framework
   gem 'rubocop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -232,11 +232,11 @@ GEM
       haml (>= 4.0.6, < 6.0)
       html2haml (>= 1.0.1)
       railties (>= 4.0.1)
-    haml_lint (0.26.0)
+    haml_lint (0.27.0)
       haml (>= 4.0, < 5.1)
       rainbow
       rake (>= 10, < 13)
-      rubocop (>= 0.49.0)
+      rubocop (>= 0.50.0)
       sysexits (~> 1.1)
     hashie (3.5.6)
     heroics (0.0.24)
@@ -427,7 +427,7 @@ GEM
       activesupport (= 4.2.10)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rainbow (2.1.0)
+    rainbow (3.0.0)
     raindrops (0.19.0)
     rake (12.3.0)
     rb-fsevent (0.10.2)
@@ -462,11 +462,11 @@ GEM
       rspec-mocks (~> 3.7.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.0)
-    rubocop (0.49.1)
+    rubocop (0.52.0)
       parallel (~> 1.10)
-      parser (>= 2.3.3.1, < 3.0)
+      parser (>= 2.4.0.2, < 3.0)
       powerpack (~> 0.1)
-      rainbow (>= 1.99.1, < 3.0)
+      rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)
@@ -620,7 +620,7 @@ DEPENDENCIES
   rails (~> 4.2.8)
   rails-assets-leaflet.markercluster!
   rails_12factor
-  rainbow (< 2.2.0)
+  rainbow (< 3.1.0)
   rake (>= 10.0.0)
   responders
   rspec-activemodel-mocks


### PR DESCRIPTION
Bumps [haml_lint](https://github.com/brigade/haml-lint) and [rainbow](https://github.com/sickill/rainbow). These dependencies needed to be updated together.

Updates `haml_lint` from 0.26.0 to 0.27.0
- [Release notes](https://github.com/brigade/haml-lint/releases/tag/v0.27.0)
- [Changelog](https://github.com/brigade/haml-lint/blob/master/CHANGELOG.md)
- [Commits](https://github.com/brigade/haml-lint/compare/v0.26.0...v0.27.0)

Updates `rainbow` from 2.1.0 to 3.0.0
- [Changelog](https://github.com/sickill/rainbow/blob/master/Changelog.md)
- [Commits](https://github.com/sickill/rainbow/compare/v2.1.0...v3.0.0)