### PR TITLE
hides crop varieties that have not been approved

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -86,6 +86,7 @@ submit the change with your pull request.
 - Jennifer Kruse / [jenkr55](https://github.com/jenkr55)
 - Christopher Bazin / [RobotScissors](https://github.com/robotscissors)
 - Ahmed Shahin / [codeminator](https://www.github.com/codeminator)
+- Brandon Baker / [brandonbaker40](https://github.com/brandonbaker40)
 
 ## Bots
 

--- a/app/views/crops/_hierarchy.html.haml
+++ b/app/views/crops/_hierarchy.html.haml
@@ -3,7 +3,7 @@
   - unless defined? max
     - max = 0 # list all without "show all" toggle button
   - display_crops.each do |c|
-    %li.crop-hierarchy{ class: max != 0 && @count >= max ? ['hide', 'toggle'] : [] }
+    %li.crop-hierarchy{ class: (max != 0 && @count >= max) || !c.approved? ? ['hide', 'toggle'] : [] }
       = link_to c, c
       - @count += 1
       - if c.varieties.present?


### PR DESCRIPTION
Hides the crop varieties that have not been approved. Issue #1631

- prevents the list item from displaying in the crop-hierarchy if the crop has not been approved
- adds the 'hide' class if the crop has not been approved

/cc @Br3nda 
