### PR TITLE
Alternative: Remove js routes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,6 @@ gem 'active_record_union'
 gem 'flickraw'
 gem 'jquery-rails'
 gem 'jquery-ui-rails'
-gem 'js-routes', "~> 2.0.0" # provides access to Rails routes in Javascript
 
 gem 'cancancan'                    # for checking member privileges
 gem 'csv_shaper'                   # CSV export

--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ gem 'active_record_union'
 gem 'flickraw'
 gem 'jquery-rails'
 gem 'jquery-ui-rails'
-gem 'js-routes' # provides access to Rails routes in Javascript
+gem 'js-routes', "~> 2.0.0" # provides access to Rails routes in Javascript
 
 gem 'cancancan'                    # for checking member privileges
 gem 'csv_shaper'                   # CSV export

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -316,7 +316,7 @@ GEM
       thor (>= 0.14, < 2.0)
     jquery-ui-rails (6.0.1)
       railties (>= 3.2.16)
-    js-routes (1.4.14)
+    js-routes (2.0.8)
       railties (>= 4)
     json (2.6.3)
     json-schema (3.0.0)
@@ -686,7 +686,7 @@ DEPENDENCIES
   i18n-tasks
   jquery-rails
   jquery-ui-rails
-  js-routes
+  js-routes (~> 2.0.0)
   jsonapi-resources
   jsonapi-swagger
   leaflet-rails (>= 1.9.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -316,8 +316,6 @@ GEM
       thor (>= 0.14, < 2.0)
     jquery-ui-rails (6.0.1)
       railties (>= 3.2.16)
-    js-routes (2.0.8)
-      railties (>= 4)
     json (2.6.3)
     json-schema (3.0.0)
       addressable (>= 2.8)
@@ -686,7 +684,6 @@ DEPENDENCIES
   i18n-tasks
   jquery-rails
   jquery-ui-rails
-  js-routes (~> 2.0.0)
   jsonapi-resources
   jsonapi-swagger
   leaflet-rails (>= 1.9.2)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,7 +12,6 @@
 //
 // = require leaflet
 // = require leaflet.markercluster
-// = require js-routes
 // = require popper
 // = require jquery
 // = require jquery_ujs

--- a/config/application.rb
+++ b/config/application.rb
@@ -81,3 +81,8 @@ module Growstuff
     end
   end
 end
+# https://github.com/railsware/js-routes/blob/master/VERSION_2_UPGRADE.md
+JsRoutes.setup do |config|
+  config.module_type = nil
+  config.namespace = "Routes"
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -81,8 +81,3 @@ module Growstuff
     end
   end
 end
-# https://github.com/railsware/js-routes/blob/master/VERSION_2_UPGRADE.md
-JsRoutes.setup do |config|
-  config.module_type = nil
-  config.namespace = "Routes"
-end


### PR DESCRIPTION
When I look at Growstuff.org, I can get access to `Routes` via the browser console.

But nothing in the code or compiled assests references it!

So; removing as an alternative to https://github.com/Growstuff/growstuff/pull/3419