### PR TITLE
Auto corrected by following Lint Ruby Layout/EmptyLineAfterMagicComment

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
 Devise.setup do |config|


### PR DESCRIPTION
Auto corrected by following Lint Ruby Layout/EmptyLineAfterMagicComment

Click [here](https://awesomecode.io/repos/Growstuff/growstuff/lint_configs/ruby/1746) to configure it on awesomecode.io