### PR TITLE
Bump pg

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,7 @@ gem 'gibbon', '~>1.2.0'            # for Mailchimp newsletter subscriptions
 gem 'leaflet-rails', '>= 1.7.0'
 gem 'rails-assets-leaflet.markercluster', source: 'https://rails-assets.org'
 
-gem 'pg', '< 1.0.0'                # Upstream bug, see https://github.com/Growstuff/growstuff/pull/1539
+gem 'pg'
 gem 'ruby-units'                   # for unit conversion
 gem 'unicorn'                      # http server
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -388,7 +388,7 @@ GEM
     parser (2.7.2.0)
       ast (~> 2.4.1)
     percy-capybara (4.3.3)
-    pg (0.21.0)
+    pg (1.3.4)
     platform-api (3.3.0)
       heroics (~> 0.1.1)
       moneta (~> 1.0.0)
@@ -677,7 +677,7 @@ DEPENDENCIES
   omniauth-flickr (>= 0.0.15)
   omniauth-twitter
   percy-capybara
-  pg (< 1.0.0)
+  pg
   platform-api
   puma
   query_diet


### PR DESCRIPTION
Previously: https://github.com/Growstuff/growstuff/pull/1539

> "Specified 'postgresql' for database adapter, but the gem is not loaded. Add gem 'pg' to your Gemfile (and ensure its version is at the minimum required by ActiveRecord)."

https://github.com/rails/rails/issues/31669#issuecomment-362609493 I think was this issue at the time.