### PR TITLE
Fix RSpec/IndexedLet RuboCop issues in spec files

### DIFF
--- a/spec/controllers/harvests_controller_spec.rb
+++ b/spec/controllers/harvests_controller_spec.rb
@@ -15,12 +15,12 @@ describe HarvestsController, :search do
   end
 
   describe "GET index" do
-    let!(:member1)  { create(:member)                                            }
-    let(:member2)   { create(:member)                                            }
-    let(:tomato)    { create(:tomato)                                            }
-    let(:maize)     { create(:maize)                                             }
-    let!(:harvest1) { create(:harvest, owner_id: member1.id, crop_id: tomato.id) }
-    let!(:harvest2) { create(:harvest, owner_id: member2.id, crop_id: maize.id)  }
+    let!(:first_member)     { create(:member)                                                  }
+    let(:second_member)     { create(:member)                                                  }
+    let(:tomato)            { create(:tomato)                                                  }
+    let(:maize)             { create(:maize)                                                   }
+    let!(:tomato_harvest)   { create(:harvest, owner_id: first_member.id, crop_id: tomato.id)  }
+    let!(:maize_harvest)    { create(:harvest, owner_id: second_member.id, crop_id: maize.id)  }
 
     before { Harvest.reindex }
 
@@ -28,16 +28,16 @@ describe HarvestsController, :search do
       before { get :index, params: {} }
 
       it { expect(assigns(:harvests).size).to eq 2 }
-      it { expect(assigns(:harvests)[0].slug).to eq harvest1.slug }
-      it { expect(assigns(:harvests)[1].slug).to eq harvest2.slug }
+      it { expect(assigns(:harvests)[0].slug).to eq tomato_harvest.slug }
+      it { expect(assigns(:harvests)[1].slug).to eq maize_harvest.slug }
     end
 
     describe "picks up owner from params and shows owner's harvests only" do
-      before { get :index, params: { member_slug: member1.slug } }
+      before { get :index, params: { member_slug: first_member.slug } }
 
-      it { expect(assigns(:owner)).to eq member1 }
+      it { expect(assigns(:owner)).to eq first_member }
       it { expect(assigns(:harvests).size).to eq 1 }
-      it { expect(assigns(:harvests)[0].slug).to eq harvest1.slug }
+      it { expect(assigns(:harvests)[0].slug).to eq tomato_harvest.slug }
     end
 
     describe "picks up crop from params and shows the harvests for the crop only" do
@@ -45,7 +45,7 @@ describe HarvestsController, :search do
 
       it { expect(assigns(:crop)).to eq maize }
       it { expect(assigns(:harvests).size).to eq 1 }
-      it { expect(assigns(:harvests)[0].slug).to eq harvest2.slug }
+      it { expect(assigns(:harvests)[0].slug).to eq maize_harvest.slug }
     end
 
     describe "generates a csv" do

--- a/spec/controllers/plantings_controller_spec.rb
+++ b/spec/controllers/plantings_controller_spec.rb
@@ -13,12 +13,12 @@ describe PlantingsController, :search do
   end
 
   describe "GET index", :search do
-    let!(:member1)   { create(:member)                                                       }
-    let!(:member2)   { create(:member)                                                       }
-    let!(:tomato)    { create(:tomato)                                                       }
-    let!(:maize)     { create(:maize)                                                        }
-    let!(:planting1) { create(:planting, crop: tomato, owner: member1, created_at: 1.day.ago) }
-    let!(:planting2) { create(:planting, crop: maize, owner: member2, created_at: 5.days.ago) }
+    let!(:first_member)      { create(:member)                                                       }
+    let!(:second_member)     { create(:member)                                                       }
+    let!(:tomato)            { create(:tomato)                                                       }
+    let!(:maize)             { create(:maize)                                                        }
+    let!(:tomato_planting)   { create(:planting, crop: tomato, owner: first_member, created_at: 1.day.ago) }
+    let!(:maize_planting)    { create(:planting, crop: maize, owner: second_member, created_at: 5.days.ago) }
 
     before do
       Planting.reindex
