### PR TITLE
BUGFIX: member slug needed on photos, to make link

### DIFF
--- a/app/models/concerns/search_photos.rb
+++ b/app/models/concerns/search_photos.rb
@@ -25,8 +25,8 @@ module SearchPhotos
         liked_by_members_names: liked_by_members_names,
         # owner
         owner_id:               owner_id,
-        owner_login_name:       owner.login_name,
-        owner_slug:             owner.slug,
+        owner_login_name:       owner_login_name,
+        owner_slug:             owner_slug,
         # counts
         likes_count:            likes_count,
 

--- a/app/models/concerns/search_photos.rb
+++ b/app/models/concerns/search_photos.rb
@@ -26,6 +26,7 @@ module SearchPhotos
         # owner
         owner_id:               owner_id,
         owner_login_name:       owner.login_name,
+        owner_slug:             owner.slug,
         # counts
         likes_count:            likes_count,
 

--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -32,7 +32,7 @@ class Photo < ApplicationRecord
     joins(:photo_associations).where(photo_associations: { photographable_type: model_name.to_s })
   }
 
-  delegate :login_name, to: :owner, prefix: true
+  delegate :login_name, :slug, to: :owner, prefix: true
 
   # This is split into a side-effect free method and a side-effecting method
   # for easier stubbing and testing.

--- a/app/views/photos/_card.html.haml
+++ b/app/views/photos/_card.html.haml
@@ -5,7 +5,7 @@
     %h5.ellipsis
       = photo_icon
       = link_to photo.title, photo_path(id: photo.id)
-    %i by #{link_to photo.owner_login_name, member_path(slug: photo.owner_login_name)}
+    %i by #{link_to photo.owner_login_name, member_path(slug: photo.owner_slug)}
     - if photo.date_taken.present?
       %small.text-muted
         %time{datetime: photo.date_taken}= I18n.l(photo.date_taken.to_date)


### PR DESCRIPTION
links to photo owner is a broken link whenever the login_name doesn't match the slug.

e.g. when the user has upper case in their login name