### PR TITLE
Remove deprecated config.read_encrypted_secrets

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -16,10 +16,6 @@ Rails.application.configure do
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true
 
-  # Attempt to read encrypted secrets from `config/secrets.yml.enc`.
-  # Requires an encryption key in `ENV["RAILS_MASTER_KEY"]` or
-  # `config/secrets.yml.key`.
-  config.read_encrypted_secrets = true
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.


### PR DESCRIPTION
Fix #4347 

This change removes the deprecated config.read_encrypted_secrets setting from config/environments/production.rb. This setting is deprecated and will be removed in Rails 8.0. Since the application does not appear to use the legacy encrypted secrets feature, this removal is safe and resolves the deprecation warning.

---
*PR created automatically by Jules for task [6887904223096282516](https://jules.google.com/task/6887904223096282516) started by @CloCkWeRX*