### PR TITLE
Only deploy from the Elasticsearch build job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,7 @@ deploy:
     secure: "WrQxf0fEKkCdXrjcejurobOnNNz3he4dDwjBbToXbQTQNDObPp7NetJrLsfM8FiUFEeOuvhIHHiDQtMvY720zGGAGxDptvgFS+0QHCUqoTRZA/yFfUmHlG2jROXTzk5uVK0AE4k6Ion5kX8+mM0EnMT/7u+MTFiukrJctSiEXfg="
   on:
     repo: Growstuff/growstuff
+    condition: "$RSPEC_TAG = elasticsearch"
   app:
     dev: growstuff-staging
     master: growstuff-prod


### PR DESCRIPTION
Fixes #1099, or at least works around it, though a better solution would be to rewrite our deployment system using Travis build stages or Heroku build pipelines.

This should reduce a lot of our problems with failed "dev" builds - currently, we're getting failures because two jobs try to deploy the same commit, and the second deployment is rejected.

The Elasticsearch job was picked because it's the one most likely to fail, and I can't work out how to deploy only if all three jobs pass.