### PR TITLE
GH-2362 Display garden type on garden show

### DIFF
--- a/app/views/gardens/show.html.haml
+++ b/app/views/gardens/show.html.haml
@@ -81,6 +81,10 @@
           %p
             %strong Area:
             = pluralize(@garden.area, @garden.area_unit)
+        - unless @garden.garden_type.blank?
+          %p
+            %strong Garden type:
+            = @garden.garden_type.name
 
     .card
       .card-header

--- a/app/views/gardens/show.html.haml
+++ b/app/views/gardens/show.html.haml
@@ -73,15 +73,15 @@
         %p
           %strong Owner:
           = link_to @garden.owner, @garden.owner
-        - unless @garden.location.blank?
+        - if @garden.location.present?
           %p
             %strong Location:
             = @garden.location
-        - unless @garden.area.blank?
+        - if @garden.area.present?
           %p
             %strong Area:
             = pluralize(@garden.area, @garden.area_unit)
-        - unless @garden.garden_type.blank?
+        - if @garden.garden_type.present?
           %p
             %strong Garden type:
             = @garden.garden_type.name

--- a/spec/features/gardens/gardens_spec.rb
+++ b/spec/features/gardens/gardens_spec.rb
@@ -73,6 +73,18 @@ describe "Planting a crop", js: true do
       end
     end
 
+    context 'When a garden has a garden type' do
+      let(:garden_type) { create :garden_type }
+      let(:garden_with_type) { create :garden, garden_type: garden_type }
+
+      it "Shows a garden type for a garden" do
+        visit garden_path(garden_with_type)
+
+        expect(page).to have_content "Garden type"
+        expect(page).to have_content garden_type.name
+      end
+    end
+
     it "Edit garden" do
       visit new_garden_path
       fill_in "Name", with: "New garden"


### PR DESCRIPTION
### Description
Garden show does not display garden type, this PR adds that functionality.
![Screenshot from 2020-01-06 13-36-57](https://user-images.githubusercontent.com/922964/71818575-b09db600-3089-11ea-9f28-e369b932c284.png)

I placed it in `About this garden section`
Original issue: https://github.com/Growstuff/growstuff/issues/2362

### Testing
I found somewhere in the docs that the feature tests are preferred over the view tests so I added a new one for the garden type and changed the description of the file to make it more descriptive. 

Also, I changed the `unless blank?` to `if present?` for better readability, I can also remove that commit if you so prefer. (https://github.com/Growstuff/growstuff/commit/fbb1be31688c5f28007e3f77cecfd44b4cb8409e)

