### PR TITLE
Use specific error for raise_error expectation in specs (GH-2332)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -90,6 +90,7 @@ submit the change with your pull request.
 - Alex Darr / [apdarr](https://github.com/apdarr)
 - Taylor William / [bestest-mensch](https://github.com/bestest-mensch)
 - André Aubin / [lambda2](https://github.com/lambda2)
+- Martina Simicic / [simicic](https://github.com/simicic)
 
 ## Bots
 

--- a/spec/controllers/photos_controller_spec.rb
+++ b/spec/controllers/photos_controller_spec.rb
@@ -138,7 +138,7 @@ describe PhotosController do
           post :create, params: {
             photo: { source_id: photo.source_id, source: 'flickr' }, type: "comment", id: comment.id
           }
-        end.to raise_error
+        end.to raise_error 'Photos not supported'
       end
     end
 


### PR DESCRIPTION
Based on the currently opened issue: https://github.com/Growstuff/growstuff/issues/2332 this should be the fix to the warning.
When running the tests, error no longer appears. 