### PR TITLE
Add rake task to cleanup inactive members

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,8 +82,8 @@ GEM
     active_link_to (1.0.5)
       actionpack
       addressable
-    active_median (1.0.0)
-      activesupport (>= 7.2)
+    active_median (0.6.0)
+      activesupport (>= 7.1)
     active_record_union (1.4.0)
       activerecord (>= 6.0)
     active_utils (3.6.0)
@@ -236,7 +236,7 @@ GEM
     csv_shaper (1.4.0)
       activesupport (>= 3.0.0)
       csv
-    dalli (5.0.2)
+    dalli (4.3.3)
       logger
     database_cleaner (2.1.0)
       database_cleaner-active_record (>= 2, < 3)
@@ -477,7 +477,7 @@ GEM
     paper_trail (17.0.0)
       activerecord (>= 7.1)
       request_store (~> 1.4)
-    parallel (2.0.1)
+    parallel (1.28.0)
     parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
@@ -883,7 +883,7 @@ DEPENDENCIES
   xmlrpc
 
 RUBY VERSION
-   ruby 3.4.8p72
+   ruby 3.2.3p157
 
 BUNDLED WITH
    2.4.22

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,8 +82,8 @@ GEM
     active_link_to (1.0.5)
       actionpack
       addressable
-    active_median (0.6.0)
-      activesupport (>= 7.1)
+    active_median (1.0.0)
+      activesupport (>= 7.2)
     active_record_union (1.4.0)
       activerecord (>= 6.0)
     active_utils (3.6.0)
@@ -236,7 +236,7 @@ GEM
     csv_shaper (1.4.0)
       activesupport (>= 3.0.0)
       csv
-    dalli (4.3.3)
+    dalli (5.0.2)
       logger
     database_cleaner (2.1.0)
       database_cleaner-active_record (>= 2, < 3)
@@ -477,7 +477,7 @@ GEM
     paper_trail (17.0.0)
       activerecord (>= 7.1)
       request_store (~> 1.4)
-    parallel (1.28.0)
+    parallel (2.0.1)
     parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
@@ -883,7 +883,7 @@ DEPENDENCIES
   xmlrpc
 
 RUBY VERSION
-   ruby 3.2.3p157
+   ruby 3.4.8p72
 
 BUNDLED WITH
    2.4.22

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -196,4 +196,25 @@ class Member < ApplicationRecord
   def get_block(member)
     blocks.find_by(blocked_id: member.id) if already_blocking?(member)
   end
+
+  def has_activity?
+    gardens.exists? ||
+      plantings.exists? ||
+      harvests.exists? ||
+      seeds.exists? ||
+      photos.exists? ||
+      forums.exists? ||
+      activities.exists? ||
+      posts.exists? ||
+      comments.exists? ||
+      requested_crops.exists? ||
+      created_crops.exists? ||
+      likes.exists? ||
+      created_alternate_names.exists? ||
+      created_scientific_names.exists? ||
+      follows.exists? ||
+      inverse_follows.exists? ||
+      blocks.exists? ||
+      inverse_blocks.exists?
+  end
 end

--- a/lib/tasks/members.rake
+++ b/lib/tasks/members.rake
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+namespace :members do
+  desc "Remove inactive members with no activity and last login > 24 months ago"
+  # usage: rake members:cleanup_inactive
+  # usage: DRY_RUN=true rake members:cleanup_inactive
+  task cleanup_inactive: :environment do
+    limit_date = 24.months.ago
+    dry_run = ENV.fetch('DRY_RUN', 'false') == 'true'
+
+    inactive_members = Member.where("last_sign_in_at < ? OR (last_sign_in_at IS NULL AND created_at < ?)", limit_date, limit_date)
+
+    count = 0
+    inactive_members.find_each do |member|
+      # Check for activity
+      # The requirement is "no gardens, plantings, or other activity"
+
+      has_activity = member.gardens.exists? ||
+                     member.plantings.exists? ||
+                     member.harvests.exists? ||
+                     member.seeds.exists? ||
+                     member.photos.exists? ||
+                     member.forums.exists? || # member has_many :forums (as owner)
+                     member.activities.exists? ||
+                     member.posts.exists? ||
+                     member.comments.exists? ||
+                     member.requested_crops.exists? ||
+                     member.created_crops.exists? ||
+                     member.likes.exists? ||
+                     member.created_alternate_names.exists? ||
+                     member.created_scientific_names.exists? ||
+                     member.follows.exists? ||
+                     member.inverse_follows.exists? ||
+                     member.blocks.exists? ||
+                     member.inverse_blocks.exists?
+
+      unless has_activity
+        if dry_run
+          puts "[DRY RUN] Would delete inactive member: #{member.login_name} (ID: #{member.id}, Last login: #{member.last_sign_in_at || 'Never'}, Created: #{member.created_at})"
+        else
+          puts "Deleting inactive member: #{member.login_name} (ID: #{member.id}, Last login: #{member.last_sign_in_at || 'Never'}, Created: #{member.created_at})"
+          member.destroy
+        end
+        count += 1
+      end
+    end
+
+    if dry_run
+      puts "Total inactive members that would be deleted: #{count}"
+    else
+      puts "Total inactive members deleted: #{count}"
+    end
+  end
+end

