### PR TITLE
Profile garden display improvements

### DIFF
--- a/app/assets/stylesheets/overrides.sass
+++ b/app/assets/stylesheets/overrides.sass
@@ -38,19 +38,20 @@ h3
   max-width: 100%
   height: auto
 
-.profile-img
-  border-radius: 50%
-  z-index: 2
-  position: relative
-  width: 80%
-
 .profile-sidebar
   margin-top: -5rem
+  .avatar
+    border-radius: 50%
+    border-radius: 50%
+    z-index: 2
+    position: relative
 
 .profile-activity
   background: white
   padding: 2em
   margin-top: 2em
+  .container
+    width: 100%
 
 .sidebar
   border-left: 1px solid darken($beige, 10%)
@@ -95,12 +96,6 @@ p.stats
 .card-row
   display: grid
   grid-template-columns: 50% 50%
-  grid-gap: 25px
-  grid-row-gap: 5px
-
-.card-row-short
-  display: grid
-  grid-template-columns: 47.5% 47.5%
   grid-gap: 25px
   grid-row-gap: 5px
 

--- a/app/assets/stylesheets/overrides.sass
+++ b/app/assets/stylesheets/overrides.sass
@@ -12,6 +12,10 @@ body
 .list-inline > li.first
   padding-left: 0px
 
+.activity-list
+  list-style-type: none
+  padding: 0
+
 h2
   font-size: 150%
 
@@ -33,6 +37,20 @@ h3
 .img-responsive
   max-width: 100%
   height: auto
+
+.profile-img
+  border-radius: 50%
+  z-index: 2
+  position: relative
+  width: 80%
+
+.profile-sidebar
+  margin-top: -5rem
+
+.profile-activity
+  background: white
+  padding: 2em
+  margin-top: 2em
 
 .sidebar
   border-left: 1px solid darken($beige, 10%)
@@ -80,6 +98,12 @@ p.stats
   grid-gap: 25px
   grid-row-gap: 5px
 
+.card-row-short
+  display: grid
+  grid-template-columns: 47.5% 47.5%
+  grid-gap: 25px
+  grid-row-gap: 5px
+
 .member-thumbnail
   padding: .25em
   margin: 1em
@@ -108,6 +132,7 @@ p.stats
 
 #membermap
   height: 250px
+  z-index: 0
 
 .location-not-set
   height: 250px

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -20,6 +20,7 @@ class MembersController < ApplicationController
     @facebook_auth = @member.auth('facebook')
     @posts         = @member.posts
     @gardens       = @member.gardens.active.order(:name)
+    @harvests      = @member.harvests
 
     # The garden form partial is called from the "New Garden" tab;
     # it requires a garden to be passed in @garden.

--- a/app/views/harvests/_card.html.haml
+++ b/app/views/harvests/_card.html.haml
@@ -22,7 +22,7 @@
           %dt Harvest date :
           %dd= harvest.harvested_at
           %dt Notes:
-          %dd=display_harvest_description(harvest)
+          %dd= display_harvest_description(harvest)
           - if harvest.planting.present?
             %dt Harvested from
             %dd= link_to(harvest.planting, planting_path(harvest.planting))

--- a/app/views/harvests/_card.html.haml
+++ b/app/views/harvests/_card.html.haml
@@ -21,8 +21,8 @@
           %dd= display_quantity(harvest)
           %dt Harvest date :
           %dd= harvest.harvested_at
-          %dd Notes:
-          %dt=display_harvest_description(harvest)
+          %dt Notes:
+          %dd=display_harvest_description(harvest)
           - if harvest.planting.present?
             %dt Harvested from
             %dd= link_to(harvest.planting, planting_path(harvest.planting))

--- a/app/views/members/_avatar.html.haml
+++ b/app/views/members/_avatar.html.haml
@@ -1,5 +1,5 @@
 - if member
   = link_to image_tag(avatar_uri(member, 150),
             alt: '',
-            class: 'img img-responsive avatar'),
+            class: 'img img-responsive avatar profile-img'),
     member_path(member)

--- a/app/views/members/_avatar.html.haml
+++ b/app/views/members/_avatar.html.haml
@@ -1,5 +1,5 @@
 - if member
   = link_to image_tag(avatar_uri(member, 150),
             alt: '',
-            class: 'img img-responsive avatar profile-img'),
+            class: 'img img-responsive avatar'),
     member_path(member)

--- a/app/views/members/_gardens.html.haml
+++ b/app/views/members/_gardens.html.haml
@@ -44,7 +44,7 @@
                   = link_to "Add photo", new_photo_path(type: "garden", id: g.id), class: 'btn btn-primary'
 
           %h3 What's planted here?
