### PR TITLE
Update garden.rb

### DIFF
--- a/app/models/garden.rb
+++ b/app/models/garden.rb
@@ -81,7 +81,7 @@ class Garden < ApplicationRecord
 
   # Deactivate any gardens with no active plantings
   def self.archive!(time_limit: 3.years.ago, limit: 100)
-    Garden.active.where("updated_at < ?", time_limit).order(updated_at: :asc).limit(limit).each do |active_garden|
+    Garden.active.where("gardens.updated_at < ?", time_limit).order(updated_at: :asc).limit(limit).each do |active_garden|
       unless active_garden.plantings.active.any?
         garden.active = false
         garden.save


### PR DESCRIPTION
```
rake aborted!
ActiveRecord::StatementInvalid: PG::AmbiguousColumn: ERROR:  column reference "updated_at" is ambiguous
LINE 1: ...rded_at" IS NULL AND "gardens"."active" = $1 AND (updated_at...
                                                             ^
/app/vendor/bundle/ruby/3.1.0/gems/activerecord-7.1.3.4/lib/active_record/connection_adapters/postgresql_adapter.rb:894:in `exec_params'
/app/vendor/bundle/ruby/3.1.0/gems/activerecord-7.1.3.4/lib/active_record/connection_adapters/postgresql_adapter.rb:894:in `block (2 levels) in exec_no_cache'
/app/vendor/bundle/ruby/3.1.0/gems/activerecord-7.1.3.4/lib/active_record/connection_adapters/abstract_adapter.rb:1028:in `block in with_raw_connection'
/app/vendor/bundle/ruby/3.1.0/gems/activesupport-7.1.3.4/lib/active_support/concurrency/null_lock.rb:9:in `synchronize'
/app/vendor/bundle/ruby/3.1.0/gems/activerecord-7.1.3.4/lib/active_record/connection_adapters/abstract_adapter.rb:1000:in `with_raw_connection'
/app/vendor/bundle/ruby/3.1.0/gems/activerecord-7.1.3.4/lib/active_record/connection_adapters/postgresql_adapter.rb:893:in `block in exec_no_cache'
/app/vendor/bundle/ruby/3.1.0/gems/activesupport-7.1.3.4/lib/active_support/notifications/instrumenter.rb:58:in `instrument'
/app/vendor/bundle/ruby/3.1.0/gems/activerecord-7.1.3.4/lib/active_record/connection_adapters/abstract_adapter.rb:1143:in `log'
/app/vendor/bundle/ruby/3.1.0/gems/scout_apm-5.3.8/lib/scout_apm/instruments/active_record.rb:257:in `log'
/app/vendor/bundle/ruby/3.1.0/gems/activerecord-7.1.3.4/lib/active_record/connection_adapters/postgresql_adapter.rb:892:in `exec_no_cache'
/app/vendor/bundle/ruby/3.1.0/gems/activerecord-7.1.3.4/lib/active_record/connection_adapters/postgresql_adapter.rb:872:in `execute_and_clear'
/app/vendor/bundle/ruby/3.1.0/gems/activerecord-7.1.3.4/lib/active_record/connection_adapters/postgresql/database_statements.rb:64:in `internal_exec_query'
/app/vendor/bundle/ruby/3.1.0/gems/activerecord-7.1.3.4/lib/active_record/connection_adapters/abstract/database_statements.rb:630:in `select'
/app/vendor/bundle/ruby/3.1.0/gems/activerecord-7.1.3.4/lib/active_record/connection_adapters/abstract/database_statements.rb:71:in `select_all'
/app/vendor/bundle/ruby/3.1.0/gems/activerecord-7.1.3.4/lib/active_record/connection_adapters/abstract/query_cache.rb:115:in `select_all'
/app/vendor/bundle/ruby/3.1.0/gems/activerecord-7.1.3.4/lib/active_record/querying.rb:62:in `_query_by_sql'
/app/vendor/bundle/ruby/3.1.0/gems/activerecord-7.1.3.4/lib/active_record/relation.rb:998:in `block in exec_main_query'
/app/vendor/bundle/ruby/3.1.0/gems/activerecord-7.1.3.4/lib/active_record/relation.rb:1018:in `skip_query_cache_if_necessary'
/app/vendor/bundle/ruby/3.1.0/gems/activerecord-7.1.3.4/lib/active_record/relation.rb:984:in `exec_main_query'
/app/vendor/bundle/ruby/3.1.0/gems/activerecord-7.1.3.4/lib/active_record/relation.rb:962:in `block in exec_queries'
/app/vendor/bundle/ruby/3.1.0/gems/activerecord-7.1.3.4/lib/active_record/relation.rb:1018:in `skip_query_cache_if_necessary'
/app/vendor/bundle/ruby/3.1.0/gems/activerecord-7.1.3.4/lib/active_record/relation.rb:956:in `exec_queries'
/app/vendor/bundle/ruby/3.1.0/gems/scout_apm-5.3.8/lib/scout_apm/instruments/active_record.rb:383:in `exec_queries'
/app/vendor/bundle/ruby/3.1.0/gems/activerecord-7.1.3.4/lib/active_record/relation.rb:742:in `load'
/app/vendor/bundle/ruby/3.1.0/gems/activerecord-7.1.3.4/lib/active_record/relation.rb:264:in `records'
/app/vendor/bundle/ruby/3.1.0/gems/activerecord-7.1.3.4/lib/active_record/relation/delegation.rb:100:in `each'
/app/app/models/garden.rb:84:in `archive!'
/app/lib/tasks/gardens.rake:8:in `block (2 levels) in <top (required)>'
/app/vendor/bundle/ruby/3.1.0/gems/rake-13.2.1/exe/rake:27:in `<top (required)>'
/app/bin/bundle:5:in `load'
/app/bin/bundle:5:in `<main>'