@@ -28,23 +28,23 @@ describe PlantingsController, :search do
       before { get :index }
 
       it { expect(assigns(:plantings).size).to eq 2 }
-      it { expect(assigns(:plantings)[0]['slug']).to eq planting1.slug }
-      it { expect(assigns(:plantings)[1]['slug']).to eq planting2.slug }
+      it { expect(assigns(:plantings)[0]['slug']).to eq tomato_planting.slug }
+      it { expect(assigns(:plantings)[1]['slug']).to eq maize_planting.slug }
     end
 
     describe "picks up owner from params and shows owner's plantings only" do
-      before { get :index, params: { member_slug: member1.slug } }
+      before { get :index, params: { member_slug: first_member.slug } }
 
-      it { expect(assigns(:owner)).to eq member1 }
+      it { expect(assigns(:owner)).to eq first_member }
       it { expect(assigns(:plantings).size).to eq 1 }
-      it { expect(assigns(:plantings).first['slug']).to eq planting1.slug }
+      it { expect(assigns(:plantings).first['slug']).to eq tomato_planting.slug }
     end
 
     describe "picks up crop from params and shows the plantings for the crop only" do
       before { get :index, params: { crop_slug: maize.slug } }
 
       it { expect(assigns(:crop)).to eq maize }
-      it { expect(assigns(:plantings).first['slug']).to eq planting2.slug }
+      it { expect(assigns(:plantings).first['slug']).to eq maize_planting.slug }
     end
   end
 

--- a/spec/features/crops/crop_photos_spec.rb
+++ b/spec/features/crops/crop_photos_spec.rb
@@ -15,20 +15,20 @@ describe "crop detail page", :js, :search do
   let!(:planting) { create(:planting, crop:, owner: owner_member) }
   let!(:seed)     { create(:seed, crop:, owner: owner_member)     }
 
-  let!(:photo1) { create(:photo, owner: owner_member) }
-  let!(:photo2) { create(:photo, owner: owner_member) }
-  let!(:photo3) { create(:photo, owner: owner_member) }
-  let!(:photo4) { create(:photo, owner: owner_member) }
-  let!(:photo5) { create(:photo, owner: owner_member) }
-  let!(:photo6) { create(:photo, owner: owner_member) }
+  let!(:first_planting_photo)  { create(:photo, owner: owner_member) }
+  let!(:second_planting_photo) { create(:photo, owner: owner_member) }
+  let!(:first_harvest_photo)   { create(:photo, owner: owner_member) }
+  let!(:second_harvest_photo)  { create(:photo, owner: owner_member) }
+  let!(:first_seed_photo)      { create(:photo, owner: owner_member) }
+  let!(:second_seed_photo)     { create(:photo, owner: owner_member) }
 
   before do
-    planting.photos << photo1
-    planting.photos << photo2
-    harvest.photos << photo3
-    harvest.photos << photo4
-    seed.photos << photo5
-    seed.photos << photo6
+    planting.photos << first_planting_photo
+    planting.photos << second_planting_photo
+    harvest.photos << first_harvest_photo
+    harvest.photos << second_harvest_photo
+    seed.photos << first_seed_photo
+    seed.photos << second_seed_photo
     Crop.reindex
     visit crop_path(crop)
     expect(crop.photos.count).to eq 6
@@ -38,18 +38,18 @@ describe "crop detail page", :js, :search do
 
   shared_examples "shows photos" do
     describe "show planting photos" do
-      it { is_expected.to have_xpath("//img[contains(@src,'#{photo1.fullsize_url}')]") }
-      it { is_expected.to have_xpath("//img[contains(@src,'#{photo2.fullsize_url}')]") }
+      it { is_expected.to have_xpath("//img[contains(@src,'#{first_planting_photo.fullsize_url}')]") }
+      it { is_expected.to have_xpath("//img[contains(@src,'#{second_planting_photo.fullsize_url}')]") }
     end
 
     describe "show harvest photos" do