-          .card-row-short
+          .card-row
             - unless g.featured_plantings.empty?
               - g.featured_plantings.each.with_index do |planting|
                 .card

--- a/app/views/members/_gardens.html.haml
+++ b/app/views/members/_gardens.html.haml
@@ -1,4 +1,3 @@
-%h2 #{member.login_name}'s gardens
 .tabbable
   %ul.nav.nav-tabs
     - first_garden = true
@@ -45,10 +44,10 @@
                   = link_to "Add photo", new_photo_path(type: "garden", id: g.id), class: 'btn btn-primary'
 
           %h3 What's planted here?
-          .row
+          .card-row-short
             - unless g.featured_plantings.empty?
               - g.featured_plantings.each.with_index do |planting|
-                .col-xs-12.col-lg-6
+                .card
                   = render partial: "plantings/card", locals: { planting: planting }
 
           %p

--- a/app/views/members/_harvests.html.haml
+++ b/app/views/members/_harvests.html.haml
@@ -2,3 +2,5 @@
   - harvests.each do |harvest|
     .card
       = render partial: "harvests/card", locals: { harvest: harvest }
+- if !harvests.any?
+  #{member.login_name} hasn't harvested anything yet.

--- a/app/views/members/_harvests.html.haml
+++ b/app/views/members/_harvests.html.haml
@@ -1,0 +1,4 @@
+.card-row-short
+  - harvests.each do |harvest|
+    .card
+      = render partial: "harvests/card", locals: { harvest: harvest }

--- a/app/views/members/_map.html.haml
+++ b/app/views/members/_map.html.haml
@@ -1,6 +1,6 @@
 - if member.latitude && member.longitude
   #membermap
-  %p
+  %p.pull-right
     See other members, plantings, seeds and more near
     = link_to member.location, place_path(member.location, anchor: "members")
 - else

--- a/app/views/members/_stats.html.haml
+++ b/app/views/members/_stats.html.haml
@@ -7,7 +7,7 @@
 
 %h3 Activity
 
-%ul.list-inline
+%ul.activity-list
   %li
     - if !member.plantings.empty?
       = link_to localize_plural(member.plantings, Planting), plantings_by_owner_path(owner: member)

--- a/app/views/members/show.html.haml
+++ b/app/views/members/show.html.haml
@@ -27,10 +27,10 @@
 
   .col-md-9
     = render partial: "map", locals: { member: @member }
-    = render partial: "bio", locals: { member: @member }
     = render partial: "gardens", locals: { member: @member, gardens: @gardens }
   .col-md-3
     = render partial: "avatar", locals: { member: @member }
+    = render partial: "bio", locals: { member: @member }
     = render partial: "roles", locals: { member: @member }
     = render partial: "stats", locals: { member: @member }
     = render partial: "contact", locals: { member: @member,

--- a/app/views/members/show.html.haml
+++ b/app/views/members/show.html.haml
@@ -9,7 +9,7 @@
   = tag("meta", property: "og:site_name", content: ENV['GROWSTUFF_SITE_NAME'])
 - content_for :buttonbar do
   - if can? :update, @member
-    = link_to 'Edit profile', edit_member_registration_path, class: 'btn btn-default'
+    = link_to 'Edit profile', edit_member_registration_path, class: 'btn btn-default pull-right'
   - if can?(:create, Notification) && current_member != @member
     = link_to 'Send message', new_notification_path(recipient_id: @member.id), class: 'btn btn-default'
 
@@ -24,11 +24,8 @@
 - content_for :member_rss_slug, @member.slug
 
 .row
-
-  .col-md-9
-    = render partial: "map", locals: { member: @member }
-    = render partial: "gardens", locals: { member: @member, gardens: @gardens }
-  .col-md-3
+  = render partial: "map", locals: { member: @member }
+  .col-md-2.profile-sidebar
     = render partial: "avatar", locals: { member: @member }
     = render partial: "bio", locals: { member: @member }
     = render partial: "roles", locals: { member: @member }
@@ -37,3 +34,16 @@
                                           twitter_auth: @twitter_auth,
                                           flickr_auth: @flickr_auth,
                                           facebook_auth: @facebook_auth }
+
+  .col-md-10
+    %ul.nav.nav-pills.nav-justified
+      %li.active
+        %a{"data-toggle" => "tab", href: "#gardens"} Gardens
+      %li
+        %a{"data-toggle" => "tab", href: "#harvests"} Harvests
+    / Tab panes
+    .tab-content.profile-activity
+      #gardens.tab-pane.active
+        = render partial: "gardens", locals: { member: @member, gardens: @gardens }
+      #harvests.tab-pane
+        = render partial: "harvests", locals: { member: @member, harvests: @harvests }

