### PR TITLE
Remove waffle link, replace with github projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ You might like to check out:
 
 Here on Github, you might find these useful:
 
-* [Waffle](http://waffle.io/Growstuff/growstuff) has stories in "ready" that can be worked on.
+* [Github Project Board](https://github.com/orgs/Growstuff/projects/1) has stories in "ready" that can be worked on.
 * [needs: design](https://github.com/Growstuff/growstuff/labels/needs:%20design) - tasks requiring high-level design
-* [needs: visual design](https://github.com/Growstuff/growstuff/labels/needs:%20visual design) - tasks requiring visual/graphical design
+* [needs: visual design](https://github.com/Growstuff/growstuff/labels/needs:%20visual+design) - tasks requiring visual/graphical design
 * [needs: documentation](https://github.com/Growstuff/growstuff/labels/needs:%20documentation)
 * [needs: data](https://github.com/Growstuff/growstuff/labels/needs:%20data) - tasks requiring data entry, data design, data import, or similar
 * [curated:beginner](https://github.com/Growstuff/growstuff/labels/curated:%20beginner) - tasks that are ideal for beginner programmers or people new to the project


### PR DESCRIPTION
Waffle is shutting down. The existing stories have been migrated to github projects.
closes #1877