### PR TITLE
Planning future plantings - Minor UX changes

### DIFF
--- a/app/models/concerns/predict_planting.rb
+++ b/app/models/concerns/predict_planting.rb
@@ -80,6 +80,8 @@ module PredictPlanting
     private
 
     def calculate_percentage_grown
+      return 0 if age_in_days < 0
+
       percent = (age_in_days / expected_lifespan.to_f) * 100
       (percent > 100 ? 100 : percent)
     end

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -11,11 +11,11 @@
       %p
         - if current_member.plantings.active.any?
           = link_to member_path(current_member), class: 'btn btn-dark' do
-            = image_icon 'plantings'
+            = planting_icon
             Track my plantings
       %p
         = link_to member_gardens_path(current_member), class: 'btn btn-dark' do
-          = image_icon 'gardens'
+          = garden_icon
           Show me my garden
 - else
   .hidden-xs

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -9,6 +9,11 @@
       %p= render 'stats', cached: true
     .col
       %p
+        - if current_member.plantings.active.any?
+          = link_to member_path(current_member), class: 'btn btn-dark' do
+            = image_icon 'plantings'
+            Track my plantings
+      %p
         = link_to member_gardens_path(current_member), class: 'btn btn-dark' do
           = image_icon 'gardens'
           Show me my garden

--- a/app/views/members/_full_summary.html.haml
+++ b/app/views/members/_full_summary.html.haml
@@ -5,13 +5,6 @@
       - @harvesting.each do |planting|
         = render 'plantings/thumbnail', planting: planting
 
-- if @harvests.any?
-  %section.havests
-    %h2 Recent Harvests
-    .index-cards
-      - @harvests.each do |harvest|
-        = render 'harvests/thumbnail', harvest: harvest
-
 - if @others.size.positive?
   %section.planting-progress
     %h2 Progress report
@@ -44,4 +37,10 @@
           = link_to planting.crop_name, planting_url(slug: planting.slug)
           planted on #{planting.planted_at.to_date}
 
+- if @harvests.any?
+  %section.havests
+    %h2 Recent Harvests
+    .index-cards
+      - @harvests.each do |harvest|
+        = render 'harvests/thumbnail', harvest: harvest
 

--- a/app/views/plantings/_facts.haml
+++ b/app/views/plantings/_facts.haml
@@ -21,8 +21,11 @@
   - if planting.finish_is_predicatable?
     .card.fact-card
       %h3 Progress
-      %strong #{planting.age_in_days}/#{planting.expected_lifespan}
-      %span days
+      - if planting.age_in_days < 0
+        %strong Planned
+      - else
+        %strong #{planting.age_in_days}/#{planting.expected_lifespan}
+        %span days
 
   .card.fact-card{class: planting.quantity.present? ? '' : 'text-muted'}
     %h3
@@ -42,6 +45,9 @@
       %h3 Growing
       %strong= seedling_icon
       %span
+      - if planting.age_in_days < 0
+        Planting planned
+      - else
         Planting is still growing today
 
   .card.fact-card{class: planting.planted_from.present? ? '' : 'text-muted'}

--- a/app/views/plantings/_form.html.haml
+++ b/app/views/plantings/_form.html.haml
@@ -36,6 +36,8 @@
           = f.text_field :planted_at,
                      value: @planting.planted_at ? @planting.planted_at.to_fs(:ymd) : '',
                      class: 'add-datepicker', label: 'When?'
+          %span.help-inline
+            Tip: Plan our your future plantings by forward dating
 
       .row
         .col-md-4

--- a/app/views/plantings/_form.html.haml
+++ b/app/views/plantings/_form.html.haml
@@ -37,8 +37,7 @@
                      value: @planting.planted_at ? @planting.planted_at.to_fs(:ymd) : '',
                      class: 'add-datepicker', label: 'When?'
           %span.help-inline
-            Tip: Plan our your future plantings by forward dating,
-            and subscribe to your iCalendar feed for reminders to plant
+            Tip: Plan our your future plantings by forward dating, and subscribe to your iCalendar feed for reminders to plant
 
       .row
         .col-md-4

--- a/app/views/plantings/_form.html.haml
+++ b/app/views/plantings/_form.html.haml
@@ -37,7 +37,8 @@
                      value: @planting.planted_at ? @planting.planted_at.to_fs(:ymd) : '',
                      class: 'add-datepicker', label: 'When?'
           %span.help-inline
-            Tip: Plan our your future plantings by forward dating
+            Tip: Plan our your future plantings by forward dating,
+            and subscribe to your iCalendar feed for reminders to plant
 
       .row
         .col-md-4

--- a/app/views/plantings/show.html.haml
+++ b/app/views/plantings/show.html.haml
@@ -37,7 +37,10 @@
             - elsif @planting.percentage_grown.present?
               #{@planting.percentage_grown.to_i}%
               - if @planting.finish_is_predicatable?
-                %strong #{@planting.age_in_days}/#{@planting.expected_lifespan} days
+                - if @planting.age_in_days < 0
+                  %strong Planned
+                - else
+                  %strong #{@planting.age_in_days}/#{@planting.expected_lifespan} days
 
         = render 'timeline', planting: @planting
 


### PR DESCRIPTION
When I log in, I get a link to "show me my gardens", but if I have active plantings I don't really see the progress unless I choose a specific garden.

Instead now, just link to the profile page and @Br3nda's nice timeline work:
![image](https://github.com/Growstuff/growstuff/assets/365751/f5206edb-e12d-4242-baf1-f70d4a586a37)
![image](https://github.com/Growstuff/growstuff/assets/365751/28995447-6e8f-4fe4-a12f-398d02048bc5)

Additionally, if I future date a planting for something I *will* do in the coming weeks - because I have seeds on hand, encourage me to forward date things; and avoid showing "negative" progress
![image](https://github.com/Growstuff/growstuff/assets/365751/a8dc50b0-aa77-4016-af3c-4aa83cbcd829)
![image](https://github.com/Growstuff/growstuff/assets/365751/e1248009-3b2f-47d6-addf-4364355b18d2)


Next:

- Add model activities due or done to gardens, such as "cultivate soil", or "routine weed" to this homepage.