-      it { is_expected.to have_xpath("//img[contains(@src,'#{photo3.fullsize_url}')]") }
-      it { is_expected.to have_xpath("//img[contains(@src,'#{photo4.fullsize_url}')]") }
+      it { is_expected.to have_xpath("//img[contains(@src,'#{first_harvest_photo.fullsize_url}')]") }
+      it { is_expected.to have_xpath("//img[contains(@src,'#{second_harvest_photo.fullsize_url}')]") }
     end
 
     describe "show seed photos" do
-      it { is_expected.to have_xpath("//img[contains(@src,'#{photo5.fullsize_url}')]") }
-      it { is_expected.to have_xpath("//img[contains(@src,'#{photo6.fullsize_url}')]") }
+      it { is_expected.to have_xpath("//img[contains(@src,'#{first_seed_photo.fullsize_url}')]") }
+      it { is_expected.to have_xpath("//img[contains(@src,'#{second_seed_photo.fullsize_url}')]") }
     end
 
     describe "link to more photos" do

--- a/spec/features/members/list_spec.rb
+++ b/spec/features/members/list_spec.rb
@@ -6,9 +6,9 @@ describe "members list" do
   context "list all members" do
     subject { page.all("#maincontainer h4.login-name") }
 
-    let!(:member1) { create(:member, login_name: "Archaeopteryx", confirmed_at: Time.zone.parse('2013-02-10')) }
-    let!(:member2) { create(:member, login_name: "Zephyrosaurus", confirmed_at: Time.zone.parse('2014-01-11')) }
-    let!(:member3) { create(:member, login_name: "Testingname", confirmed_at: Time.zone.parse('2014-05-09'))   }
+    let!(:archaeopteryx) { create(:member, login_name: "Archaeopteryx", confirmed_at: Time.zone.parse('2013-02-10')) }
+    let!(:zephyrosaurus) { create(:member, login_name: "Zephyrosaurus", confirmed_at: Time.zone.parse('2014-01-11')) }
+    let!(:testingname)   { create(:member, login_name: "Testingname", confirmed_at: Time.zone.parse('2014-05-09'))   }
 
     before do
       visit members_path
@@ -18,15 +18,15 @@ describe "members list" do
 
     it "default alphabetical sort" do
       click_button('Show')
-      expect(subject.first).to have_text member1.login_name
-      expect(subject.last).to have_text member2.login_name
+      expect(subject.first).to have_text archaeopteryx.login_name
+      expect(subject.last).to have_text zephyrosaurus.login_name
     end
 
     it "recently joined sort" do
       select("recently", from: 'sort')
       click_button('Show')
-      expect(subject.first).to have_text member3.login_name
-      expect(subject.last).to have_text member1.login_name
+      expect(subject.first).to have_text testingname.login_name
+      expect(subject.last).to have_text archaeopteryx.login_name
     end
   end
 end

--- a/spec/features/members/profile_spec.rb
+++ b/spec/features/members/profile_spec.rb
@@ -118,15 +118,15 @@ describe "member profile", :js do
     end
 
     context 'member has activities' do
-      let!(:activity) { create(:activity, owner: member, due_date: 3.days.ago) }
-      let!(:activity2) { create(:activity, :planting, owner: member) }
-      let!(:activity3) { create(:activity, :garden, owner: member) }
+      let!(:past_activity) { create(:activity, owner: member, due_date: 3.days.ago) }
+      let!(:planting_activity) { create(:activity, :planting, owner: member) }
+      let!(:garden_activity) { create(:activity, :garden, owner: member) }
 
       before { visit member_path(member) }
 
-      it { expect(page).to have_link href: activity_path(activity) }
-      it { expect(page).to have_link href: activity_path(activity2) }
-      it { expect(page).to have_link href: activity_path(activity3) }
+      it { expect(page).to have_link href: activity_path(past_activity) }
+      it { expect(page).to have_link href: activity_path(planting_activity) }
+      it { expect(page).to have_link href: activity_path(garden_activity) }
     end
 
     context 'member has seeds' do

