### PR TITLE
Fix SeedsController to return 404 for missing members, crops, or plantings

### DIFF
--- a/app/controllers/seeds_controller.rb
+++ b/app/controllers/seeds_controller.rb
@@ -1,21 +1,22 @@
 # frozen_string_literal: true
 
 class SeedsController < DataController
+  before_action :set_owner
+
   def index
     where = {}
 
-    if params[:member_slug].present?
-      @owner = Member.find_by!(slug: params[:member_slug])
+    if @owner
       where['owner_id'] = @owner.id
     end
 
     if params[:crop_slug].present?
-      @crop = Crop.find_by(slug: params[:crop_slug])
+      @crop = Crop.find_by!(slug: params[:crop_slug])
       where['crop_id'] = @crop.id
     end
 
     if params[:planting_id].present?
-      @planting = Planting.find_by(slug: params[:planting_id])
+      @planting = Planting.find_by!(slug: params[:planting_id])
       where['parent_planting'] = @planting.id
     end
 
@@ -46,7 +47,7 @@ class SeedsController < DataController
     @seed.source = 'my own seed saving'
 
     if params[:planting_slug]
-      @planting = Planting.find_by(slug: params[:planting_slug])
+      @planting = Planting.find_by!(slug: params[:planting_slug])
     else
       @crop = Crop.find_or_initialize_by(id: params[:crop_id])
     end
@@ -80,6 +81,10 @@ class SeedsController < DataController
   end
 
   private
+
+  def set_owner
+    @owner = Member.find_by!(slug: params[:member_slug]) if params[:member_slug].present?
+  end
 
   def seed_params
     params.require(:seed).permit(

--- a/spec/controllers/seeds_controller_missing_member_spec.rb
+++ b/spec/controllers/seeds_controller_missing_member_spec.rb
@@ -1,0 +1,43 @@
+
+require 'rails_helper'
+
+describe SeedsController do
+  let(:member) { create(:member) }
+
+  describe "GET index with non-existent member" do
+    it "returns 404" do
+      get :index, params: { member_slug: 'non-existent' }
+      expect(response.status).to eq(404)
+    end
+  end
+
+  describe "GET new with non-existent member" do
+    before { sign_in member }
+    it "returns 404" do
+      get :new, params: { member_slug: 'non-existent' }
+      expect(response.status).to eq(404)
+    end
+  end
+
+  describe "GET index with non-existent crop" do
+    it "returns 404" do
+      get :index, params: { crop_slug: 'non-existent' }
+      expect(response.status).to eq(404)
+    end
+  end
+
+  describe "GET index with non-existent planting" do
+    it "returns 404" do
+      get :index, params: { planting_id: 'non-existent' }
+      expect(response.status).to eq(404)
+    end
+  end
+
+  describe "GET new with non-existent planting_slug" do
+    before { sign_in member }
+    it "returns 404" do
+      get :new, params: { planting_slug: 'non-existent' }
+      expect(response.status).to eq(404)
+    end
+  end
+end


### PR DESCRIPTION
Fixed the `SeedsController` to consistently use `.find_by!` when looking up members, crops, and plantings by their slugs or IDs. This ensures that the application returns a proper `404 Not Found` response (via `ActiveRecord::RecordNotFound`) whenever an invalid identifier is provided in the URL parameters.

Key changes:
- Introduced a `set_owner` private method and a `before_action` to centralize member validation.
- Refactored the `index` action to use the validated `@owner`.
- Updated `Crop` and `Planting` lookups in `index` and `new` to use `find_by!`.
- Added a new test file `spec/controllers/seeds_controller_missing_member_spec.rb` verifying these 404 responses across different actions.

---
*PR created automatically by Jules for task [14932105164574328438](https://jules.google.com/task/14932105164574328438) started by @CloCkWeRX*