### PR TITLE
Darken green buttons, headings etc for Accessbility contrast ratios

### DIFF
--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -4,7 +4,7 @@
 $beige: #f3f1ee;
 $brown: #413f3b;
 
-$green: #5f8e43;
+$green: #57803c;
 $blue: #2f4365;
 $red: #ff4d43;
 $orange: #ffa500;


### PR DESCRIPTION
#2067

Before:
![image](https://github.com/Growstuff/growstuff/assets/365751/ee1bd9bd-7e8f-44c3-ac98-b73a7f015eda)

After:
![image](https://github.com/Growstuff/growstuff/assets/365751/559fdd6b-5d09-44fe-81e4-f692ec535231)
(Note a few places missing the change, as this is me in Chrome rails than via the app)