--- a/spec/features/percy/percy_spec.rb
+++ b/spec/features/percy/percy_spec.rb
@@ -17,7 +17,7 @@ describe 'Test with visual testing', :js do
   let(:admin_gravatar) { 'https://secure.gravatar.com/avatar/622db62c7beab8d5d8b7a80aa6385b2f?size=150&default=identicon' }
   let(:someone_else_gravatar) { 'https://secure.gravatar.com/avatar/7fd767571ff5ceefc7a687a543b2c402?size=150&default=identicon' }
 
-  let!(:tomato)   { create(:tomato, creator: someone_else) }
+  let!(:tomato) { create(:tomato, creator: someone_else) }
   let(:plant_part) { create(:plant_part, name: 'fruit') }
 
   let(:tomato_photo) do

--- a/spec/features/percy/percy_spec.rb
+++ b/spec/features/percy/percy_spec.rb
@@ -7,15 +7,15 @@ describe 'Test with visual testing', :js do
   # on every run, so doesn't trigger percy to see changes
   before { Faker::Config.random = Random.new(42) }
 
-  let!(:member)        { create(:member, login_name: 'percy', preferred_avatar_uri: gravatar) }
-  let!(:crop_wrangler) { create(:crop_wrangling_member, login_name: 'croppy', preferred_avatar_uri: gravatar2) }
-  let!(:admin_user) { create(:admin_member, login_name: 'janitor', preferred_avatar_uri: gravatar3) }
-  let!(:someone_else) { create(:edinburgh_member, login_name: 'ruby', preferred_avatar_uri: gravatar4) }
+  let!(:member)        { create(:member, login_name: 'percy', preferred_avatar_uri: member_gravatar) }
+  let!(:crop_wrangler) { create(:crop_wrangling_member, login_name: 'croppy', preferred_avatar_uri: crop_wrangler_gravatar) }
+  let!(:admin_user) { create(:admin_member, login_name: 'janitor', preferred_avatar_uri: admin_gravatar) }
+  let!(:someone_else) { create(:edinburgh_member, login_name: 'ruby', preferred_avatar_uri: someone_else_gravatar) }
 
-  let(:gravatar) { 'https://secure.gravatar.com/avatar/d021434aac03a7f7c7c0de60d07dad1c?size=150&default=identicon' }
-  let(:gravatar2) { 'https://secure.gravatar.com/avatar/353d83d3677b142520987e1936fd093c?size=150&default=identicon' }
-  let(:gravatar3) { 'https://secure.gravatar.com/avatar/622db62c7beab8d5d8b7a80aa6385b2f?size=150&default=identicon' }
-  let(:gravatar4) { 'https://secure.gravatar.com/avatar/7fd767571ff5ceefc7a687a543b2c402?size=150&default=identicon' }
+  let(:member_gravatar) { 'https://secure.gravatar.com/avatar/d021434aac03a7f7c7c0de60d07dad1c?size=150&default=identicon' }
+  let(:crop_wrangler_gravatar) { 'https://secure.gravatar.com/avatar/353d83d3677b142520987e1936fd093c?size=150&default=identicon' }
+  let(:admin_gravatar) { 'https://secure.gravatar.com/avatar/622db62c7beab8d5d8b7a80aa6385b2f?size=150&default=identicon' }
+  let(:someone_else_gravatar) { 'https://secure.gravatar.com/avatar/7fd767571ff5ceefc7a687a543b2c402?size=150&default=identicon' }
 
   let!(:tomato)   { create(:tomato, creator: someone_else) }
   let(:plant_part) { create(:plant_part, name: 'fruit') }

--- a/spec/features/planting_reminder_spec.rb
+++ b/spec/features/planting_reminder_spec.rb
@@ -30,13 +30,13 @@ describe "Planting reminder email", :js do
   context "when member has some plantings" do
     # Bangs are used on the following 2 let blocks in order to ensure that the plantings are present
     # in the database before the email is generated: otherwise, they won't be present in the email.
