### PR TITLE
Improve Charts::CropsController caching

### DIFF
--- a/app/controllers/charts/crops_controller.rb
+++ b/app/controllers/charts/crops_controller.rb
@@ -3,6 +3,7 @@
 module Charts
   class CropsController < ApplicationController
     respond_to :json
+    before_action :set_crop
 
     def sunniness
       pie_chart_query 'sunniness'
@@ -13,7 +14,6 @@ module Charts
     end
 
     def harvested_for
-      @crop = Crop.find_by!(slug: params[:crop_slug])
       data = Rails.cache.fetch("#{@crop.cache_key_with_version}/harvested_for", expires_in: 1.day) do
         Harvest.joins(:plant_part)
           .where(crop: @crop)
@@ -24,12 +24,18 @@ module Charts
 
     private
 
-    def pie_chart_query(field)
+    def set_crop
       @crop = Crop.find_by!(slug: params[:crop_slug])
-      render json: Planting.where(crop: @crop)
-        .where.not(field.to_sym => nil)
-        .where.not(field.to_sym => '')
-        .group(field.to_sym).count(:id)
+    end
+
+    def pie_chart_query(field)
+      data = Rails.cache.fetch("#{@crop.cache_key_with_version}/#{field}", expires_in: 1.day) do
+        Planting.where(crop: @crop)
+          .where.not(field.to_sym => nil)
+          .where.not(field.to_sym => '')
+          .group(field.to_sym).count(:id)
+      end
+      render json: data
     end
   end
 end

--- a/spec/controllers/charts/crops_controller_spec.rb
+++ b/spec/controllers/charts/crops_controller_spec.rb
@@ -7,21 +7,42 @@ describe Charts::CropsController do
     let(:crop) { create(:crop) }
 
     describe 'sunniness' do
-      before { get :sunniness, params: { crop_slug: crop.to_param } }
+      it "returns a successful response" do
+        get :sunniness, params: { crop_slug: crop.to_param }
+        expect(response).to be_successful
+      end
 
-      it { expect(response).to be_successful }
+      it "caches the result" do
+        cache_key = "#{crop.cache_key_with_version}/sunniness"
+        expect(Rails.cache).to receive(:fetch).with(cache_key, expires_in: 1.day).and_call_original
+        get :sunniness, params: { crop_slug: crop.to_param }
+      end
     end
 
     describe 'planted_from' do
-      before { get :planted_from, params: { crop_slug: crop.to_param } }
+      it "returns a successful response" do
+        get :planted_from, params: { crop_slug: crop.to_param }
+        expect(response).to be_successful
+      end
 
-      it { expect(response).to be_successful }
+      it "caches the result" do
+        cache_key = "#{crop.cache_key_with_version}/planted_from"
+        expect(Rails.cache).to receive(:fetch).with(cache_key, expires_in: 1.day).and_call_original
+        get :planted_from, params: { crop_slug: crop.to_param }
+      end
     end
 
     describe 'harvested_for' do
-      before { get :harvested_for, params: { crop_slug: crop.to_param } }
+      it "returns a successful response" do
+        get :harvested_for, params: { crop_slug: crop.to_param }
+        expect(response).to be_successful
+      end
 
-      it { expect(response).to be_successful }
+      it "caches the result" do
+        cache_key = "#{crop.cache_key_with_version}/harvested_for"
+        expect(Rails.cache).to receive(:fetch).with(cache_key, expires_in: 1.day).and_call_original
+        get :harvested_for, params: { crop_slug: crop.to_param }
+      end
     end
   end
 end


### PR DESCRIPTION
This PR improves the performance of the crop charts by caching the data for `sunniness`, `planted_from`, and `harvested_for` actions. It also refactors the controller to use a `before_action` for crop loading and updates the test suite to explicitly verify that the cache is being utilized with the correct keys and expiration.

---
*PR created automatically by Jules for task [7725540171807829398](https://jules.google.com/task/7725540171807829398) started by @CloCkWeRX*