### PR TITLE
Issue 565 create harvests RSS

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -84,6 +84,7 @@ submit the change with your pull request.
 - Logan Gingerich / [logangingerich](https://github.com/logangingerich)
 - Mark Taffman / [mftaff](https://github.com/mftaff)
 - Jennifer Kruse / [jenkr55](https://github.com/jenkr55)
+- Christopher Bazin / [RobotScissors](https://github.com/robotscissors)
 
 ## Bots
 

--- a/app/controllers/harvests_controller.rb
+++ b/app/controllers/harvests_controller.rb
@@ -3,7 +3,7 @@ class HarvestsController < ApplicationController
   after_action :update_crop_medians, only: %i(create update destroy)
   load_and_authorize_resource
   respond_to :html, :json
-  respond_to :csv, only: :index
+  respond_to :csv, :rss, only: :index
   responders :flash
 
   def index

--- a/app/views/harvests/index.html.haml
+++ b/app/views/harvests/index.html.haml
@@ -24,8 +24,10 @@
   %ul.list-inline
     %li The data on this page is available in the following formats:
     - if @owner
+      %li= link_to "RSS", harvests_by_owner_path(@owner, format: 'rss')
       %li= link_to "CSV", harvests_by_owner_path(@owner, format: 'csv')
       %li= link_to "JSON", harvests_by_owner_path(@owner, format: 'json')
     - else
+      %li= link_to "RSS", harvests_path(format: 'rss')
       %li= link_to "CSV", harvests_path(format: 'csv')
       %li= link_to "JSON", harvests_path(format: 'json')

--- a/app/views/harvests/index.rss.haml
+++ b/app/views/harvests/index.rss.haml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+%rss{ version: 2.0 }
+  %channel
+    %title
+      Recent harvests from #{@owner ? @owner : 'all members'} (#{ENV['GROWSTUFF_SITE_NAME']})
+    %link= harvests_url
+    - @harvests.each do |harvest|
+      %item
+        %title #{harvest.owner.login_name}'s #{harvest.crop.name}
+        %pubdate= harvest.harvested_at.to_s(:rfc822)
+        %description
+          :escaped
+            <p>Crop: #{harvest.crop ? harvest.crop : 'unknown' }</p>
+            <p>Quantity: #{harvest.quantity ? harvest.quantity : 'unknown' }</p>
+            <p>Harvested on: #{harvest.harvested_at ? harvest.harvested_at : 'unknown' }</p>
+          :escaped_markdown
+            #{ strip_tags harvest.description }
+        %link= harvest_url(harvest)
+        %guid= harvest_url(harvest)

--- a/spec/views/harvests/index.rss.haml_spec.rb
+++ b/spec/views/harvests/index.rss.haml_spec.rb
@@ -33,10 +33,10 @@ describe 'harvests/index.rss.haml' do
   it "displays crop's name in title" do
     assign(:crop, @tomato)
     render
-    rendered.should have_content "#{@tomato.name.to_s}"
+    expect(rendered).to have_content @tomato.name
   end
 
   it 'shows formatted content of harvest posts' do
-    rendered.should have_content "<p>Quantity: "
+    expect(rendered).to have_content "<p>Quantity: "
   end
 end

--- a/spec/views/harvests/index.rss.haml_spec.rb
+++ b/spec/views/harvests/index.rss.haml_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+describe 'harvests/index.rss.haml' do
+  before(:each) do
+    controller.stub(:current_user) { nil }
+    @member = FactoryBot.create(:member)
+    @tomato = FactoryBot.create(:tomato)
+    @maize  = FactoryBot.create(:maize)
+    @pp = FactoryBot.create(:plant_part)
+    assign(:harvests, harvests)
+    render
+  end
+
+  context 'all harvests' do
+    before(:each) do
+      #assign(:harvest, FactoryBot.create(:harvest))
+      render
+    end
+
+    it 'shows RSS feed title' do
+      rendered.should have_content "Recent harvests from all members"
+    end
+
+    it 'item title shows owner and crop' do
+      rendered.should have_content "#{@harvest.crop}"
+    end
+
+    # it 'shows formatted content of posts' do
+    #   rendered.should have_content "This is a <em>really</em> good plant."
+    # end
+    #
+    # it 'shows sunniness' do
+    #   rendered.should have_content 'Sunniness: sun'
+    # end
+    #
+    # it 'shows propagation method' do
+    #   rendered.should have_content 'Planted from: seedling'
+    # end
+  end
+
+  # context "one person's plantings" do
+  #   before :each do
+  #     @planting = FactoryBot.create(:planting)
+  #     assign(:plantings, [@planting])
+  #     assign(:owner, @planting.owner)
+  #     render
+  #   end
+  #
+  #   it 'shows title for single member' do
+  #     rendered.should have_content "Recent plantings from #{@planting.owner}"
+  #   end
+  # end
+end

--- a/spec/views/harvests/index.rss.haml_spec.rb
+++ b/spec/views/harvests/index.rss.haml_spec.rb
@@ -33,7 +33,7 @@ describe 'harvests/index.rss.haml' do
   it "displays crop's name in title" do
     assign(:crop, @tomato)
     render
-    rendered.should have_content "#{@tomato.name}"
+    rendered.should have_content "#{@tomato.name.to_s}"
   end
 
   it 'shows formatted content of harvest posts' do

--- a/spec/views/harvests/index.rss.haml_spec.rb
+++ b/spec/views/harvests/index.rss.haml_spec.rb
@@ -7,47 +7,36 @@ describe 'harvests/index.rss.haml' do
     @tomato = FactoryBot.create(:tomato)
     @maize  = FactoryBot.create(:maize)
     @pp = FactoryBot.create(:plant_part)
+    page = 1
+    per_page = 2
+    total_entries = 2
+    harvests = WillPaginate::Collection.create(page, per_page, total_entries) do |pager|
+      pager.replace([
+                      FactoryBot.create(:harvest,
+                        crop: @tomato,
+                        owner: @member),
+                      FactoryBot.create(:harvest,
+                        crop: @maize,
+                        plant_part: @pp,
+                        owner: @member,
+                        quantity: 2)
+                    ])
+    end
     assign(:harvests, harvests)
     render
   end
 
-  context 'all harvests' do
-    before(:each) do
-      #assign(:harvest, FactoryBot.create(:harvest))
-      render
-    end
-
-    it 'shows RSS feed title' do
-      rendered.should have_content "Recent harvests from all members"
-    end
-
-    it 'item title shows owner and crop' do
-      rendered.should have_content "#{@harvest.crop}"
-    end
-
-    # it 'shows formatted content of posts' do
-    #   rendered.should have_content "This is a <em>really</em> good plant."
-    # end
-    #
-    # it 'shows sunniness' do
-    #   rendered.should have_content 'Sunniness: sun'
-    # end
-    #
-    # it 'shows propagation method' do
-    #   rendered.should have_content 'Planted from: seedling'
-    # end
+  it 'shows RSS feed title' do
+    rendered.should have_content "Recent harvests from all members"
   end
 
-  # context "one person's plantings" do
-  #   before :each do
-  #     @planting = FactoryBot.create(:planting)
-  #     assign(:plantings, [@planting])
-  #     assign(:owner, @planting.owner)
-  #     render
-  #   end
-  #
-  #   it 'shows title for single member' do
-  #     rendered.should have_content "Recent plantings from #{@planting.owner}"
-  #   end
-  # end
+  it "displays crop's name in title" do
+    assign(:crop, @tomato)
+    render
+    rendered.should have_content "#{@tomato.name}"
+  end
+
+  it 'shows formatted content of harvest posts' do
+    rendered.should have_content "<p>Quantity: "
+  end
 end


### PR DESCRIPTION
This should solve issue #565.

Your feedback is welcome. 

Files modified:
* __harvests_controller__ - so the controller can respond to rss requests.
* __view/harvests/index.html.haml__ - modified the links on this index page to access the RSS feeds (both for an individual owner or all members.
* __view/harvests/index.rss.haml__ - created this file to handle the RSS feed requests. I based it on the previous RSS feeds for plantings and seedings but changed it based on the db table harvests.
* __spec/views/harvests/index.rss.haml_spec.rb__ - created an rspec file to assist in testing which was based on the plantings rspec file.

I tested it on a browser feed-burner, and I did struggle with the tests. I know how important they are. 