### PR TITLE
Seeds for trade - avoid showing expired seeds on homepage.

### DIFF
--- a/app/controllers/seeds_controller.rb
+++ b/app/controllers/seeds_controller.rb
@@ -19,9 +19,7 @@ class SeedsController < DataController
       where['parent_planting'] = @planting.id
     end
 
-    if params[:tradeable_to].present?
-      where['tradeable_to'] = params[:tradeable_to]
-    end
+    where['tradeable_to'] = params[:tradeable_to] if params[:tradeable_to].present?
 
     @show_all = (params[:all] == '1')
     where['finished'] = false unless @show_all
@@ -58,6 +56,7 @@ class SeedsController < DataController
 
   def create
     @seed = Seed.new(seed_params)
+    @seed.finished ||= false
     @seed.owner = current_member
     @seed.crop = @seed.parent_planting.crop if @seed.parent_planting
     flash[:notice] = "Successfully added #{@seed.crop} seed to your stash." if @seed.save

--- a/app/models/concerns/search_seeds.rb
+++ b/app/models/concerns/search_seeds.rb
@@ -59,7 +59,8 @@ module SearchSeeds
       search('*', limit:,
                   where:    {
                     finished: false,
-                    tradable: true
+                    tradable: true,
+                    _or:      [{ plant_before: nil }, { plant_before: { lt: Date.today } }]
                   },
                   boost_by: [:created_at],
                   load:     false)

--- a/app/views/seeds/_card.html.haml
+++ b/app/views/seeds/_card.html.haml
@@ -16,14 +16,20 @@
       %p
         - if seed.quantity
           .badge.badge-info #{seed.quantity} seeds
-        - if seed.organic != 'unknown'
-          .badge.badge-success.seedtitle--organic= seed.organic
-        - if seed.gmo != 'unknown'
-          .badge.badge-success.seedtitle--gmo= seed.gmo
-        - if seed.heirloom != 'unknown'
-          .badge.badge-success.seedtitle--heirloom= seed.heirloom
-    - if seed.tradable
-      .card-footer
-        .d-flex.w-100.justify-content-between
+        %ul
+          - if seed.organic != 'unknown'
+            %li
+              %small.seedtitle--organic= seed.organic
+          - if seed.gmo != 'unknown'
+            %li
+              %small.seedtitle--gmo= seed.gmo
+          - if seed.heirloom != 'unknown'
+            %li
+              %small.seedtitle--heirloom= seed.heirloom
+
+    .card-footer
+      .d-flex.w-100.justify-content-between
+        - if seed.tradable
           %small Will trade #{seed.tradable_to}
-          / %a.btn.btn-sm{href: "#"} Request
+        - if seed.plant_before
+          %small Plant before #{seed.plant_before}

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -173,8 +173,8 @@ def load_test_users
         organic:         select_random_item(Seed::ORGANIC_VALUES),
         gmo:             select_random_item(['certified GMO-free', 'non-certified GMO-free', 'GMO', 'unknown']), # Strangely, this doesn't want to work as Seed:GMO_VALUES
         heirloom:        select_random_item(Seed::HEIRLOOM_VALUES),
-        parent_planting: @user.plantings.first.
-        finished:       false
+        parent_planting: @user.plantings.first,
+        finished:        false
       )
 
       photo = Photo.create!(

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -173,7 +173,8 @@ def load_test_users
         organic:         select_random_item(Seed::ORGANIC_VALUES),
         gmo:             select_random_item(['certified GMO-free', 'non-certified GMO-free', 'GMO', 'unknown']), # Strangely, this doesn't want to work as Seed:GMO_VALUES
         heirloom:        select_random_item(Seed::HEIRLOOM_VALUES),
-        parent_planting: @user.plantings.first
+        parent_planting: @user.plantings.first.
+        finished:       false
       )
 
       photo = Photo.create!(


### PR DESCRIPTION
Fix https://github.com/Growstuff/growstuff/issues/945

Card shows plant before:
<img width="320" height="587" alt="image" src="https://github.com/user-attachments/assets/5026c355-094d-4a5e-ab38-9902631705bb" />

Homepage excludes expired by default.
Fixed seeded data/seed creation to explicitly state finished is false.