-    let!(:p1) { create(:predictable_planting, planted_at: 10.days.ago, garden: member.gardens.first, owner: member) }
-    let!(:p2) { create(:predictable_planting, planted_at: 30.days.ago, garden: member.gardens.first, owner: member) }
+    let!(:recent_planting) { create(:predictable_planting, planted_at: 10.days.ago, garden: member.gardens.first, owner: member) }
+    let!(:older_planting)  { create(:predictable_planting, planted_at: 30.days.ago, garden: member.gardens.first, owner: member) }
 
     describe "lists plantings" do
       it { expect(mail).to have_content "Progress report" }
-      it { expect(mail).to have_link p1.crop.to_s, href: planting_url(p1) }
-      it { expect(mail).to have_link p2.crop.to_s, href: planting_url(p2) }
+      it { expect(mail).to have_link recent_planting.crop.to_s, href: planting_url(recent_planting) }
+      it { expect(mail).to have_link older_planting.crop.to_s, href: planting_url(older_planting) }
       it { expect(mail).to have_content "keep your garden records up to date" }
     end
   end
@@ -50,15 +50,15 @@ describe "Planting reminder email", :js do
   context "when member has some harvests" do
     # Bangs are used on the following 2 let blocks in order to ensure that the plantings are present
     # in the database before the spec is run.
-    let!(:p1) { create(:predictable_planting, garden: member.gardens.first, owner: member, planted_at: 20.days.ago) }
-    let!(:p2) { create(:predictable_planting, garden: member.gardens.first, owner: member) }
-    let!(:h1) { create(:harvest, owner: member, planting: p1, harvested_at: 1.day.ago) }
-    let!(:h2) { create(:harvest, owner: member, planting: p2, harvested_at: 3.days.ago) }
+    let!(:recent_planting) { create(:predictable_planting, garden: member.gardens.first, owner: member, planted_at: 20.days.ago) }
+    let!(:older_planting)  { create(:predictable_planting, garden: member.gardens.first, owner: member) }
+    let!(:recent_harvest)  { create(:harvest, owner: member, planting: recent_planting, harvested_at: 1.day.ago) }
+    let!(:older_harvest)   { create(:harvest, owner: member, planting: older_planting, harvested_at: 3.days.ago) }
 
     describe "lists planting that are ready for harvest" do
       it { expect(mail).to have_content "Ready to harvest" }
-      it { expect(mail).to have_link p1.crop.name, href: planting_url(p1) }
-      it { expect(mail).to have_link p2.crop.name, href: planting_url(p2) }
+      it { expect(mail).to have_link recent_planting.crop.name, href: planting_url(recent_planting) }
+      it { expect(mail).to have_link older_planting.crop.name, href: planting_url(older_planting) }
       it { expect(mail).to have_content "Harvested anything lately?" }
     end
   end

--- a/spec/features/timeline/index_spec.rb
+++ b/spec/features/timeline/index_spec.rb
@@ -4,23 +4,23 @@ require 'rails_helper'
 
 describe "timeline", :js do
   let(:member) { create(:member) }
-  let(:friend1) { create(:member) }
-  let(:friend2) { create(:member) }
+  let(:planting_friend) { create(:member) }
+  let(:post_friend) { create(:member) }
 
   before do
-    member.followed << friend1
-    member.followed << friend2
+    member.followed << planting_friend
+    member.followed << post_friend
   end
 
   describe 'visit timeline' do
-    let!(:friend_planting) { create(:planting, owner: friend1, planted_at: 1.day.ago) }
-    let!(:friend_harvest) { create(:planting, owner: friend2, planted_at: 3.years.ago) }
-    let!(:finished_planting) { create(:finished_planting, owner: friend1) }
-    let!(:no_planted_at_planting) { create(:planting, owner: friend2, planted_at: nil) }
-    let!(:friend_photo) { create(:photo, owner: friend1) }
-    let!(:friend_post) { create(:post, author: friend2) }
-    let!(:liked_post) { create(:like, likeable: friend_photo, member: friend2) }
-    let!(:liked_photo) { create(:like, likeable: friend_post, member: friend1) }
+    let!(:friend_planting) { create(:planting, owner: planting_friend, planted_at: 1.day.ago) }
+    let!(:friend_harvest) { create(:planting, owner: post_friend, planted_at: 3.years.ago) }
+    let!(:finished_planting) { create(:finished_planting, owner: planting_friend) }
+    let!(:no_planted_at_planting) { create(:planting, owner: post_friend, planted_at: nil) }
+    let!(:friend_photo) { create(:photo, owner: planting_friend) }
+    let!(:friend_post) { create(:post, author: post_friend) }
+    let!(:liked_post) { create(:like, likeable: friend_photo, member: post_friend) }
+    let!(:liked_photo) { create(:like, likeable: friend_post, member: planting_friend) }
 
     before do
       login_as(member)
