### PR TITLE
Global Searchkick Settings for 0 Replicas

### DIFF
--- a/app/models/concerns/search_activities.rb
+++ b/app/models/concerns/search_activities.rb
@@ -5,7 +5,6 @@ module SearchActivities
 
   included do
     searchkick merge_mappings: true,
-               settings:       { number_of_shards: 1, number_of_replicas: 0 },
                mappings:       {
                  properties: {
                    active:     { type: :boolean },

--- a/app/models/concerns/search_crops.rb
+++ b/app/models/concerns/search_crops.rb
@@ -10,7 +10,6 @@ module SearchCrops
                searchable:     %i(name descriptions alternate_names scientific_names),
                case_sensitive: false,
                merge_mappings: true,
-               settings:       { number_of_shards: 1, number_of_replicas: 0 },
                mappings:       {
                  properties: {
                    created_at:      { type: :integer },

--- a/app/models/concerns/search_harvests.rb
+++ b/app/models/concerns/search_harvests.rb
@@ -5,7 +5,6 @@ module SearchHarvests
 
   included do
     searchkick merge_mappings: true,
-               settings:       { number_of_shards: 1, number_of_replicas: 0 },
                mappings:       {
                  properties: {
                    harvests_count: { type: :integer },

--- a/app/models/concerns/search_photos.rb
+++ b/app/models/concerns/search_photos.rb
@@ -5,7 +5,6 @@ module SearchPhotos
 
   included do
     searchkick merge_mappings: true,
-               settings:       { number_of_shards: 1, number_of_replicas: 0 },
                mappings:       {
                  properties: {
                    title:      { type: :text },

--- a/app/models/concerns/search_plantings.rb
+++ b/app/models/concerns/search_plantings.rb
@@ -5,7 +5,6 @@ module SearchPlantings
 
   included do
     searchkick merge_mappings: true,
-               settings:       { number_of_shards: 1, number_of_replicas: 0 },
                mappings:       {
                  properties: {
                    active:         { type: :boolean },

--- a/app/models/concerns/search_seeds.rb
+++ b/app/models/concerns/search_seeds.rb
@@ -5,7 +5,6 @@ module SearchSeeds
 
   included do
     searchkick merge_mappings: true,
-               settings:       { number_of_shards: 1, number_of_replicas: 0 },
                mappings:       {
                  properties: {
                    id:           { type: :integer },

--- a/config/initializers/searchkick.rb
+++ b/config/initializers/searchkick.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+Searchkick.model_options = {
+  settings: {
+    number_of_shards:   1,
+    number_of_replicas: 0
+  }
+}


### PR DESCRIPTION
Decreased the number of replicas for Elasticsearch shards to 0 by implementing a global Searchkick configuration and removing redundant per-model settings.

---
*PR created automatically by Jules for task [7327249159822857899](https://jules.google.com/task/7327249159822857899) started by @CloCkWeRX*

# Why?

Resource constraints. We don't really need 3x elastic search boxes to serve up the very small amount of data we have. It's higher risk to have no replicas, but we can always re-index.

Interestingly, this is not much of a significant change - the default settings for number of replicas have been ignored somewhere along the line.