### PR TITLE
Add Flickr tag filtering for adding photos

### DIFF
--- a/app/controllers/photos_controller.rb
+++ b/app/controllers/photos_controller.rb
@@ -102,11 +102,12 @@ class PhotosController < ApplicationController
     end
 
     @current_set = params[:set]
+    @current_tag = params[:tag]
 
     page = params[:page] || 1
 
     @sets = current_member.flickr_sets
-    photos, total = current_member.flickr_photos(page, @current_set)
+    photos, total = current_member.flickr_photos(page, @current_set, @current_tag)
 
     @photos = WillPaginate::Collection.create(page, 30, total) do |pager|
       pager.replace photos

--- a/app/models/concerns/member_flickr.rb
+++ b/app/models/concerns/member_flickr.rb
@@ -40,8 +40,15 @@ module MemberFlickr
     # Fetches a collection of photos from Flickr
     # Returns a [[page of photos], total] pair.
     # Total is needed for pagination.
-    def flickr_photos(page_num = 1, set = nil)
-      result = if set
+    def flickr_photos(page_num = 1, set = nil, tags = nil)
+      result = if tags.present?
+                 flickr.photos.search(
+                   user_id:  'me',
+                   tags:     tags,
+                   page:     page_num,
+                   per_page: 30
+                 )
+               elsif set.present?
                  flickr.photosets.getPhotos(
                    photoset_id: set,
                    page:        page_num,

--- a/app/views/photos/new.html.haml
+++ b/app/views/photos/new.html.haml
@@ -21,13 +21,14 @@
     Please select a photo from your recent uploads.
 
 
-  - if @sets && !@sets.empty?
-    %p
-      = bootstrap_form_tag(url: new_photo_path, method: :get, layout: :inline) do |f|
-        = f.select :set, options_for_select(@sets, @current_set), label: "Choose a photo album"
-        = hidden_field_tag :type, @type
-        = hidden_field_tag :id, @id
-        = f.submit "Search", class: "btn btn-success"
+  %p
+    = bootstrap_form_tag(url: new_photo_path, method: :get, layout: :inline) do |f|
+      - if @sets && !@sets.empty?
+        = f.select :set, options_for_select(@sets, @current_set), label: "Choose a photo album", include_blank: true
+      = f.text_field :tag, value: @current_tag, label: "or search by tag"
+      = hidden_field_tag :type, @type
+      = hidden_field_tag :id, @id
+      = f.submit "Search", class: "btn btn-success"
 
   - if @sets && @current_set
     %h2= @sets.key(@current_set)

--- a/spec/controllers/photos_controller_spec.rb
+++ b/spec/controllers/photos_controller_spec.rb
@@ -60,6 +60,7 @@ describe PhotosController, :search do
       sign_in member
       member.stub(:flickr_photos) { [[], 0] }
       member.stub(:flickr_sets) { { "foo" => "bar" } }
+      member.stub(:flickr_auth_valid?) { true }
       controller.stub(:current_member) { member }
     end
 
@@ -84,6 +85,16 @@ describe PhotosController, :search do
 
       it { expect(assigns(:item)).to eq garden }
       it { expect(flash[:alert]).not_to be_present }
+    end
+
+    describe "filtering by tag" do
+      let(:tag) { "tomato" }
+
+      it "passes the tag to flickr_photos" do
+        expect(member).to receive(:flickr_photos).with(anything, nil, tag).and_return([[], 0])
+        get :new, params: { type: "planting", id: planting.id, tag: tag }
+        expect(assigns(:current_tag)).to eq tag
+      end
     end
   end
 


### PR DESCRIPTION
This change allows members to filter their Flickr photos by a specific tag when adding photos to Growstuff. 

Key changes:
- `MemberFlickr#flickr_photos` now accepts an optional `tags` parameter. If provided, it uses `flickr.photos.search` (filtered to the current user) instead of the default photostream or photoset retrieval.
- `PhotosController#retrieve_from_flickr` extracts `params[:tag]` and passes it to the `flickr_photos` method.
- The "New Photo" view (`app/views/photos/new.html.haml`) now includes a text input field for searching by tag, alongside the existing photoset selection.
- Added a test case in `spec/controllers/photos_controller_spec.rb` to ensure the tag parameter is correctly extracted and passed to the model.

---
*PR created automatically by Jules for task [3395495860406820072](https://jules.google.com/task/3395495860406820072) started by @CloCkWeRX*