### PR TITLE
Refactor existing username signup spec

### DIFF
--- a/spec/features/signup_spec.rb
+++ b/spec/features/signup_spec.rb
@@ -16,22 +16,15 @@ describe "signup" do
   end
 
   it "sign up for new account with existing username" do
-    visit crops_path # something other than front page, which has multiple signup links
-    click_link 'Sign up'
+    create(:member, login_name: 'person123')
+    visit new_member_registration_path
     fill_in 'Login name', with: 'person123'
-    fill_in 'Email', with: 'gardener@example.com'
+    fill_in 'Email', with: 'gardener2@example.com'
     fill_in 'Password', with: 'abc123'
     fill_in 'Password confirmation', with: 'abc123'
     check 'member_tos_agreement'
     click_button 'Sign up'
-    expect(page).to have_current_path root_path, ignore_query: true
-    first('.signup a').click # click the 'Sign up' button in the middle of the page
-    fill_in 'Login name', with: 'person123'
-    fill_in 'Email', with: 'gardener@example.com'
-    fill_in 'Password', with: 'abc123'
-    fill_in 'Password confirmation', with: 'abc123'
-    check 'member_tos_agreement'
-    click_button 'Sign up'
+    expect(page).to have_content 'has already been taken'
   end
 
   it "sign up for new account without accepting TOS" do


### PR DESCRIPTION
I have refactored the signup feature test in `spec/features/signup_spec.rb` as requested. The test now sets up the existing user directly in the database using FactoryBot and navigates directly to the signup route using Rails helpers, rather than relying on UI interactions for setup. I also added an assertion to verify that the validation error for an existing username is correctly displayed.

---
*PR created automatically by Jules for task [10681697950343780211](https://jules.google.com/task/10681697950343780211) started by @CloCkWeRX*