### PR TITLE
Auto corrected by following Lint Ruby EmptyLine

### DIFF
--- a/spec/controllers/crops_controller_spec.rb
+++ b/spec/controllers/crops_controller_spec.rb
@@ -61,7 +61,6 @@ describe CropsController do
     subject { delete :destroy, params: { slug: crop.to_param } }
     let!(:crop) { FactoryBot.create :crop }
 
-
     context 'not logged in' do
       it { expect { subject }.not_to change(Crop, :count) }
     end


### PR DESCRIPTION
Auto corrected by following Lint Ruby EmptyLine

Click [here](https://awesomecode.io/repos/Growstuff/growstuff/ruby_config_groups/881) to configure it on awesomecode.io