### PR TITLE
Don't update flickr photos in migration

### DIFF
--- a/db/migrate/20180118112809_add_datetaken_to_photos.rb
+++ b/db/migrate/20180118112809_add_datetaken_to_photos.rb
@@ -1,20 +1,5 @@
 class AddDatetakenToPhotos < ActiveRecord::Migration
-  def up
+  def change
     add_column :photos, :date_taken, :datetime
-    update_flickr_metadata
-  end
-
-  def down
-    add_column :photos, :date_taken
-  end
-
-  private
-
-  def update_flickr_metadata
-    # Fetch from flickr, the photos updated the longest ago will be fetched first
-    Photo.all.order(:updated_at).each do |photo|
-      say "Fetch flickr data for #{photo}"
-      photo.set_flickr_metadata!
-    end
   end
 end


### PR DESCRIPTION
fix for #1581

We can run the update of photos.date_taken manually