### PR TITLE
Fix modified schema deploy error

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180401220637) do
+ActiveRecord::Schema.define(version: 2018_04_01_220637) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Travis isn't deploying to staging - instead, it has an error about the schema file changing.

The error Travis-CI during deploy is:
```
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)
	modified:   db/schema.rb
```

I've re-run migrate, and the schema version format has changed in Rails 5.2. Here's the modified file needed.