@@ -37,8 +37,8 @@ describe "timeline", :js do
     end
 
     describe 'shows the friends you follow' do
-      it { expect(page).to have_link href: member_path(friend1) }
-      it { expect(page).to have_link href: member_path(friend2) }
+      it { expect(page).to have_link href: member_path(planting_friend) }
+      it { expect(page).to have_link href: member_path(post_friend) }
     end
   end
 end

--- a/spec/models/crop_spec.rb
+++ b/spec/models/crop_spec.rb
@@ -297,54 +297,54 @@ describe Crop do
     subject { described_class.interesting }
 
     # first, a couple of candidate crops
-    let(:crop1) { create(:crop) }
-    let(:crop2) { create(:crop) }
+    let(:first_crop) { create(:crop) }
+    let(:second_crop) { create(:crop) }
 
-    let(:crop1_planting) { crop1.plantings.first }
-    let(:crop2_planting) { crop2.plantings.first }
+    let(:first_crop_planting) { first_crop.plantings.first }
+    let(:second_crop_planting) { second_crop.plantings.first }
 
     let(:member) { create(:member, login_name: 'pikachu') }
 
     describe 'lists interesting crops' do
       before do
         # they need 3+ plantings each to be interesting
-        create_list(:planting, 3, crop: crop1, owner: member)
-        create_list(:planting, 3, crop: crop2, owner: member)
+        create_list(:planting, 3, crop: first_crop, owner: member)
+        create_list(:planting, 3, crop: second_crop, owner: member)
         # crops need 3+ photos to be interesting
-        crop1_planting.photos = create_list :photo, 3, owner: member
-        crop2_planting.photos = create_list :photo, 3, owner: member
+        first_crop_planting.photos = create_list :photo, 3, owner: member
+        second_crop_planting.photos = create_list :photo, 3, owner: member
       end
 
-      it { is_expected.to include crop1 }
-      it { is_expected.to include crop2 }
+      it { is_expected.to include first_crop }
+      it { is_expected.to include second_crop }
       it { expect(subject.size).to eq 2 }
     end
 
     describe 'crops without plantings are not interesting' do
       before do
-        # only crop1 has plantings
-        create_list(:planting, 3, crop: crop1, owner: member)
+        # only first_crop has plantings
+        create_list(:planting, 3, crop: first_crop, owner: member)
         # ... and photos
-        crop1_planting.photos = create_list(:photo, 3, owner: member)
+        first_crop_planting.photos = create_list(:photo, 3, owner: member)
       end
 
-      it { is_expected.to include crop1 }
-      it { is_expected.not_to include crop2 }
+      it { is_expected.to include first_crop }
+      it { is_expected.not_to include second_crop }
       it { expect(subject.size).to eq 1 }
     end
 
     describe 'crops without photos are not interesting' do
       before do
         # both crops have plantings
-        create_list(:planting, 3, crop: crop1, owner: member)
-        create_list(:planting, 3, crop: crop2, owner: member)
+        create_list(:planting, 3, crop: first_crop, owner: member)
+        create_list(:planting, 3, crop: second_crop, owner: member)
 
-        # but only crop1 has photos
-        crop1_planting.photos = create_list(:photo, 3, owner: member)
+        # but only first_crop has photos
+        first_crop_planting.photos = create_list(:photo, 3, owner: member)
       end
 
-      it { is_expected.to include crop1 }
-      it { is_expected.not_to include crop2 }
+      it { is_expected.to include first_crop }
+      it { is_expected.not_to include second_crop }
       it { expect(subject.size).to eq 1 }
     end
   end

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -102,10 +102,10 @@ describe Member do
 
   context 'newsletter scope' do
     it 'finds newsletter recipients' do
