### PR TITLE
Auto corrected by following Lint Ruby EmptyLine

### DIFF
--- a/spec/controllers/api/v1/plantings_controller_spec.rb
+++ b/spec/controllers/api/v1/plantings_controller_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe Api::V1::PlantingsController, type: :controller do
   end
   let!(:member) { FactoryBot.create :member }
 
-
   describe '#index' do
     let(:matching_planting) { subject['data'].select { |planting| planting['id'] == my_planting.id.to_s }.first }
 


### PR DESCRIPTION
Auto corrected by following Lint Ruby EmptyLine

Click [here](https://awesomecode.io/repos/Growstuff/growstuff/ruby_config_groups/527) to configure it on awesomecode.io