### PR TITLE
Add rake task for clean up of old content

### DIFF
--- a/app/models/garden.rb
+++ b/app/models/garden.rb
@@ -78,6 +78,16 @@ class Garden < ApplicationRecord
 
   def reindex(refresh: false); end
 
+  # Deactivate any gardens with no active plantings
+  def self.archive!(time_limit: 3.years.ago, limit: 100)
+    Garden.active.where("updated_at < ?", time_limit).order(updated_at: :asc).limit(limit).each do |active_garden|
+      unless active_garden.plantings.active.any?
+        garden.active = false
+        garden.save
+      end
+    end
+  end
+
   protected
 
   def strip_blanks

--- a/lib/tasks/gardens.rake
+++ b/lib/tasks/gardens.rake
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+namespace :gardens do
+
+  desc "Mark old gardens inactive"
+  task archive: :environment do
+    Planting.archive!
+    Garden.archive!
+  end
+end


### PR DESCRIPTION
https://www.growstuff.org/gardens - 85 pages of gardens.
https://www.growstuff.org/plantings?page=96 - 96 pages of plantings.

Unlikely people are returning, so archive.

Can either run it on the heroku scheduler, or maybe add a webhook for some of these "monthly" admin tasks.