### PR TITLE
Update member_slug lookup to 404 when not found

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -7,9 +7,9 @@ class ActivitiesController < DataController
     where = {}
     where['active'] = true unless @show_all
 
-    if params[:member_slug]
-      @owner = Member.find_by(slug: params[:member_slug])
-      where['owner_id'] = @owner.id unless @owner.nil?
+    if params[:member_slug].present?
+      @owner = Member.find_by!(slug: params[:member_slug])
+      where['owner_id'] = @owner.id
     end
 
     @activities = Activity.search(

--- a/app/controllers/gardens_controller.rb
+++ b/app/controllers/gardens_controller.rb
@@ -2,7 +2,7 @@
 
 class GardensController < DataController
   def index
-    @owner = Member.find_by(slug: params[:member_slug])
+    @owner = Member.find_by!(slug: params[:member_slug]) if params[:member_slug].present?
     @show_all = params[:all] == '1'
     @show_jump_to = params[:member_slug].present? || false
 

--- a/app/controllers/harvests_controller.rb
+++ b/app/controllers/harvests_controller.rb
@@ -5,8 +5,8 @@ class HarvestsController < DataController
 
   def index
     where = {}
-    if params[:member_slug]
-      @owner = Member.find_by(slug: params[:member_slug])
+    if params[:member_slug].present?
+      @owner = Member.find_by!(slug: params[:member_slug])
       where['owner_id'] = @owner.id
     end
 

--- a/app/controllers/plantings_controller.rb
+++ b/app/controllers/plantings_controller.rb
@@ -11,9 +11,9 @@ class PlantingsController < DataController
     where = {}
     where['active'] = true unless @show_all
 
-    if params[:member_slug]
-      @owner = Member.find_by(slug: params[:member_slug])
-      where['owner_id'] = @owner.id unless @owner.nil?
+    if params[:member_slug].present?
+      @owner = Member.find_by!(slug: params[:member_slug])
+      where['owner_id'] = @owner.id
     end
 
     if params[:crop_slug]

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -8,7 +8,7 @@ class PostsController < ApplicationController
   respond_to :rss, only: %i(index show)
 
   def index
-    @author = Member.find_by(slug: params[:member_slug])
+    @author = Member.find_by!(slug: params[:member_slug]) if params[:member_slug].present?
     @posts = posts
     respond_with(@posts)
   end

--- a/app/controllers/seeds_controller.rb
+++ b/app/controllers/seeds_controller.rb
@@ -5,7 +5,7 @@ class SeedsController < DataController
     where = {}
 
     if params[:member_slug].present?
-      @owner = Member.find_by(slug: params[:member_slug])
+      @owner = Member.find_by!(slug: params[:member_slug])
       where['owner_id'] = @owner.id
     end
 


### PR DESCRIPTION
Updated several controllers (Seeds, Activities, Posts, Plantings, Harvests, and Gardens) to use Member.find_by!(slug: params[:member_slug]) when params[:member_slug] is present. This ensures that an ActiveRecord::RecordNotFound exception is raised (leading to a 404 response) if an invalid slug is provided, while maintaining existing filtering behavior when a valid slug is found.

---
*PR created automatically by Jules for task [17599607196474746471](https://jules.google.com/task/17599607196474746471) started by @CloCkWeRX*