### PR TITLE
Show second comment button when many comments on a post

### DIFF
--- a/app/assets/stylesheets/overrides.sass
+++ b/app/assets/stylesheets/overrides.sass
@@ -193,6 +193,9 @@ li.crop-hierarchy
 .navbar-bottom
   margin: 40px 0px 0px 0px !important
 
+.post-actions
+  margin-bottom: 1rem
+  
 // footer
 footer
   #footer1, #footer2, #footer3

--- a/app/assets/stylesheets/overrides.sass
+++ b/app/assets/stylesheets/overrides.sass
@@ -201,7 +201,7 @@ li.crop-hierarchy
 
 .post-actions
   margin-bottom: 1rem
-  
+
 // footer
 footer
   #footer1, #footer2, #footer3

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -29,17 +29,19 @@
     .col-md-2
       = render partial: 'crops/thumbnail', locals: { crop: c }
 
-.col-md-11.post-actions
+.col-md-11
   - if can?(:edit, @post) || can?(:destroy, @post)
-    - if can? :edit, @post
-      = link_to 'Edit Post', edit_post_path(@post), class: 'btn btn-default btn-xs'
-    - if can? :destroy, @post
-      = link_to 'Delete Post', @post, method: :delete,
-                    data: { confirm: 'Are you sure?' },
-                    class: 'btn btn-default btn-xs'
+    .post-actions
+      - if can? :edit, @post
+        = link_to 'Edit Post', edit_post_path(@post), class: 'btn btn-default btn-xs'
+      - if can? :destroy, @post
+        = link_to 'Delete Post', @post, method: :delete,
+                      data: { confirm: 'Are you sure?' },
+                      class: 'btn btn-default btn-xs'
+
   - if @post.comments.count > 10 && can?(:create, Comment)
-    = link_to 'Comment', new_comment_path(post_id: @post.id),
-                class: 'btn btn-default btn-xs'
+    .post-actions
+      = link_to 'Comment', new_comment_path(post_id: @post.id), class: 'btn btn-primary'
 
   = render partial: "comments", locals: { post: @post }
 

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -29,15 +29,17 @@
     .col-md-2
       = render partial: 'crops/thumbnail', locals: { crop: c }
 
-.col-md-11
+.col-md-11.post-actions
   - if can?(:edit, @post) || can?(:destroy, @post)
-    .post-actions
-      - if can? :edit, @post
-        = link_to 'Edit Post', edit_post_path(@post), class: 'btn btn-default btn-xs'
-      - if can? :destroy, @post
-        = link_to 'Delete Post', @post, method: :delete,
-                  data: { confirm: 'Are you sure?' },
-                  class: 'btn btn-default btn-xs'
+    - if can? :edit, @post
+      = link_to 'Edit Post', edit_post_path(@post), class: 'btn btn-default btn-xs'
+    - if can? :destroy, @post
+      = link_to 'Delete Post', @post, method: :delete,
+                    data: { confirm: 'Are you sure?' },
+                    class: 'btn btn-default btn-xs'
+  - if @post.comments.count > 10 && can?(:create, Comment)
+    = link_to 'Comment', new_comment_path(post_id: @post.id),
+                class: 'btn btn-default btn-xs'
 
   = render partial: "comments", locals: { post: @post }
 


### PR DESCRIPTION
Fixes https://github.com/Growstuff/growstuff/issues/869

Added second Comment button and made it look like the other buttons in this area.

<img width="267" alt="screen shot 2018-04-18 at 7 39 04 pm" src="https://user-images.githubusercontent.com/8432175/38965090-2ee65e9c-4340-11e8-89d2-d633f2d141a0.png">
<img width="401" alt="screen shot 2018-04-18 at 6 01 11 pm" src="https://user-images.githubusercontent.com/8432175/38965091-322a2188-4340-11e8-8ba0-255998b4703c.png">


Made this happen when there are more than 10 comments but open to suggestions!