### PR TITLE
Add "mark as failed" action to crop view

### DIFF
--- a/app/views/crops/_actions.html.haml
+++ b/app/views/crops/_actions.html.haml
@@ -1,6 +1,9 @@
 - if crop.approved? && signed_in?
+  - active_plantings = current_member.plantings.where(crop: crop).active
 
   .btn-group.crop-actions{"aria-label" => "Crop Actions", role: "group"}
     = render 'plantings/modal', planting: Planting.new(crop: crop, owner: current_member)
     = render 'harvests/modal', harvest: Harvest.new(crop: @crop,  owner: current_member)
     = render 'seeds/modal', seed: Seed.new(crop: @crop,  owner: current_member)
+    - if active_plantings.any?
+      = render 'plantings/failed_modal', crop: crop, active_plantings: active_plantings

--- a/app/views/crops/_plantings.html.haml
+++ b/app/views/crops/_plantings.html.haml
@@ -8,6 +8,8 @@
           = link_to planting_path(planting), class: 'card-link' do
             = planting_icon
             = planting
+          - if can?(:edit, planting)
+            .float-right= render 'plantings/actions', planting: planting
           .float-right= render 'members/location', member: planting.owner
   .card-footer
     - if crop.approved?

--- a/app/views/plantings/_failed_modal.html.haml
+++ b/app/views/plantings/_failed_modal.html.haml
@@ -1,0 +1,26 @@
+#modelFailedPlantingForm.modal.fade{"aria-hidden" => "true", "aria-labelledby" => "failed-planting-button", role: "dialog", tabindex: "-1"}
+  .modal-dialog{role: "document"}
+    .modal-content
+      .modal-header.text-center
+        %h4.modal-title.w-100.font-weight-bold Mark #{crop.name} planting as failed
+        %button.close{"aria-label" => "Close", "data-bs-dismiss" => "modal", type: "button"}
+          %span{"aria-hidden" => "true"} &#215;
+      .modal-body
+        %p Which planting would you like to mark as failed?
+
+        %ul.list-group
+          - active_plantings.each do |planting|
+            %li.list-group-item
+              = link_to planting_path(planting, planting: {failed: 1}), method: :put do
+                .d-flex.justify-content-between
+                  %span
+                    %h4= planting.garden.name
+                    %p Planted #{planting.planted_at}
+                  %span
+                    = finished_icon
+        .mt-3.text-right
+          = link_to 'cancel', '', "data-bs-dismiss" => "modal", class: 'btn btn-secondary'
+
+%a.btn#failed-planting-button{"data-bs-target" => "#modelFailedPlantingForm", "data-bs-toggle" => "modal", href: ""}
+  = finished_icon
+  Mark as failed


### PR DESCRIPTION
Ensure the "mark as failed" option is available as an action for a planting when viewing a crop. Added a selection modal for multiple plantings and direct actions in the plantings list.

---
*PR created automatically by Jules for task [13853484652230549508](https://jules.google.com/task/13853484652230549508) started by @CloCkWeRX*