### PR TITLE
Use photos helpers to find photos

### DIFF
--- a/app/helpers/photos_helper.rb
+++ b/app/helpers/photos_helper.rb
@@ -24,8 +24,10 @@ module PhotosHelper
   end
 
   def seed_image_path(seed)
-    if seed.default_photo
+    if seed.default_photo.present?
       seed.default_photo.thumbnail_url
+    elsif seed.crop.default_photo.present?
+      seed.crop.default_photo
     else
       default_image
     end

--- a/app/helpers/photos_helper.rb
+++ b/app/helpers/photos_helper.rb
@@ -3,7 +3,15 @@ module PhotosHelper
     if crop.default_photo.present?
       crop.default_photo.thumbnail_url
     else
-      default_image
+      placeholder_image
+    end
+  end
+
+  def garden_image_path(garden)
+    if garden.default_photo.present?
+      garden.default_photo.thumbnail_url
+    else
+      placeholder_image
     end
   end
 
@@ -11,15 +19,17 @@ module PhotosHelper
     if planting.photos.present?
       planting.photos.first.thumbnail_url
     else
-      default_image
+      placeholder_image
     end
   end
 
   def harvest_image_path(harvest)
     if harvest.photos.present?
       harvest.photos.first.thumbnail_url
+    elsif harvest.planting.present? && harvest.planting.photos.present?
+      harvest.planting.photos.first.thumbnail_url
     else
-      default_image
+      placeholder_image
     end
   end
 
@@ -27,15 +37,15 @@ module PhotosHelper
     if seed.default_photo.present?
       seed.default_photo.thumbnail_url
     elsif seed.crop.default_photo.present?
-      seed.crop.default_photo
+      seed.crop.default_photo.thumbnail_url
     else
-      default_image
+      placeholder_image
     end
   end
 
   private
 
-  def default_image
+  def placeholder_image
     'placeholder_150.png'
   end
 end

--- a/app/views/crops/_index_card.html.haml
+++ b/app/views/crops/_index_card.html.haml
@@ -1,7 +1,7 @@
 .well
   .row
     .col-md-4
