### PR TITLE
Update crop wrangling guide links to GitHub wiki

### DIFF
--- a/app/views/alternate_names/_form.html.haml
+++ b/app/views/alternate_names/_form.html.haml
@@ -16,7 +16,7 @@
       %p
         %span.help-block
           For detailed crop wrangling guidelines, please consult the
-          = link_to "crop wrangling guide", "http://wiki.growstuff.org/index.php/Crop_wrangling"
+          = link_to "crop wrangling guide", "https://github.com/Growstuff/growstuff/wiki/Crop-Wrangling"
           on the Growstuff wiki.
 
       .form-group

--- a/app/views/scientific_names/_form.html.haml
+++ b/app/views/scientific_names/_form.html.haml
@@ -11,7 +11,7 @@
   %p
     %span.help-block
       For detailed crop wrangling guidelines, please consult the
-      = link_to "crop wrangling guide", "http://wiki.growstuff.org/index.php/Crop_wrangling"
+      = link_to "crop wrangling guide", "https://github.com/Growstuff/growstuff/wiki/Crop-Wrangling"
       on the Growstuff wiki.
 
   .form-group


### PR DESCRIPTION
Fix #4350

This PR updates legacy links to the Growstuff wiki with the new GitHub wiki URLs for the "Crop Wrangling" guide.

Changes:
- Updated `app/views/scientific_names/_form.html.haml`
- Updated `app/views/alternate_names/_form.html.haml`

Verified that `app/views/crops/_form.html.haml` and its corresponding spec already point to the correct GitHub wiki URL.

---
*PR created automatically by Jules for task [4812587945321495224](https://jules.google.com/task/4812587945321495224) started by @CloCkWeRX*