### PR TITLE
Remove haml-lint-extractor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -178,7 +178,6 @@ group :development, :test do
   gem 'dotenv-rails'
 
   # cli utils
-  gem 'haml-i18n-extractor', require: false
   gem 'haml_lint', '>= 0.25.1', require: false # Checks haml files for goodness
   gem 'i18n-tasks', require: false # adds tests for finding missing and unused translations
   gem 'rspectre', require: false # finds unused code in specs

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -294,12 +294,6 @@ GEM
       temple (>= 0.8.2)
       thor
       tilt
-    haml-i18n-extractor (0.5.9)
-      activesupport
-      haml
-      highline
-      tilt
-      trollop (= 1.16.2)
     haml-rails (2.1.0)
       actionpack (>= 5.1)
       activesupport (>= 5.1)
@@ -701,7 +695,6 @@ GEM
     tilt (2.6.1)
     timecop (0.9.10)
     timeout (0.4.3)
-    trollop (1.16.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (3.1.5)
@@ -788,7 +781,6 @@ DEPENDENCIES
   gibbon (~> 1.2.0)
   gravatar-ultimate
   haml
-  haml-i18n-extractor
   haml-rails
   haml_lint (>= 0.25.1)
   hashie (>= 3.5.3)


### PR DESCRIPTION
```
@CloCkWeRX ➜ /workspaces/growstuff (90bd70603) $ haml-i18n-extractor app/views/activities/
You must choose either one of interactive mode or non interactive mode.
See haml-i18n-extractor --help below:

  haml-i18n-extractor --version # print version of this gem
  haml-i18n-extractor --help    # this message
  haml-i18n-extractor <path> [--interactive|--non-interactive]
[--other-options]

  See options list (short options available next to long option):
      --interactive, -i:   interactive mode
  --non-interactive, -n:   non interactive mode
    --yaml-file, -y <s>:   yaml file path, defaults to config/locales/en.yml
   --i18n-scope, -s <s>:   top level i18n scope, defaults to :en
@CloCkWeRX ➜ /workspaces/growstuff (90bd70603) $ haml-i18n-extractor -n app/views/activities/
overwrite-d file /workspaces/growstuff/app/views/activities/_actions.haml

/usr/local/rvm/gems/default/gems/haml-i18n-extractor-0.5.9/lib/haml-i18n-extractor/extraction/extractor.rb:167:in `validate_haml': uninitialized constant Haml::Options (NameError)

        parser = Haml::Parser.new(haml, Haml::Options.new)
                                            ^^^^^^^^^
Did you mean?  OptionParser
        from /usr/local/rvm/gems/default/gems/haml-i18n-extractor-0.5.9/lib/haml-i18n-extractor/extraction/extractor.rb:32:in `initialize'
        from /usr/local/rvm/gems/default/gems/haml-i18n-extractor-0.5.9/lib/haml-i18n-extractor/flow/workflow.rb:69:in `new'
        from /usr/local/rvm/gems/default/gems/haml-i18n-extractor-0.5.9/lib/haml-i18n-extractor/flow/workflow.rb:69:in `process'
        from /usr/local/rvm/gems/default/gems/haml-i18n-extractor-0.5.9/lib/haml-i18n-extractor/flow/workflow.rb:50:in `block in run'
        from /usr/local/rvm/gems/default/gems/haml-i18n-extractor-0.5.9/lib/haml-i18n-extractor/flow/workflow.rb:49:in `each'
        from /usr/local/rvm/gems/default/gems/haml-i18n-extractor-0.5.9/lib/haml-i18n-extractor/flow/workflow.rb:49:in `run'
        from /usr/local/rvm/gems/default/gems/haml-i18n-extractor-0.5.9/lib/haml-i18n-extractor/flow/cli.rb:44:in `start'
        from /usr/local/rvm/gems/default/gems/haml-i18n-extractor-0.5.9/bin/haml-i18n-extractor:18:in `<top (required)>'
        from /usr/local/rvm/gems/default/bin/haml-i18n-extractor:25:in `load'
        from /usr/local/rvm/gems/default/bin/haml-i18n-extractor:25:in `<main>'
```