### PR TITLE
GH-2361 Optional garden type when editing garden

### DIFF
--- a/app/views/gardens/_form.html.haml
+++ b/app/views/gardens/_form.html.haml
@@ -30,7 +30,7 @@
         .col-md-5.col-12= f.number_field :area, class: 'input-small'
         .col-md-7.col-12= f.select(:area_unit, Garden::AREA_UNITS_VALUES, { include_blank: false })
         .col-12= f.select(:garden_type_id, GardenType.all.order(:name).pluck(:name, :id),
-                          selected: @garden.garden_type_id)
+                          selected: @garden.garden_type_id, include_blank: true)
         .col-12
           = f.check_box :active, label: 'Active?'
           %p


### PR DESCRIPTION
## Description
A while ago, garden type was made optional for the garden (https://github.com/Growstuff/growstuff/commit/55f6636da54314e0a000dd661d2a664f6b1d506b) but the edit form would always enforce a `garden_type_id` - this change includes a blank option so that when updating a garden - `garden_type_id` can be set to `nil`. (For more context see: https://github.com/Growstuff/growstuff/issues/2361)

## Testing
No automated tests has been added since the current GardenController tests already account for `garden_type_id` being `nil` (https://github.com/Growstuff/growstuff/blob/8360e4ac0f5aaaf6a5a56a3235894fc591a846c3/spec/controllers/gardens_controller_spec.rb#L41 - https://github.com/Growstuff/growstuff/blob/8360e4ac0f5aaaf6a5a56a3235894fc591a846c3/spec/controllers/gardens_controller_spec.rb#L7)
I could add a feature tests but since there are known issues in the slowness of the test suit, and this is not a critical feature - maybe that is not needed?