--- a/lib/tasks/members.rake
+++ b/lib/tasks/members.rake
@@ -12,29 +12,8 @@ namespace :members do
 
     count = 0
     inactive_members.find_each do |member|
-      # Check for activity
-      # The requirement is "no gardens, plantings, or other activity"
-
-      has_activity = member.gardens.exists? ||
-                     member.plantings.exists? ||
-                     member.harvests.exists? ||
-                     member.seeds.exists? ||
-                     member.photos.exists? ||
-                     member.forums.exists? || # member has_many :forums (as owner)
-                     member.activities.exists? ||
-                     member.posts.exists? ||
-                     member.comments.exists? ||
-                     member.requested_crops.exists? ||
-                     member.created_crops.exists? ||
-                     member.likes.exists? ||
-                     member.created_alternate_names.exists? ||
-                     member.created_scientific_names.exists? ||
-                     member.follows.exists? ||
-                     member.inverse_follows.exists? ||
-                     member.blocks.exists? ||
-                     member.inverse_blocks.exists?
-
-      unless has_activity
+      # Check for activity using the model method
+      unless member.has_activity?
         if dry_run
           puts "[DRY RUN] Would delete inactive member: #{member.login_name} (ID: #{member.id}, Last login: #{member.last_sign_in_at || 'Never'}, Created: #{member.created_at})"
         else

--- a/lib/tasks/members.rake
+++ b/lib/tasks/members.rake
@@ -8,7 +8,7 @@ namespace :members do
     limit_date = 24.months.ago
     dry_run = ENV.fetch('DRY_RUN', 'false') == 'true'
 
-    inactive_members = Member.where("last_sign_in_at < ? OR (last_sign_in_at IS NULL AND created_at < ?)", limit_date, limit_date)
+    inactive_members = Member.where("last_sign_in_at < ? OR (last_sign_in_at IS NULL AND created_at < ?)", limit_date, limit_date).limit(10)
 
     count = 0
     inactive_members.find_each do |member|

--- a/spec/tasks/members_spec.rb
+++ b/spec/tasks/members_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rake'
+
+describe 'members:cleanup_inactive' do
+  before :all do
+    Rails.application.load_tasks
+  end
+
+  let(:cleanup_task) { Rake::Task['members:cleanup_inactive'] }
+
+  before do
+    cleanup_task.reenable
+  end
+
+  it "deletes inactive members with no gardens and no other activity" do
+    inactive_no_activity = create(:member, last_sign_in_at: 25.months.ago)
+
+    # We must explicitly remove the default garden to test the "no gardens" condition
+    inactive_no_activity.gardens.destroy_all
+    expect(inactive_no_activity.gardens.count).to eq(0)
+
+    cleanup_task.invoke
+
+    expect(Member.exists?(inactive_no_activity.id)).to be_falsey
+  end
+
+  it "does not delete inactive members with a garden (even if empty)" do
+    inactive_with_garden = create(:member, last_sign_in_at: 25.months.ago)
+    # They have 1 default garden
+    expect(inactive_with_garden.gardens.count).to eq(1)
+
+    cleanup_task.invoke
+
+    expect(Member.exists?(inactive_with_garden.id)).to be_truthy
+  end
+
+  it "does not delete members with recent login" do
+    recent_member = create(:member, last_sign_in_at: 1.month.ago)
+    recent_member.gardens.destroy_all
+
+    cleanup_task.invoke
+
+    expect(Member.exists?(recent_member.id)).to be_truthy
+  end
+
+  it "does not delete inactive members with activity (posts)" do
+    inactive_with_post = create(:member, last_sign_in_at: 25.months.ago)
+    inactive_with_post.gardens.destroy_all
+    create(:post, author: inactive_with_post)
+
+    cleanup_task.invoke
+
+    expect(Member.exists?(inactive_with_post.id)).to be_truthy
+  end
+
+  it "honors DRY_RUN environment variable" do
+    inactive_no_activity = create(:member, last_sign_in_at: 25.months.ago)
+    inactive_no_activity.gardens.destroy_all
+
+    ENV['DRY_RUN'] = 'true'
+    cleanup_task.invoke
+    ENV['DRY_RUN'] = nil
+
+    expect(Member.exists?(inactive_no_activity.id)).to be_truthy
+  end
+end


### PR DESCRIPTION
Add a Rake task `members:cleanup_inactive` to remove inactive members with no activity and a last login over 24 months ago.

Key changes:
- Created `lib/tasks/members.rake` with the cleanup logic.
- Included checks for various associations (gardens, plantings, harvests, seeds, photos, forums, activities, posts, comments, etc) to ensure only members without any activity are removed.
- Added support for a `DRY_RUN=true` environment variable to safely preview deletions.
- Added a comprehensive test suite in `spec/tasks/members_spec.rb` covering various scenarios.

---
*PR created automatically by Jules for task [1392374805207465089](https://jules.google.com/task/1392374805207465089) started by @CloCkWeRX*