### PR TITLE
GH-2369 update gardens index style

### DIFF
--- a/app/controllers/gardens_controller.rb
+++ b/app/controllers/gardens_controller.rb
@@ -4,7 +4,7 @@ class GardensController < DataController
   def index
     @owner = Member.find_by(slug: params[:member_slug])
     @show_all = params[:all] == '1'
-    @my_garden = params[:member_slug].present? ? true : false
+    @show_jump_to = params[:member_slug].present? ? true : false
 
     @gardens = @gardens.includes(:owner)
     @gardens = @gardens.active unless @show_all

--- a/app/controllers/gardens_controller.rb
+++ b/app/controllers/gardens_controller.rb
@@ -5,6 +5,7 @@ class GardensController < DataController
     @owner = Member.find_by(slug: params[:member_slug])
     @show_all = params[:all] == '1'
 
+    @gardens = @gardens.includes(:owner)
     @gardens = @gardens.active unless @show_all
     @gardens = @gardens.where(owner: @owner) if @owner.present?
     @gardens = @gardens.where.not(members: { confirmed_at: nil })

--- a/app/controllers/gardens_controller.rb
+++ b/app/controllers/gardens_controller.rb
@@ -4,6 +4,7 @@ class GardensController < DataController
   def index
     @owner = Member.find_by(slug: params[:member_slug])
     @show_all = params[:all] == '1'
+    @my_garden = params[:member_slug].present? ? true : false
 
     @gardens = @gardens.includes(:owner)
     @gardens = @gardens.active unless @show_all

--- a/app/views/gardens/index.html.haml
+++ b/app/views/gardens/index.html.haml
@@ -29,7 +29,7 @@
         %h2= page_entries_info @gardens
         = will_paginate @gardens
 
-      - if @my_garden == true
+      - if @show_jump_to == true
         %section
           .jump
             jump to:

--- a/app/views/gardens/index.html.haml
+++ b/app/views/gardens/index.html.haml
@@ -2,8 +2,6 @@
 
 %h1= @owner ? "#{@owner}'s gardens" : "Everyone's gardens"
 
-= render 'layouts/nav', model: Garden
-
 - content_for :breadcrumbs do
   - if @owner
     %li.breadcrumb-item= link_to 'Gardens', gardens_path
@@ -11,51 +9,74 @@
   - else
     %li.breadcrumb-item.active= link_to 'Gardens', gardens_path
 
-%section.border-top
-  = link_to show_inactive_tickbox_path('gardens', owner: @owner, show_all: @show_all), class: 'btn'  do
-    = check_box_tag 'active', 'all', @show_all
-    include in-active
+.row
+  .col-md-2
+    = render 'layouts/nav', model: Garden
 
-- if @gardens.empty?
-  %p There are no gardens to display.
-  - if can?(:create, Garden) && @owner == current_member
-    = link_to 'Add a garden', new_garden_path, class: 'btn btn-primary'
+    %section.border-top
+      = link_to show_inactive_tickbox_path('gardens', owner: @owner, show_all: @show_all), class: 'btn'  do
+        = check_box_tag 'active', 'all', @show_all
+        include in-active
 
-- else
-  = page_entries_info @gardens
-  = will_paginate @gardens
-  .jump
-    jump to:
-    - @gardens.each do |garden|
-      .badge.badge-primary
-        - if @owner.present?
-          = link_to garden.name, member_gardens_path(@owner, anchor: "garden-#{garden.id}")
-        - else
-          = link_to garden.name, gardens_path(anchor: "garden-#{garden.id}")
-  - @gardens.each do |garden|
-    %section.card
-      %h2= link_to garden.name, garden, name: "garden-#{garden.id}"
-      .card-header
-        .row
-          .col-12.col-md-3
-            - unless @owner.present?
-              owner:
-              = render 'members/tiny', member: garden.owner
-            = image_tag garden_image_path(garden), alt: garden.name, class: 'img-card'
-          .col-12.col-md-2= render 'gardens/actions', garden: garden
-          .col
-            - if garden.plantings.active.perennial.any?
-              %strong Perennials:
-              - garden.plantings.active.perennial.each do |planting|
-                = link_to planting do
-                  = crop_icon planting.crop
-                  = planting.crop
-      .card-body
-        - if garden.plantings.active.annual.any?
-          = render 'plantings/progress_list', plantings: garden.plantings.active.annual
-        - else
-          No annual plantings
+  .col-md-10
+    - if @gardens.empty?
+      %p There are no gardens to display.
+      - if can?(:create, Garden) && @owner == current_member
+        = link_to 'Add a garden', new_garden_path, class: 'btn btn-primary'
 
