### PR TITLE
Add tests #3041 - wrong resources loaded

### DIFF
--- a/app/resources/api/v1/member_resource.rb
+++ b/app/resources/api/v1/member_resource.rb
@@ -5,10 +5,10 @@ module Api
     class MemberResource < BaseResource
       immutable
 
-      has_many :gardens
-      has_many :plantings
-      has_many :harvests
-      has_many :seeds
+      has_many :gardens, foreign_key: 'owner_id'
+      has_many :plantings, foreign_key: 'owner_id'
+      has_many :harvests, foreign_key: 'owner_id'
+      has_many :seeds, foreign_key: 'owner_id'
 
       has_many :photos
 

--- a/app/resources/api/v1/planting_resource.rb
+++ b/app/resources/api/v1/planting_resource.rb
@@ -33,6 +33,7 @@ module Api
       filter :planted_from
       filter :garden
       filter :owner
+      filter :owner_id
       filter :finished
 
       attribute :percentage_grown

--- a/spec/requests/api/v1/plantings_request_spec.rb
+++ b/spec/requests/api/v1/plantings_request_spec.rb
@@ -123,11 +123,19 @@ RSpec.describe 'Plantings', type: :request do
 
     describe "#show" do
       it "locates the correct member" do
+        get "/api/v1/plantings?filter[owner-id]=#{@member1.id}"
+        expect(JSON.parse(response.body)['data'][0]['id']).to eq(planting.id.to_s)
+
+        get "/api/v1/plantings?filter[owner-id]=#{@member2.id}"
+        expect(JSON.parse(response.body)['data'][0]['id']).to eq(@planting2.id.to_s)
+
+        pending "The below should be identical to the above, but aren't."
+
         get "/api/v1/members/#{@member1.id}/plantings"
-        expect(subject['data'][0]['id']).to eq(planting.id.to_s)
+        expect(JSON.parse(response.body)['data'][0]['id']).to eq(planting.id.to_s)
 
         get "/api/v1/members/#{@member2.id}/plantings"
-        expect(subject['data'][0]['id']).to eq(@planting2.id.to_s)
+        expect(JSON.parse(response.body)['data'][0]['id']).to eq(@planting2.id.to_s)
       end
     end
   end

--- a/spec/requests/api/v1/plantings_request_spec.rb
+++ b/spec/requests/api/v1/plantings_request_spec.rb
@@ -113,4 +113,22 @@ RSpec.describe 'Plantings', type: :request do
       delete "/api/v1/plantings/#{planting.id}", params: {}, headers: headers
     end.to raise_error ActionController::RoutingError
   end
+
+  describe "by member/owner" do
+    before :each do
+      @member1 = planting.owner
+      @planting2 = create(:planting, owner: create(:owner))
+      @member2 = @planting2.owner
+    end
+
+    describe "#show" do
+      it "locates the correct member" do
+        get "/api/v1/members/#{@member1.id}/plantings"
+        expect(subject['data'][0]['id']).to eq(planting.id.to_s)
+
+        get "/api/v1/members/#{@member2.id}/plantings"
+        expect(subject['data'][0]['id']).to eq(@planting2.id.to_s)
+      end
+    end
+  end
 end


### PR DESCRIPTION
* Adds foreign keys to the resources - https://jsonapi-resources.com/v0.10/guide/resources.html#Relationships
* Adds a spec, marked pending, showing the broken behaviour of #3041 - we can see plantings_controller gets passed a params[:member_id] instead of [:owner_id], others affected in a similar way no doubt
* Adds filter by owner_id as a work around. Currently HTTP 500 errors
