### PR TITLE
Fix styling of cards to space evenly

### DIFF
--- a/app/assets/stylesheets/overrides.scss
+++ b/app/assets/stylesheets/overrides.scss
@@ -132,6 +132,8 @@ section {
     border-radius: 5%;
     margin: 0.5em 0.5em 0.5em 0;
     width: 200px;
+    align-items: stretch;
+    justify-content: space-between;
 
     .img-card {
       border-top-left-radius: 5%;


### PR DESCRIPTION
Before:
<img width="1742" height="857" alt="image" src="https://github.com/user-attachments/assets/88c5c59c-be95-4863-8fc9-8ae51e1e609f" />

AFter:
<img width="1457" height="960" alt="image" src="https://github.com/user-attachments/assets/6c9ff760-97f5-42c8-b434-2caaf1ac7039" />
