### PR TITLE
Decrease failures by checking for the save message first in admin tests

### DIFF
--- a/spec/features/admin/forums_spec.rb
+++ b/spec/features/admin/forums_spec.rb
@@ -29,8 +29,10 @@ describe "forums", :js do
       click_button 'Save'
     end
 
-    it { expect(page).to have_current_path forum_path(Forum.last), ignore_query: true }
-    it { expect(page).to have_content 'Forum was successfully created' }
+    it 'saves' do
+      expect(page).to have_content 'Forum was successfully created'
+      expect(page).to have_current_path forum_path(Forum.last), ignore_query: true
+    end
   end
 
   describe 'editing forum' do

--- a/spec/features/admin/plant_parts_spec.rb
+++ b/spec/features/admin/plant_parts_spec.rb
@@ -28,8 +28,10 @@ describe "plant parts", :js do
       click_button 'Save'
     end
 
-    it { expect(page).to have_current_path plant_part_path(PlantPart.last), ignore_query: true }
-    it { expect(page).to have_content 'Plant part was successfully created' }
+    it 'saves' do
+      expect(page).to have_content 'Plant part was successfully created'
+      expect(page).to have_current_path plant_part_path(PlantPart.last), ignore_query: true
+    end
   end
 
   describe 'editing plant part' do


### PR DESCRIPTION
These two keep being flaky.
```
rspec ./spec/features/admin/plant_parts_spec.rb:31 # plant parts adding a plant part is expected to have current path "/plant_parts/new"
rspec ./spec/features/admin/forums_spec.rb:32 # forums adding a forum is expected to have current path "/forums/new"
```
If CI runs too quickly, Capybara can apparently not get the right last record, as it's not written fully yet.

