### PR TITLE
Upgrade heroku stack

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,0 +1,51 @@
+{
+  "name": "growstuff",
+  "stack": "heroku-18",
+  "description": "Open data project for small-scale food growers",
+  "scripts": {
+    "postdeploy": "bundle exec rails db:migrate db:seed"
+  },
+  "env": {
+    "GROWSTUFF_ELASTICSEARCH": {
+      "required": true
+    },
+    "GROWSTUFF_FACEBOOK_KEY": {
+      "required": true
+    },
+    "GROWSTUFF_FACEBOOK_SECRET": {
+      "required": true
+    },
+    "GROWSTUFF_FLICKR_KEY": {
+      "required": true
+    },
+    "GROWSTUFF_FLICKR_SECRET": {
+      "required": true
+    },
+    "GROWSTUFF_SITE_NAME": {
+      "required": true
+    },
+    "GROWSTUFF_EMAIL": {
+      "required": true
+    },
+    "MAIL_SENDER_HOST": {
+      "required": true
+    }
+  },
+  "formation": {
+    "web": {
+      "quantity": 1
+    }
+  },
+  "addons": [
+    "heroku-postgresql",
+    "bonsai-elasticsearch",
+    "memcachier",
+    "newrelic",
+    "sparkhost"
+  ],
+  "buildpacks": [
+    {
+      "url": "heroku/ruby"
+    }
+  ]
+}


### PR DESCRIPTION
Based on @eoinkelly's work in https://github.com/ODNZSL/nzsl-online/pull/480

The version of the heroku stack is old on both staging and prod. Prod uses cedar-14 and staging uses heroku-16

by moving this into heroku's `app.json` file, we will be able to both upgrade it from a PR, and also keep staging and prod in sync.

This also adds enough info for someone else to quickly deploy their own version of growstuff.org on heroku if they want to.
