### PR TITLE
Forum model - Add presence validation

### DIFF
--- a/app/models/forum.rb
+++ b/app/models/forum.rb
@@ -4,6 +4,7 @@ class Forum < ApplicationRecord
   extend FriendlyId
   include Ownable
   validates :name, presence: true
+  validates :description, presence: true
   friendly_id :name, use: %i(slugged finders)
 
   has_many :posts, dependent: :destroy


### PR DESCRIPTION
Fix
```
irb(main):019:0> Forum.create(name: "Hello", owner_id: 1)
  TRANSACTION (0.2ms)  BEGIN
  Forum Exists? (0.3ms)  SELECT 1 AS one FROM "forums" WHERE "forums"."id" IS NOT NULL AND "forums"."slug" = $1 LIMIT $2  [["slug", "hello"], ["LIMIT", 1]]
  Member Load (0.2ms)  SELECT "members".* FROM "members" WHERE "members"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
  Forum Create (0.5ms)  INSERT INTO "forums" ("name", "description", "owner_id", "created_at", "updated_at", "slug") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"  [["name", "Hello"], ["description", nil], ["owner_id", 1], ["created_at", "2023-08-11 05:20:29.712966"], ["updated_at", "2023-08-11 05:20:29.712966"], ["slug", "hello-6e86261f-8c17-45ad-b1c9-ded2e4507234"]]
  TRANSACTION (0.1ms)  ROLLBACK                                                  
/usr/local/rvm/gems/default/gems/activerecord-7.0.7/lib/active_record/connection_adapters/postgresql_adapter.rb:768:in `exec_params': PG::NotNullViolation: ERROR:  null value in column "description" of relation "forums" violates not-null constraint (ActiveRecord::NotNullViolation) 
DETAIL:  Failing row contains (3, Hello, null, 1, 2023-08-11 05:20:29.712966, 2023-08-11 05:20:29.712966, hello-6e86261f-8c17-45ad-b1c9-ded2e4507234).
/usr/local/rvm/gems/default/gems/activerecord-7.0.7/lib/active_record/connection_adapters/postgresql_adapter.rb:768:in `exec_params': ERROR:  null value in column "description" of relation "forums" violates not-null constraint (PG::NotNullViolation)                                 
DETAIL:  Failing row contains (3, Hello, null, 1, 2023-08-11 05:20:29.712966, 2023-08-11 05:20:29.712966, hello-6e86261f-8c17-45ad-b1c9-ded2e4507234).
```