### PR TITLE
Fix failing member blocking specs by defining Block abilities

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -164,6 +164,12 @@ class Ability
     can :destroy, Follow
     cannot :destroy, Follow, followed_id: member.id # can't unfollow yourself
 
+    # blocking/unblocking permissions
+    can :create, Block
+    cannot :create, Block, blocked_id: member.id # can't block yourself
+
+    can :destroy, Block, blocker_id: member.id # can only unblock your own blocks
+
     cannot :create, GardenType
     cannot :update, GardenType
     cannot :destroy, GardenType


### PR DESCRIPTION
Fixed the failing member blocking specs by adding necessary Block permissions to the Ability model. Previously, the "Block" button was missing because the system didn't have authorization rules for the Block resource. The new rules allow members to block others (but not themselves) and to unblock their own blocks.

---
*PR created automatically by Jules for task [17694592103725719994](https://jules.google.com/task/17694592103725719994) started by @CloCkWeRX*