### PR TITLE
Fix rswag deprecations

### DIFF
--- a/config/initializers/rswag_api.rb
+++ b/config/initializers/rswag_api.rb
@@ -5,7 +5,7 @@ Rswag::Api.configure do |c|
   # This is used by the Swagger middleware to serve requests for API descriptions
   # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
   # that it's configured to generate files in the same folder
-  c.swagger_root = Rails.root.to_s + '/swagger'
+  c.openapi_root = Rails.root.to_s + '/swagger'
 
   # Inject a lamda function to alter the returned Swagger prior to serialization
   # The function will have access to the rack env for the current request

--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -7,5 +7,5 @@ Rswag::Ui.configure do |c|
   # NOTE: If you're using rspec-api to expose Swagger files (under swagger_root) as JSON or YAML endpoints,
   # then the list below should correspond to the relative paths for those endpoints
 
-  c.swagger_endpoint '/api-docs/v1/swagger.json', 'API V1 Docs'
+  c.openapi_endpoint '/api-docs/v1/swagger.json', 'API V1 Docs'
 end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -6,11 +6,11 @@ RSpec.configure do |config|
   # Specify a root folder where Swagger JSON files are generated
   # NOTE: If you're using the rswag-api to serve API descriptions, you'll need
   # to ensure that it's configured to serve Swagger from the same folder
-  config.swagger_root = Rails.root.join('swagger').to_s
+  config.openapi_root = Rails.root.join('swagger').to_s
 
   # Define one or more Swagger documents and provide global metadata for each one
   # When you run the 'rswag:specs:swaggerize' rake task, the complete Swagger will
-  # be generated at the provided relative path under swagger_root
+  # be generated at the provided relative path under openapi_root
   # By default, the operations defined in spec files are added to the first
   # document below. You can override this behavior by adding a swagger_doc tag to the
   # the root example_group in your specs, e.g. describe '...', swagger_doc: 'v2/swagger.json'


### PR DESCRIPTION
DEPRECATION WARNING: swagger_root= is deprecated and will be removed from rswag-api 3.0 (use openapi_root= instead) (called from block in <top (required)> at /workspaces/growstuff/config/initializers/rswag_api.rb:8)
DEPRECATION WARNING: Rswag::Ui: WARNING: The method will be renamed to "openapi_endpoint" in v3.0 (called from block in <top (required)> at /workspaces/growstuff/config/initializers/rswag_ui.rb:10)