### PR TITLE
Delete inactive members with no activity in 3 years

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -198,7 +198,7 @@ class Member < ApplicationRecord
   end
 
   def has_activity?
-    gardens.exists? ||
+    (gardens.exists? && gardens.count > 1) ||
       plantings.exists? ||
       harvests.exists? ||
       seeds.exists? ||

--- a/lib/tasks/members.rake
+++ b/lib/tasks/members.rake
@@ -5,7 +5,7 @@ namespace :members do
   # usage: rake members:cleanup_inactive
   # usage: DRY_RUN=true rake members:cleanup_inactive
   task cleanup_inactive: :environment do
-    limit_date = 24.months.ago
+    limit_date = 3.years.ago
     dry_run = ENV.fetch('DRY_RUN', 'false') == 'true'
 
     inactive_members = Member.where("last_sign_in_at < ? OR (last_sign_in_at IS NULL AND created_at < ?)", limit_date, limit_date)

--- a/lib/tasks/members.rake
+++ b/lib/tasks/members.rake
@@ -8,7 +8,7 @@ namespace :members do
     limit_date = 24.months.ago
     dry_run = ENV.fetch('DRY_RUN', 'false') == 'true'
 
-    inactive_members = Member.where("last_sign_in_at < ? OR (last_sign_in_at IS NULL AND created_at < ?)", limit_date, limit_date).limit(10)
+    inactive_members = Member.where("last_sign_in_at < ? OR (last_sign_in_at IS NULL AND created_at < ?)", limit_date, limit_date).limit(100)
 
     count = 0
     inactive_members.find_each do |member|

--- a/lib/tasks/members.rake
+++ b/lib/tasks/members.rake
@@ -8,7 +8,7 @@ namespace :members do
     limit_date = 24.months.ago
     dry_run = ENV.fetch('DRY_RUN', 'false') == 'true'
 
-    inactive_members = Member.where("last_sign_in_at < ? OR (last_sign_in_at IS NULL AND created_at < ?)", limit_date, limit_date).limit(100)
+    inactive_members = Member.where("last_sign_in_at < ? OR (last_sign_in_at IS NULL AND created_at < ?)", limit_date, limit_date)
 
     count = 0
     inactive_members.find_each do |member|


### PR DESCRIPTION
1. Backup taken in heroku.
2. Manually run for now, but could be scheduled later.