### PR TITLE
Auto corrected by following Lint Ruby RSpec/ExampleWording

### DIFF
--- a/spec/models/crop_spec.rb
+++ b/spec/models/crop_spec.rb
@@ -6,18 +6,18 @@ describe Crop do
   context 'all fields present' do
     let(:crop) { FactoryBot.create(:tomato) }
 
-    it 'should save a basic crop' do
+    it 'saves a basic crop' do
       crop.save.should be(true)
     end
 
-    it 'should be fetchable from the database' do
+    it 'is fetchable from the database' do
       crop.save
       @crop2 = described_class.find_by(name: 'tomato')
       @crop2.en_wikipedia_url.should eq("http://en.wikipedia.org/wiki/Tomato")
       @crop2.slug.should eq("tomato")
     end
 
-    it 'should stringify as the system name' do
+    it 'stringifies as the system name' do
       crop.save
       crop.to_s.should eq('tomato')
     end
@@ -29,7 +29,7 @@ describe Crop do
   end
 
   context 'invalid data' do
-    it 'should not save a crop without a system name' do
+    it 'does not save a crop without a system name' do
       crop = FactoryBot.build(:crop, name: nil)
       expect { crop.save }.to raise_error ActiveRecord::StatementInvalid
     end
@@ -530,11 +530,11 @@ describe Crop do
         tomato.destroy
       end
 
-      it "should delete the association between post and the crop(tomato)" do
+      it "deletes the association between post and the crop(tomato)" do
         expect(Post.find(post.id).crops).to eq [maize]
       end
 
-      it "should not delete the posts" do
+      it "does not delete the posts" do
         expect(Post.find(post.id)).not_to eq nil
       end
     end
@@ -554,11 +554,11 @@ describe Crop do
     end
 
     describe "rejecting a crop" do
-      it "should give reason if a default option" do
+      it "gives reason if a default option" do
         expect(rejected_reason.rejection_explanation).to eq "not edible"
       end
 
-      it "should show rejection notes if reason was other" do
+      it "shows rejection notes if reason was other" do
         expect(rejected_other.rejection_explanation).to eq "blah blah blah"
       end
     end


### PR DESCRIPTION
Auto corrected by following Lint Ruby RSpec/ExampleWording

Click [here](https://awesomecode.io//repos/Growstuff/growstuff/lint_configs/ruby/27199) to configure it on awesomecode.io