### PR TITLE
Fix various wrapping issues

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -83,7 +83,7 @@ submit the change with your pull request.
 - Jeff Kingswood / [ancyentmariner](https://github.com/ancyentmariner)
 - Logan Gingerich / [logangingerich](https://github.com/logangingerich)
 - Mark Taffman / [mftaff](https://github.com/mftaff)
-- Jennifer Kruse / [mftaff](https://github.com/mftaff)
+- Jennifer Kruse / [jenkr55](https://github.com/jenkr55)
 
 ## Bots
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -83,6 +83,7 @@ submit the change with your pull request.
 - Jeff Kingswood / [ancyentmariner](https://github.com/ancyentmariner)
 - Logan Gingerich / [logangingerich](https://github.com/logangingerich)
 - Mark Taffman / [mftaff](https://github.com/mftaff)
+- Jennifer Kruse / [mftaff](https://github.com/mftaff)
 
 ## Bots
 

--- a/app/assets/stylesheets/overrides.sass
+++ b/app/assets/stylesheets/overrides.sass
@@ -73,10 +73,16 @@ p.stats
   display: flex
   flex: none
   flex-wrap: wrap
-  justify-content: space-between
+
+.seeds-row
+  display: grid
+  grid-template-columns: 50% 50%
+  grid-gap: 25px
+  grid-row-gap: 5px
 
 .member-thumbnail
   padding: .25em
+  margin: 1em
 
   div
     width: 5em

--- a/app/views/seeds/index.html.haml
+++ b/app/views/seeds/index.html.haml
@@ -24,10 +24,10 @@
   = page_entries_info @seeds
   = will_paginate @seeds
 
-.row
+.seeds-row
   - unless @seeds.empty?
     - @seeds.each do |seed|
-      .col-md-6
+      .seedcard
         = render 'seeds/card', seed: seed
 
 .pagination


### PR DESCRIPTION
Fixes weird wrapping on `/seeds` and `/members`. I didn't see the issue on the homepage or `/gardens#index`

https://github.com/Growstuff/growstuff/issues/1459