### PR TITLE
feat: Add prompts for new activities

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -32,6 +32,8 @@ class ActivitiesController < DataController
       owner: current_member,
       due_date: Date.today
     )
+    @activity.name = params[:name] if params[:name]
+    @activity.due_date = params[:due_date] if params[:due_date]
     if params[:garden_id]
       @activity.garden = Garden.find_by(
         owner: current_member,
@@ -63,7 +65,17 @@ class ActivitiesController < DataController
   end
 
   def update
-    @activity.update(activity_params)
+    if @activity.update(activity_params)
+      if activity_params[:finished].present?
+        link = new_activity_path(
+          name:        @activity.name,
+          garden_id:   @activity.garden_id,
+          planting_id: @activity.planting_id,
+          due_date:    2.weeks.from_now.to_date
+        )
+        flash[:notice] = t('activities.finished_prompt_html', link: link).html_safe
+      end
+    end
     respond_with @activity
   end
 

--- a/app/controllers/gardens_controller.rb
+++ b/app/controllers/gardens_controller.rb
@@ -38,7 +38,10 @@ class GardensController < DataController
 
   def create
     @garden.owner_id = current_member.id
-    flash[:notice] = I18n.t('gardens.created') if @garden.save
+    if @garden.save
+      link = new_activity_path(name: 'Weed the garden bed', garden_id: @garden.id, due_date: 2.weeks.from_now.to_date)
+      flash[:notice] = t('gardens.created_prompt_html', link: link).html_safe
+    end
     respond_with(@garden)
   end
 

--- a/app/controllers/plantings_controller.rb
+++ b/app/controllers/plantings_controller.rb
@@ -82,7 +82,12 @@ class PlantingsController < DataController
   end
 
   def update
-    @planting.update(planting_params)
+    if @planting.update(planting_params)
+      if planting_params[:finished].present? && @planting.garden.plantings.current.empty?
+        link = new_activity_path(name: 'Cultivate soil', garden_id: @planting.garden_id)
+        flash[:notice] = t('plantings.finished_prompt_html', link: link).html_safe
+      end
+    end
     respond_with @planting
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -125,6 +125,7 @@ en:
     updated: Garden was successfully updated.
     confirm_delete: All plantings associated with this garden will also be deleted. Are you sure?
     confirm_deactivate: All plantings associated with this garden will be marked as finished. Are you sure?
+    created_prompt_html: "Garden created. Would you like to <a href=\"%{link}\">plan to weed this garden bed in two weeks</a>?"
   harvests:
     created: Harvest was successfully created.
     harvest_something: Harvest something
@@ -301,6 +302,7 @@ en:
       finish_helper: >
         An activity is finished when you've completed it, or it's otherwise
         no longer possible.
+    finished_prompt_html: "Activity finished. Would you like to <a href=\"%{link}\">repeat this activity in two weeks</a>?"
   plantings:
     badges:
       days_until_finished: days until finished
@@ -325,6 +327,7 @@ en:
     string: "%{crop} planting in %{garden} by %{owner}"
     progress:
       progress_0_not_planted_yet: 'Progress: 0% - not planted yet'
+    finished_prompt_html: "Planting finished. Would you like to <a href=\"%{link}\">plan a soil cultivation activity</a>?"
   posts:
     write_blog_post: Write blog post
     index:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -327,7 +327,7 @@ en:
     string: "%{crop} planting in %{garden} by %{owner}"
     progress:
       progress_0_not_planted_yet: 'Progress: 0% - not planted yet'
-    finished_prompt_html: "Planting finished. Would you like to <a href=\"%{link}\">plan a soil cultivation activity</a>?"
+    finished_prompt_html: "Planting was successfully updated. Would you like to <a href=\"%{link}\">plan a soil cultivation activity</a>?"
   posts:
     write_blog_post: Write blog post
     index:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -125,7 +125,7 @@ en:
     updated: Garden was successfully updated.
     confirm_delete: All plantings associated with this garden will also be deleted. Are you sure?
     confirm_deactivate: All plantings associated with this garden will be marked as finished. Are you sure?
-    created_prompt_html: "Garden created. Would you like to <a href=\"%{link}\">plan to weed this garden bed in two weeks</a>?"
+    created_prompt_html: "Garden was successfully created. Would you like to <a href=\"%{link}\">plan to weed this garden bed in two weeks</a>?"
   harvests:
     created: Harvest was successfully created.
     harvest_something: Harvest something

--- a/spec/features/plantings/planting_a_crop_spec.rb
+++ b/spec/features/plantings/planting_a_crop_spec.rb
@@ -175,7 +175,7 @@ describe "Planting a crop", :js, :search do
       click_link "Edit"
       fill_in "Tell us more about it", with: "Some extra notes"
       click_button "Save"
-      expect(page).to have_content "planting was successfully updated"
+      expect(page).to have_content "Planting was successfully updated"
     end
 
     it "Editing a planting to fill in the finished date" do
@@ -187,7 +187,7 @@ describe "Planting a crop", :js, :search do
       check "finished"
       fill_in "Finished date", with: "2015-06-25"
       click_button "Save"
-      expect(page).to have_content "planting was successfully updated"
+      expect(page).to have_content "Planting was successfully updated"
       expect(page).to have_content "Finished"
     end
 

--- a/spec/features/plantings/planting_a_crop_spec.rb
+++ b/spec/features/plantings/planting_a_crop_spec.rb
@@ -175,7 +175,7 @@ describe "Planting a crop", :js, :search do
       click_link "Edit"
       fill_in "Tell us more about it", with: "Some extra notes"
       click_button "Save"
-      expect(page).to have_content "Planting was successfully updated"
+      expect(page).to have_content "planting was successfully updated"
     end
 
     it "Editing a planting to fill in the finished date" do


### PR DESCRIPTION
This commit introduces three new prompts to the application to suggest relevant follow-up activities to the user.

- When a user finishes the last planting in a garden, they are prompted to create a new activity for soil cultivation.
- When a user creates a new garden, they are prompted to plan a weeding activity for two weeks in the future.
- When a user marks an activity as finished, they are prompted to repeat the activity in two weeks.

These prompts are displayed as flash messages and include links to pre-filled forms for the new activities.