### PR TITLE
Accessibility: Landmarks

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -12,9 +12,10 @@
     .container
       #maincontainer
         - if content_for?(:breadcrumbs)
-          %ol.breadcrumb{ "aria-label" => "breadcrumb" }
-            %li.breadcrumb-item= link_to 'Home', root_path
-            = yield(:breadcrumbs)
+          %nav{ "aria-label" => "breadcrumb" }
+            %ol.breadcrumb
+              %li.breadcrumb-item= link_to 'Home', root_path
+              = yield(:breadcrumbs)
         - if content_for?(:buttonbar)
           = yield(:buttonbar)
 

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -22,7 +22,7 @@
           %small= yield(:subtitle)
 
         = render "shared/flash_messages", flash: flash
-        = yield
+        %main= yield
 
     %footer.page-footer.font-small.bg-dark.pt-4= render "layouts/footer"
     /


### PR DESCRIPTION
 landmark-one-main: Document should have one main landmark (moderate)
           https://dequeuniversity.com/rules/axe/4.8/landmark-one-main?application=axeAPI
           The following 1 node violate this rule:
           
               Selector: html
               HTML: <html lang="en" prefix="og: https://ogp.me/ns#">
               Fix all of the following:
               - Document does not have a main landmark

and


region: All page content should be contained by landmarks (moderate)
           https://dequeuniversity.com/rules/axe/4.8/region?application=axeAPI
           The following 3 nodes violate this rule:
           
               Selector: ol
               HTML: <ol aria-label="breadcrumb" class="breadcrumb"><li class="breadcrumb-item"><a href="/">Home</a></li><li class="breadcrumb-item"><a href="/conversations">Conversations</a></li><li class="breadcrumb-item active"><a href="/conversations?box=inbox">inbox</a></li></ol>
               Fix any of the following:
               - Some page content is not contained by landmarks