Caused by:
PG::AmbiguousColumn: ERROR:  column reference "updated_at" is ambiguous
LINE 1: ...rded_at" IS NULL AND "gardens"."active" = $1 AND (updated_at...
                                                             ^
/app/vendor/bundle/ruby/3.1.0/gems/activerecord-7.1.3.4/lib/active_record/connection_adapters/postgresql_adapter.rb:894:in `exec_params'
/app/vendor/bundle/ruby/3.1.0/gems/activerecord-7.1.3.4/lib/active_record/connection_adapters/postgresql_adapter.rb:894:in `block (2 levels) in exec_no_cache'
/app/vendor/bundle/ruby/3.1.0/gems/activerecord-7.1.3.4/lib/active_record/connection_adapters/abstract_adapter.rb:1028:in `block in with_raw_connection'
/app/vendor/bundle/ruby/3.1.0/gems/activesupport-7.1.3.4/lib/active_support/concurrency/null_lock.rb:9:in `synchronize'
/app/vendor/bundle/ruby/3.1.0/gems/activerecord-7.1.3.4/lib/active_record/connection_adapters/abstract_adapter.rb:1000:in `with_raw_connection'
/app/vendor/bundle/ruby/3.1.0/gems/activerecord-7.1.3.4/lib/active_record/connection_adapters/postgresql_adapter.rb:893:in `block in exec_no_cache'
/app/vendor/bundle/ruby/3.1.0/gems/activesupport-7.1.3.4/lib/active_support/notifications/instrumenter.rb:58:in `instrument'
/app/vendor/bundle/ruby/3.1.0/gems/activerecord-7.1.3.4/lib/active_record/connection_adapters/abstract_adapter.rb:1143:in `log'
/app/vendor/bundle/ruby/3.1.0/gems/scout_apm-5.3.8/lib/scout_apm/instruments/active_record.rb:257:in `log'
/app/vendor/bundle/ruby/3.1.0/gems/activerecord-7.1.3.4/lib/active_record/connection_adapters/postgresql_adapter.rb:892:in `exec_no_cache'
/app/vendor/bundle/ruby/3.1.0/gems/activerecord-7.1.3.4/lib/active_record/connection_adapters/postgresql_adapter.rb:872:in `execute_and_clear'
/app/vendor/bundle/ruby/3.1.0/gems/activerecord-7.1.3.4/lib/active_record/connection_adapters/postgresql/database_statements.rb:64:in `internal_exec_query'
/app/vendor/bundle/ruby/3.1.0/gems/activerecord-7.1.3.4/lib/active_record/connection_adapters/abstract/database_statements.rb:630:in `select'
/app/vendor/bundle/ruby/3.1.0/gems/activerecord-7.1.3.4/lib/active_record/connection_adapters/abstract/database_statements.rb:71:in `select_all'
/app/vendor/bundle/ruby/3.1.0/gems/activerecord-7.1.3.4/lib/active_record/connection_adapters/abstract/query_cache.rb:115:in `select_all'
/app/vendor/bundle/ruby/3.1.0/gems/activerecord-7.1.3.4/lib/active_record/querying.rb:62:in `_query_by_sql'
/app/vendor/bundle/ruby/3.1.0/gems/activerecord-7.1.3.4/lib/active_record/relation.rb:998:in `block in exec_main_query'
/app/vendor/bundle/ruby/3.1.0/gems/activerecord-7.1.3.4/lib/active_record/relation.rb:1018:in `skip_query_cache_if_necessary'
/app/vendor/bundle/ruby/3.1.0/gems/activerecord-7.1.3.4/lib/active_record/relation.rb:984:in `exec_main_query'
/app/vendor/bundle/ruby/3.1.0/gems/activerecord-7.1.3.4/lib/active_record/relation.rb:962:in `block in exec_queries'
/app/vendor/bundle/ruby/3.1.0/gems/activerecord-7.1.3.4/lib/active_record/relation.rb:1018:in `skip_query_cache_if_necessary'
/app/vendor/bundle/ruby/3.1.0/gems/activerecord-7.1.3.4/lib/active_record/relation.rb:956:in `exec_queries'
/app/vendor/bundle/ruby/3.1.0/gems/scout_apm-5.3.8/lib/scout_apm/instruments/active_record.rb:383:in `exec_querie
```