### PR TITLE
Suppress Time.to_s warning until next rails

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -3,7 +3,7 @@
 require_relative 'boot'
 
 require 'rails/all'
-ENV['RAILS_DISABLE_DEPRECATED_TO_S_CONVERSION'] = git"true"
+ENV['RAILS_DISABLE_DEPRECATED_TO_S_CONVERSION'] = "true"
 
 require 'openssl'
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -3,6 +3,8 @@
 require_relative 'boot'
 
 require 'rails/all'
+ENV['RAILS_DISABLE_DEPRECATED_TO_S_CONVERSION'] = git"true"
+
 require 'openssl'
 
 # Require the gems listed in Gemfile, including any gems


### PR DESCRIPTION
DEPRECATION WARNING: Using a :default format for Time#to_s is deprecated. Please use Time#to_fs instead. If you fixed all places inside your application that you see this deprecation, you can set `ENV['RAILS_DISABLE_DEPRECATED_TO_S_CONVERSION']` to `"true"` in the `config/application.rb` file before the `Bundler.require` call to fix all the callers outside of your application. (called from require at bin/rails:6)