### PR TITLE
Auto corrected by following Lint Ruby RSpec/NotToNot

### DIFF
--- a/spec/requests/conversations_spec.rb
+++ b/spec/requests/conversations_spec.rb
@@ -26,7 +26,7 @@ describe 'Converstions' do
       # we dont actually destroy the messages, we move them to the trash folder
       expect do
         delete '/conversations/destroy_multiple', params: { conversation_ids: conversations_to_trash, box: 'inbox' }
-      end.to_not change(Mailboxer::Conversation, :count)
+      end.not_to change(Mailboxer::Conversation, :count)
 
       expect(member.mailbox.inbox.count).to eq 0
       expect(member.mailbox.trash.count).to eq 2
@@ -41,7 +41,7 @@ describe 'Converstions' do
       # we dont actually destroy the messages, we move them to the trash folder
       expect do
         delete '/conversations/destroy_multiple', params: { conversation_ids: conversations_to_trash }
-      end.to_not change(Mailboxer::Conversation, :count)
+      end.not_to change(Mailboxer::Conversation, :count)
 
       expect(second_member.mailbox.inbox.count).to eq 2
       expect(second_member.mailbox.trash.count).to eq 0
@@ -55,7 +55,7 @@ describe 'Converstions' do
       # we dont actually destroy the messages, we move them to the trash folder
       expect do
         delete '/conversations/destroy_multiple', params: { conversation_ids: conversations_to_trash, box: 'sent' }
-      end.to_not change(Mailboxer::Conversation, :count)
+      end.not_to change(Mailboxer::Conversation, :count)
 
       expect(member.mailbox.sentbox.count).to eq 0
       expect(member.mailbox.trash.count).to eq 2


### PR DESCRIPTION
Auto corrected by following Lint Ruby RSpec/NotToNot

Click [here](https://awesomecode.io//repos/Growstuff/growstuff/lint_configs/ruby/28129) to configure it on awesomecode.io