### PR TITLE
Optimize CropsHelper with caching and memoization

### DIFF
--- a/app/helpers/crops_helper.rb
+++ b/app/helpers/crops_helper.rb
@@ -2,28 +2,47 @@
 
 module CropsHelper
   def crop_or_parent(crop, attribute)
-    default = crop.send(attribute)
-    return default if default.present?
+    @crop_or_parent_cache ||= {}
+    cache_key = [crop.persisted? ? crop.id : crop.object_id, attribute]
+    return @crop_or_parent_cache[cache_key] if @crop_or_parent_cache.key?(cache_key)
 
-    parent = crop
-    while parent = parent.parent
-      return parent.send(attribute) if parent&.send(attribute).present?
+    @crop_or_parent_cache[cache_key] = begin
+      value = crop.send(attribute)
+      if value.blank?
+        parent = crop
+        while (parent = parent.parent)
+          parent_value = parent.send(attribute)
+          if parent_value.present?
+            value = parent_value
+            break
+          end
+        end
+      end
+      value
     end
-
-    # For scopes, arrays, etc return the empty value
-    default
   end
 
   def display_seed_availability(member, crop)
-    seeds = member.seeds.where(crop:)
-    total_quantity = seeds.where.not(quantity: nil).sum(:quantity)
+    @seed_availability_cache ||= {}
+    cache_key = [
+      member.persisted? ? member.id : member.object_id,
+      crop.persisted? ? crop.id : crop.object_id
+    ]
+    return @seed_availability_cache[cache_key] if @seed_availability_cache.key?(cache_key)
 
-    return "You don't have any seeds of this crop." if seeds.none?
+    @seed_availability_cache[cache_key] = begin
+      seeds = member.seeds.where(crop:)
 
-    if total_quantity == 0
-      "You have an unknown quantity of seeds of this crop."
-    else
-      "You have #{total_quantity} #{Seed.model_name.human(count: total_quantity)} of this crop."
+      if seeds.none?
+        "You don't have any seeds of this crop."
+      else
+        total_quantity = seeds.where.not(quantity: nil).sum(:quantity)
+        if total_quantity == 0
+          "You have an unknown quantity of seeds of this crop."
+        else
+          "You have #{total_quantity} #{Seed.model_name.human(count: total_quantity)} of this crop."
+        end
+      end
     end
   end
 
@@ -40,53 +59,57 @@ module CropsHelper
   end
 
   def crop_jsonld_data(crop, full_attributes: true)
-    same_as_urls = [crop.en_wikipedia_url]
-    crop.scientific_names.each do |scientific_name|
-      same_as_urls << "https://www.wikidata.org/wiki/#{scientific_name.wikidata_id}" if scientific_name.wikidata_id.present?
-    end
-
-    subject_of_entities = []
-    if full_attributes
-      if crop.en_youtube_url.present?
-        subject_of_entities << {
-          '@type': "VideoObject",
-          url:     crop.en_youtube_url
-        }
+    Rails.cache.fetch([crop.cache_key_with_version, "jsonld", full_attributes]) do
+      same_as_urls = [crop.en_wikipedia_url]
+      crop.scientific_names.each do |scientific_name|
+        if scientific_name.wikidata_id.present?
+          same_as_urls << "https://www.wikidata.org/wiki/#{scientific_name.wikidata_id}"
+        end
       end
 
-      crop.posts.each do |post|
-        subject_of_entities << {
-          '@type': "SocialMediaPosting",
-          url:     post_url(post),
-          author:  {
-            '@type': 'Person',
-            name: post.author.login_name
-          },
-          datePublished: post.created_at
-        }
-      end
-
+      subject_of_entities = []
       images = []
-      crop.photos.each do |photo|
-        images << photo.fullsize_url
+      if full_attributes
+        if crop.en_youtube_url.present?
+          subject_of_entities << {
+            '@type': "VideoObject",
+            url:     crop.en_youtube_url
+          }
+        end
+
+        crop.posts.each do |post|
+          subject_of_entities << {
+            '@type': "SocialMediaPosting",
+            url:     post_url(post),
+            author:  {
+              '@type': 'Person',
+              name:    post.author.login_name
+            },
+            datePublished: post.created_at
+          }
+        end
+
+        crop.photos.each do |photo|
+          images << photo.fullsize_url
+        end
       end
+
+      # TODO: Review plantings, seeds, harvests as a subtype of social media post or event that ended? Or creative work?
+      # has_many :plantings, dependent: :destroy
+      # has_many :seeds, dependent: :destroy
+      # has_many :harvests, dependent: :destroy
+
+      {
+        '@context':     "https://schema.org",
+        '@type':        "BioChemEntity",
+        name:           crop.name,
+        taxonomicRange: crop.scientific_names.map(&:name),
+        description:    crop.description,
+        sameAs:         same_as_urls,
+        alternateName:  crop.alternate_names.map(&:name),
+        subjectOf:      subject_of_entities,
+        image:          images
+      }.compact
     end
-
-    # TODO: Review plantings, seeds, harvests as a subtype of social media post or event that ended? Or creative work?
-    # has_many :plantings, dependent: :destroy
-    # has_many :seeds, dependent: :destroy
-    # has_many :harvests, dependent: :destroy
-
-    {
-      '@context':     "https://schema.org",
-      '@type':        "BioChemEntity",
-      name:           crop.name,
-      taxonomicRange: crop.scientific_names.map(&:name),
-      description:    crop.description,
-      sameAs:         same_as_urls,
-      alternateName:  crop.alternate_names.map(&:name),
-      subjectOf:      subject_of_entities,
-      image:          images
-    }.compact
   end
 end


### PR DESCRIPTION
I have reviewed `app/helpers/crops_helper.rb` and implemented several caching and memoization optimizations:

1.  **`crop_or_parent`**: Added request-level memoization to avoid redundant database lookups and tree traversals. The implementation now correctly handles `nil` results and uses stable keys for both persisted and non-persisted objects.
2.  **`display_seed_availability`**: Implemented request-level memoization and optimized the logic to avoid performing a `.sum` query if no seeds are found.
3.  **`crop_jsonld_data`**: Added low-level persistent caching using `Rails.cache.fetch` keyed by the crop's cache key. This is particularly beneficial as the method performs multiple association lookups.
4.  **Bug Fix**: Fixed a potential `NameError` in `crop_jsonld_data` where the `images` variable could be undefined when `full_attributes` was false.

I verified these changes by creating a temporary test suite that confirmed:
- Method calls are only executed once per request for memoized methods.
- `nil` results are correctly memoized.
- `Rails.cache` is correctly utilized for JSON-LD data.
- The `images` variable is correctly initialized.

All changes are confined to `app/helpers/crops_helper.rb`. Environmental changes made during testing (such as `.ruby-version` and `Gemfile.lock`) have been restored.

---
*PR created automatically by Jules for task [10992479017878632568](https://jules.google.com/task/10992479017878632568) started by @CloCkWeRX*