-      member1 = create(:member)
-      member2 = create(:newsletter_recipient_member)
-      Member.wants_newsletter.should include member2
-      Member.wants_newsletter.should_not include member1
+      regular_member = create(:member)
+      newsletter_member = create(:newsletter_recipient_member)
+      Member.wants_newsletter.should include newsletter_member
+      Member.wants_newsletter.should_not include regular_member
     end
   end
 
@@ -299,31 +299,31 @@ describe Member do
   end
 
   context 'member who followed another member' do
-    let(:member1) { create(:member) }
-    let(:member2) { create(:member) }
-    let(:member3) { create(:member) }
+    let(:follower) { create(:member) }
+    let(:followed_member) { create(:member) }
+    let(:other_member) { create(:member) }
 
     before do
-      @follow = member1.follows.create(follower_id: member1.id, followed_id: member2.id)
+      @follow = follower.follows.create(follower_id: follower.id, followed_id: followed_member.id)
     end
 
     context 'already_following' do
       it 'detects that member is already following a member' do
-        expect(member1.already_following?(member2)).to be true
+        expect(follower.already_following?(followed_member)).to be true
       end
 
       it 'detects that member is not already following a member' do
-        expect(member1.already_following?(member3)).to be false
+        expect(follower.already_following?(other_member)).to be false
       end
     end
 
     context 'get_follow' do
       it 'gets the correct follow for a followed member' do
-        expect(member1.get_follow(member2).id).to eq @follow.id
+        expect(follower.get_follow(followed_member).id).to eq @follow.id
       end
 
       it 'returns nil for a member that is not followed' do
-        expect(member1.get_follow(member3)).to be_nil
+        expect(follower.get_follow(other_member)).to be_nil
       end
     end
   end

--- a/spec/views/forums/index.html.haml_spec.rb
+++ b/spec/views/forums/index.html.haml_spec.rb
@@ -4,17 +4,17 @@ require 'rails_helper'
 
 describe "forums/index" do
   let(:admin) { create(:admin_member) }
-  let(:forum1) { create(:forum) }
-  let(:forum2) { create(:forum) }
+  let(:first_forum) { create(:forum) }
+  let(:second_forum) { create(:forum) }
 
   before do
     controller.stub(:current_user) { admin }
-    assign(:forums, [forum1, forum2])
+    assign(:forums, [first_forum, second_forum])
   end
 
   it "renders a list of forums" do
     render
-    assert_select "h2", text: forum1.name, count: 2
+    assert_select "h2", text: first_forum.name, count: 2
   end
 
   it "doesn't display posts for empty forums" do
@@ -23,7 +23,7 @@ describe "forums/index" do
   end
 
   context "posts" do
-    let!(:post) { create(:forum_post, forum: forum1) }
+    let!(:post) { create(:forum_post, forum: first_forum) }
     let!(:comment) { create(:comment, commentable: post) }
 
     before { render }


### PR DESCRIPTION
Replaced indexed `let` variable names (e.g., `member1`, `p1`, `harvest2`) with descriptive names across 11 spec files to comply with the `RSpec/IndexedLet` RuboCop rule.

Changes include:
- Renaming `member1`/`member2` to `first_member`/`second_member` in controller specs.
- Renaming `photo1` through `photo6` to `first_planting_photo`, etc., in `crop_photos_spec.rb`.
- Renaming `p1`, `p2`, `h1`, `h2` to `recent_planting`, `older_harvest`, etc., in `planting_reminder_spec.rb`.
- Renaming `friend1`, `friend2` to `planting_friend`, `post_friend` in `timeline/index_spec.rb`.
- Using actual login names or roles for member variables where appropriate.

All references to renamed variables were updated accordingly. Manual verification using `grep` confirmed that no indexed `let` declarations remain in the modified files.

---
*PR created automatically by Jules for task [6723791317025255683](https://jules.google.com/task/6723791317025255683) started by @CloCkWeRX*