### PR TITLE
[HOTFIX] Send message to everyone in migration (no email tho)

### DIFF
--- a/db/migrate/20190720000625_notifications_to_mailboxer.rb
+++ b/db/migrate/20190720000625_notifications_to_mailboxer.rb
@@ -7,7 +7,7 @@ class NotificationsToMailboxer < ActiveRecord::Migration[5.2]
     Notification.find_in_batches.each do |group|
       group.each do |n|
         n.body = 'message has no body' if n.body.blank?
-        receipt = n.send_message
+        receipt = n.sender.send_message(n.recipient, n.body, n.subject)
         # Copy over which messages are read
         receipt.conversation.receipts.each(&:mark_as_read) if n.read
         # copy over timestamps


### PR DESCRIPTION
can't use the method on notification model during migration, because if a user has opted out of notifications then the method returns nil.

instead, send messages for everyone

note: email sending is turned off while this migration runs