--- a/app/views/members/show.html.haml
+++ b/app/views/members/show.html.haml
@@ -38,11 +38,11 @@
   .col-md-10
     %ul.nav.nav-pills.nav-justified
       %li.active
-        %a{"data-toggle" => "tab", href: "#gardens"} Gardens
+        %a{ "data-toggle" => "tab", href: "#gardens" } Gardens
       %li
-        %a{"data-toggle" => "tab", href: "#harvests"} Harvests
+        %a{ "data-toggle" => "tab", href: "#harvests" } Harvests
     .tab-content.profile-activity
-      #gardens.tab-pane.active
+      .tab-pane.active#gardens
         = render partial: "gardens", locals: { member: @member, gardens: @gardens }
-      #harvests.tab-pane
+      .tab-pane#harvests
         = render partial: "harvests", locals: { member: @member, harvests: @harvests }

--- a/app/views/members/show.html.haml
+++ b/app/views/members/show.html.haml
@@ -11,14 +11,14 @@
   - if can? :update, @member
     = link_to 'Edit profile', edit_member_registration_path, class: 'btn btn-default pull-right'
   - if can?(:create, Notification) && current_member != @member
-    = link_to 'Send message', new_notification_path(recipient_id: @member.id), class: 'btn btn-default'
+    = link_to 'Send message', new_notification_path(recipient_id: @member.id), class: 'btn btn-default pull-right'
 
   - if current_member && current_member != @member # must be logged in, can't follow yourself
     - follow = current_member.get_follow(@member)
     - if !follow && can?(:create, Follow) # not already following
-      = link_to 'Follow', follows_path(followed_id: @member.id), method: :post, class: 'btn btn-default'
+      = link_to 'Follow', follows_path(followed_id: @member.id), method: :post, class: 'btn btn-default pull-right'
     - if follow && can?(:destroy, follow) # already following
-      = link_to 'Unfollow', follow_path(follow), method: :delete, class: 'btn btn-default'
+      = link_to 'Unfollow', follow_path(follow), method: :delete, class: 'btn btn-default pull-right'
 
 - content_for :member_rss_login_name, @member.login_name
 - content_for :member_rss_slug, @member.slug
@@ -41,7 +41,6 @@
         %a{"data-toggle" => "tab", href: "#gardens"} Gardens
       %li
         %a{"data-toggle" => "tab", href: "#harvests"} Harvests
-    / Tab panes
     .tab-content.profile-activity
       #gardens.tab-pane.active
         = render partial: "gardens", locals: { member: @member, gardens: @gardens }

--- a/spec/features/member_profile_spec.rb
+++ b/spec/features/member_profile_spec.rb
@@ -9,7 +9,6 @@ feature "member profile", js: true do
       expect(page).to have_css("h1", text: member.login_name)
       expect(page).to have_content member.bio
       expect(page).to have_content "Member since: #{member.created_at.to_s(:date)}"
-      expect(page).to have_content "#{member.login_name}'s gardens"
       expect(page).to have_link "More about this garden...", href: garden_path(member.gardens.first)
     end
 


### PR DESCRIPTION
Improves this issue and adds harvests to profiles: https://github.com/Growstuff/growstuff/issues/516

I went ahead and refreshed the profile page on this one to make it look more modern and less messy. I'm definitely open to any suggestions, and also ok with reverting it back to something similar to the current profile page and just improving gardens!

## **Before:** 
<img width="1278" alt="screen shot 2018-04-21 at 7 58 09 pm" src="https://user-images.githubusercontent.com/8432175/39090778-57a1e922-45ad-11e8-8d70-c161c7426e1c.png">

## **After:** 
<img width="1280" alt="screen shot 2018-04-21 at 9 24 59 pm" src="https://user-images.githubusercontent.com/8432175/39090780-5f6fe5fa-45ad-11e8-85f2-12795460077d.png">

There was also a style bug on the harvests card with the notes field that I fixed.
Before:
<img width="610" alt="screen shot 2018-04-21 at 9 26 44 pm" src="https://user-images.githubusercontent.com/8432175/39090787-84a0c01a-45ad-11e8-85a6-4aaead86ff8f.png">
After:
<img width="607" alt="screen shot 2018-04-21 at 9 27 09 pm" src="https://user-images.githubusercontent.com/8432175/39090789-88ca026e-45ad-11e8-9eac-c4a97a79b780.png">
