### PR TITLE
Opt into view transitions

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -30,3 +30,7 @@
 @import "predictions";
 @import "homepage";
 @import "maps";
+
+@view-transition {
+  navigation: auto;
+}


### PR DESCRIPTION
Fix #4100.

We have a lot more visual content and could describe thumbnails transitioning to full images or similar; but for now; default cross fade.