-      = link_to image_tag((crop.default_photo ? crop.default_photo.thumbnail_url : 'placeholder_150.png'),
+      = link_to image_tag(crop_image_path(crop),
                           alt: '',
                           class: 'img crop-image'),
                           crop

--- a/app/views/crops/_thumbnail.html.haml
+++ b/app/views/crops/_thumbnail.html.haml
@@ -2,7 +2,7 @@
   .thumbnail
     .crop-thumbnail
       - if crop
-        = link_to image_tag((crop.default_photo ? crop.default_photo.thumbnail_url : 'placeholder_150.png'),
+        = link_to image_tag(crop_image_path(crop),
                             alt: crop.name, class: 'img'),
                             crop
         .cropinfo

--- a/app/views/gardens/_photo.html.haml
+++ b/app/views/gardens/_photo.html.haml
@@ -1,3 +1,3 @@
-= link_to image_tag((garden.default_photo ? garden.default_photo.thumbnail_url : 'placeholder_150.png'),
+= link_to image_tag(garden_image_path(garden),
                     alt: garden.name, class: 'img-responsive'),
           garden_path(garden)

--- a/app/views/gardens/_thumbnail.html.haml
+++ b/app/views/gardens/_thumbnail.html.haml
@@ -8,7 +8,7 @@
   .panel-body{ id: "gardens_panel_body" }
     .row
       .col-md-4
-        = link_to image_tag((garden.default_photo ? garden.default_photo.thumbnail_url : 'placeholder_150.png'),
+        = link_to image_tag(garden_image_path(garden),
                             alt: garden.name, class: 'img'),
                   garden_path(garden)
       .col-md-8

--- a/app/views/harvests/_card.html.haml
+++ b/app/views/harvests/_card.html.haml
@@ -8,7 +8,7 @@
   .panel-body
     .row
       .col-md-4
-        = link_to image_tag((harvest.default_photo ? harvest.default_photo.thumbnail_url : 'placeholder_150.png'),
+        = link_to image_tag(harvest_image_path(harvest),
                             alt: harvest.crop.name, class: 'img'),
                   harvest
       .col-md-8

--- a/app/views/harvests/_thumbnail.html.haml
+++ b/app/views/harvests/_thumbnail.html.haml
@@ -1,7 +1,7 @@
 .thumbnail
   .harvest-thumbnail
     - if harvest
-      = link_to image_tag((harvest.default_photo ? harvest.default_photo.thumbnail_url : 'placeholder_150.png'),
+      = link_to image_tag(harvest_image_path(harvest),
                           alt: harvest.crop.name, class: 'img'),
                           harvest
       .harvestinfo

--- a/app/views/plantings/_card.html.haml
+++ b/app/views/plantings/_card.html.haml
@@ -8,7 +8,7 @@
   .panel-body
     .row
       .col-xs-12.col-md-5
-        = link_to image_tag((planting.default_photo ? planting.default_photo.thumbnail_url : 'placeholder_150.png'),
+        = link_to image_tag(planting_image_path(planting),
                   alt: planting.crop_id, class: 'img img-responsive'),
                   planting
       .col-xs-12.col-md-7

--- a/app/views/plantings/_thumbnail.html.haml
+++ b/app/views/plantings/_thumbnail.html.haml
@@ -1,7 +1,7 @@
 .thumbnail
   .planting-thumbnail
     - if planting
-      = link_to image_tag((planting.default_photo ? planting.default_photo.thumbnail_url : 'placeholder_150.png'),
+      = link_to image_tag(planting_image_path(planting),
                           alt: planting.crop.name, class: 'img'),
                           planting
       .plantinginfo

--- a/app/views/seeds/_card.html.haml
+++ b/app/views/seeds/_card.html.haml
@@ -8,7 +8,7 @@
   .panel-body
     .row
       .col-md-4
-        = link_to image_tag((seed.crop.default_photo ? seed.crop.default_photo.thumbnail_url : 'placeholder_150.png'),
+        = link_to image_tag(seed_image_path(seed),
                             alt: seed.crop.name, class: 'img'),
                   seed.crop
       .col-md-8

--- a/app/views/seeds/_thumbnail.html.haml
+++ b/app/views/seeds/_thumbnail.html.haml
@@ -1,6 +1,6 @@
 .thumbnail
   .seed-thumbnail
-    = link_to image_tag((seed.default_photo ? seed.default_photo.thumbnail_url : 'placeholder_150.png'),
+    = link_to image_tag(seed_image_path(seed),
               alt: seed.crop.name, class: 'img'),
               seed_path(seed)
     .seedinfo

--- a/spec/helpers/photos_helper_spec.rb
+++ b/spec/helpers/photos_helper_spec.rb
@@ -2,14 +2,14 @@ require 'rails_helper'
 
 describe PhotosHelper do
   let(:crop) { FactoryBot.create :crop }
-  let(:crop_photo) { FactoryBot.create :photo, thumbnail_url: 'crop.jpg' }
+
   let(:garden) { FactoryBot.create :garden }
   let(:garden_photo) { FactoryBot.create(:photo, thumbnail_url: 'garden.jpg') }
-  let(:planting) { FactoryBot.create :planting }
+  let(:planting) { FactoryBot.create :planting, crop: crop }
   let(:planting_photo) { FactoryBot.create(:photo, thumbnail_url: 'planting.jpg') }
-  let(:harvest) { FactoryBot.create :harvest }
+  let(:harvest) { FactoryBot.create :harvest, crop: crop }
   let(:harvest_photo) { FactoryBot.create(:photo, thumbnail_url: 'harvest.jpg') }
-  let(:seed) { FactoryBot.create :seed }
+  let(:seed) { FactoryBot.create :seed, crop: crop }
   let(:seed_photo) { FactoryBot.create(:photo, thumbnail_url: 'seed.jpg') }
 
   describe "crops" do
@@ -18,30 +18,21 @@ describe PhotosHelper do
     it { is_expected.to eq 'placeholder_150.png' }
 
     describe "with a planting" do
-      before do
-        planting.photos << planting_photo
-        crop.plantings << planting
-      end
+      before { planting.photos << planting_photo }
       it "uses planting photos" do
         is_expected.to eq planting_photo.thumbnail_url
       end
     end
 
     describe "with a harvest photos" do
-      before do
-        harvest.photos << harvest_photo
-        crop.harvests << harvest
-      end
+      before { harvest.photos << harvest_photo }
       it "uses harvest photos" do
         is_expected.to eq harvest_photo.thumbnail_url
       end
     end
 
     describe "uses seed photo" do
-      before do
-        seed.photos << seed_photo
-        crop.seeds << seed
-      end
+      before { seed.photos << seed_photo }
       it "uses seed photos" do
         is_expected.to eq seed_photo.thumbnail_url
       end

--- a/spec/helpers/photos_helper_spec.rb
+++ b/spec/helpers/photos_helper_spec.rb
@@ -1,0 +1,88 @@
+require 'rails_helper'
+
+describe PhotosHelper do
+  let(:crop) { FactoryBot.create :crop }
+  let(:crop_photo) { FactoryBot.create :photo, thumbnail_url: 'crop.jpg' }
+  let(:garden) { FactoryBot.create :garden }
+  let(:garden_photo) { FactoryBot.create(:photo, thumbnail_url: 'garden.jpg') }
+  let(:planting) { FactoryBot.create :planting }
+  let(:planting_photo) { FactoryBot.create(:photo, thumbnail_url: 'planting.jpg') }
+  let(:harvest) { FactoryBot.create :harvest }
+  let(:harvest_photo) { FactoryBot.create(:photo, thumbnail_url: 'harvest.jpg') }
+  let(:seed) { FactoryBot.create :seed }
+  let(:seed_photo) { FactoryBot.create(:photo, thumbnail_url: 'seed.jpg') }
+
+  describe "crops" do
+    subject { crop_image_path(crop) }
+
+    it { is_expected.to eq 'placeholder_150.png' }
+
+    describe "with a planting" do
+      before do
+        planting.photos << planting_photo
+        crop.plantings << planting
+      end
+      it "uses planting photos" do
+        is_expected.to eq planting_photo.thumbnail_url
+      end
+    end
+
+    describe "with a harvest photos" do
+      before do
+        harvest.photos << harvest_photo
+        crop.harvests << harvest
+      end
+      it "uses harvest photos" do
+        is_expected.to eq harvest_photo.thumbnail_url
+      end
+    end
+
+    describe "uses seed photo" do
+      before do
+        seed.photos << seed_photo
+        crop.seeds << seed
+      end
+      it "uses seed photos" do
+        is_expected.to eq seed_photo.thumbnail_url
+      end
+    end
+  end
+
+  describe "gardens" do
+    subject { garden_image_path(garden) }
+    it { is_expected.to eq 'placeholder_150.png' }
+
+    describe "uses garden's own photo" do
+      before { garden.photos << garden_photo }
+      it { is_expected.to eq garden_photo.thumbnail_url }
+    end
+  end
+
+  describe 'plantings' do
+    subject { planting_image_path(planting) }
+    it { is_expected.to eq 'placeholder_150.png' }
+    describe "uses planting's own photo" do
+      before { planting.photos << planting_photo }
+      it { is_expected.to eq planting_photo.thumbnail_url }
+    end
+  end
+
+  describe 'harvests' do
+    subject { harvest_image_path(harvest) }
+    it { is_expected.to eq 'placeholder_150.png' }
+    describe "uses harvest's own photo" do
+      before { harvest.photos << harvest_photo }
+      it { is_expected.to eq harvest_photo.thumbnail_url }
+    end
+  end
+
+  describe 'seeds' do
+    subject { seed_image_path(seed) }
+    it { is_expected.to eq 'placeholder_150.png' }
+
+    describe "uses seed's own photo" do
+      before { seed.photos << seed_photo }
+      it { is_expected.to eq seed_photo.thumbnail_url }
+    end
+  end
+end


### PR DESCRIPTION
Moved photo image selection all into one file. Removes a lot of repeating code and then let me tidy up photo selection.
The photo for seeds was different on the #show and #index and home page. This makes it always the same. 
Also tidied up crop photo selection to look on planting, harvests, and then seeds. 
Added unit tests of the helpers. 