-  .row
-    .col-12= page_entries_info @gardens
-    .col-12= will_paginate @gardens
+    - else
+      %section
+        %h2= page_entries_info @gardens
+        = will_paginate @gardens
+
+      - unless defined?(@show_all)
+        .jump
+          jump to:
+          - @gardens.each do |garden|
+            .badge.badge-primary
+              - if @owner.present?
+                = link_to garden.name, member_gardens_path(@owner, anchor: "garden-#{garden.id}")
+              - else
+                = link_to garden.name, gardens_path(anchor: "garden-#{garden.id}")
+      - @gardens.each do |garden|
+        .card
+          .card-header
+            .row
+              .col-12.col-md-3
+                %h2= link_to garden.name, garden, name: "garden-#{garden.id}"
+            .row
+              .col-md-3
+                - if @owner.blank?
+                  owner:
+                  = render 'members/tiny', member: garden.owner
+
+
+                = image_tag garden_image_path(garden), alt: garden.name, class: 'img-card'
+
+              .col-md-9
+                %section
+                  = render 'gardens/actions', garden: garden
+
+                - active_plantings = garden.plantings.active
+
+                %section
+                  - if active_plantings.perennial.any?
+                    %strong Perennials:
+                    - active_plantings.perennial.each do |planting|
+                      = link_to planting do
+                        = crop_icon planting.crop
+                        = planting.crop
+                  - else
+                    %p No perennial plantings
+
+                %hr
+
+                %section
+                  - if active_plantings.annual.any?
+                    = render 'plantings/progress_list', plantings: garden.plantings.active.annual
+                  - else
+                    %p No annual plantings
+
+      .row
+        .col-12= page_entries_info @gardens
+        .col-12= will_paginate @gardens

--- a/app/views/gardens/index.html.haml
+++ b/app/views/gardens/index.html.haml
@@ -29,15 +29,16 @@
         %h2= page_entries_info @gardens
         = will_paginate @gardens
 
-      - unless defined?(@show_all)
-        .jump
-          jump to:
-          - @gardens.each do |garden|
-            .badge.badge-primary
-              - if @owner.present?
-                = link_to garden.name, member_gardens_path(@owner, anchor: "garden-#{garden.id}")
-              - else
-                = link_to garden.name, gardens_path(anchor: "garden-#{garden.id}")
+      - if @my_garden == true
+        %section
+          .jump
+            jump to:
+            - @gardens.each do |garden|
+              .badge.badge-primary
+                - if @owner.present?
+                  = link_to garden.name, member_gardens_path(@owner, anchor: "garden-#{garden.id}")
+                - else
+                  = link_to garden.name, gardens_path(anchor: "garden-#{garden.id}")
       - @gardens.each do |garden|
         .card
           .card-header


### PR DESCRIPTION
### Description
Gardens index page needs some love and this is an attempt of it. 
Following changes were made: 
- page navigation is no longer stretched cross page - I followed existing designs done in plantings and crops index
- jump to is shown only when viewing own gardens
- name of the garden does not have green background
- no perennial plantings is shown if none of the items in category exist
- plantings are shown next to the image instead of below

### Testing
- I tested it by clicking around - looks good
- I also checked how it looks on mobile - and there is this issue of not being stretched cross screen, but after visiting for example plantings index page and going back to gardens - the content is shown correctly - not sure why that happens, let me know if you know what the deal is there...

Here are some examples with my limited data...
Before: 
![Screenshot from 2020-01-07 11-15-46](https://user-images.githubusercontent.com/922964/71890700-2b77d700-3145-11ea-9b75-74fe03759797.png)

After: 
![Screenshot from 2020-01-07 11-20-31](https://user-images.githubusercontent.com/922964/71890819-67ab3780-3145-11ea-8060-fb442ef53e44.png)

![Screenshot from 2020-01-07 11-30-29](https://user-images.githubusercontent.com/922964/71890847-7db8f800-3145-11ea-9380-dae028a0227e.png)


