### PR TITLE
Pin elasticsearch back at 6, to fix errors on staging/prod

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,8 +87,8 @@ gem 'omniauth-twitter'
 gem "chartkick"
 
 # clever elastic search
-gem 'searchkick'
 gem 'elasticsearch', '< 7.0.0'
+gem 'searchkick'
 
 gem "hashie", ">= 3.5.3"
 

--- a/Gemfile
+++ b/Gemfile
@@ -88,6 +88,7 @@ gem "chartkick"
 
 # clever elastic search
 gem 'searchkick'
+gem 'elasticsearch', '< 7.0.0'
 
 gem "hashie", ">= 3.5.3"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,9 +63,9 @@ GEM
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
     bluecloth (2.2.0)
-    bonsai-elasticsearch-rails (7.0.1)
-      elasticsearch-model (< 8)
-      elasticsearch-rails (< 8)
+    bonsai-elasticsearch-rails (6.0.0)
+      elasticsearch-model (~> 6)
+      elasticsearch-rails (~> 6)
     bootstrap-datepicker-rails (1.8.0.1)
       railties (>= 3.0)
     bootstrap-kaminari-views (0.0.5)
@@ -142,17 +142,17 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.3)
     docile (1.1.5)
-    elasticsearch (7.1.0)
-      elasticsearch-api (= 7.1.0)
-      elasticsearch-transport (= 7.1.0)
-    elasticsearch-api (7.1.0)
+    elasticsearch (6.8.0)
+      elasticsearch-api (= 6.8.0)
+      elasticsearch-transport (= 6.8.0)
+    elasticsearch-api (6.8.0)
       multi_json
     elasticsearch-model (6.0.0)
       activesupport (> 3)
       elasticsearch (> 1)
       hashie
     elasticsearch-rails (6.0.0)
-    elasticsearch-transport (7.1.0)
+    elasticsearch-transport (6.8.0)
       faraday
       multi_json
     erubi (1.8.0)
@@ -543,6 +543,7 @@ DEPENDENCIES
   dalli
   database_cleaner
   devise
+  elasticsearch (< 7.0.0)
   factory_bot_rails
   faker
   figaro
@@ -609,4 +610,4 @@ RUBY VERSION
    ruby 2.6.0p0
 
 BUNDLED WITH
-   1.17.2
+   1.17.3


### PR DESCRIPTION
Production and staging have "Wrong version" errors when attempting SSL connection to bonsai elastic search. I've rolled production back one version on heroku to fix.

This should fix the error - not sure as i can't reproduce it on dev. We'll know once we test on staging.
