### PR TITLE
Add Harvest Reminder Emails and Scheduled Task

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -68,7 +68,7 @@ class ApplicationController < ActionController::Base
                     # profile stuff
                     :bio, :location, :latitude, :longitude,
                     # email settings
-                    :show_email, :newsletter, :send_notification_email, :send_planting_reminder)
+                    :show_email, :newsletter, :send_notification_email, :send_planting_reminder, :send_harvest_reminder)
     end
 
     devise_parameter_sanitizer.permit(:account_update) do |member|
@@ -80,7 +80,7 @@ class ApplicationController < ActionController::Base
                     :bio, :location, :latitude, :longitude,
                     :website_url, :instagram_handle, :facebook_handle, :bluesky_handle, :other_url,
                     # email settings
-                    :show_email, :newsletter, :send_notification_email, :send_planting_reminder,
+                    :show_email, :newsletter, :send_notification_email, :send_planting_reminder, :send_harvest_reminder,
                     # update password
                     :current_password)
     end

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -90,11 +90,12 @@ class MembersController < ApplicationController
 
   EMAIL_TYPE_STRING = {
     send_notification_email: "direct message notifications",
-    send_planting_reminder:  "planting reminders"
+    send_planting_reminder:  "planting reminders",
+    send_harvest_reminder:   "harvest reminders"
   }.freeze
 
   def member_params
-    params.require(:member).permit(:login_name, :tos_agreement, :email, :newsletter)
+    params.require(:member).permit(:login_name, :tos_agreement, :email, :newsletter, :send_harvest_reminder)
   end
 
   def member_json_fields

--- a/app/mailers/notifier_mailer.rb
+++ b/app/mailers/notifier_mailer.rb
@@ -57,6 +57,19 @@ class NotifierMailer < ApplicationMailer
     mail(to: @member.email, subject: @subject) if @member.send_planting_reminder
   end
 
+  def harvest_reminder(member)
+    @member = member
+    @plantings = @member.plantings.active.select(&:harvest_in_next_week?)
+    @sitename = ENV.fetch('GROWSTUFF_SITE_NAME', nil)
+    @subject = I18n.t('notifier_mailer.harvest_reminder.subject', sitename: @sitename)
+
+    # Encrypting
+    message = { member_id: @member.id, type: :send_harvest_reminder }
+    @signed_message = verifier.generate(message)
+
+    mail(to: @member.email, subject: @subject) if @member.send_harvest_reminder
+  end
+
   def new_crop_request(member, request)
     @member = member
     @request = request

--- a/app/models/concerns/predict_harvest.rb
+++ b/app/models/concerns/predict_harvest.rb
@@ -60,8 +60,14 @@ module PredictHarvest
     def before_harvest_time?
       first_harvest_predicted_at.present? &&
         harvests.empty? &&
-        first_harvest_predicted_at.present? &&
         first_harvest_predicted_at > Time.zone.today
+    end
+
+    def harvest_in_next_week?
+      first_harvest_predicted_at.present? &&
+        harvests.empty? &&
+        first_harvest_predicted_at >= Time.zone.today &&
+        first_harvest_predicted_at <= Time.zone.today + 7.days
     end
 
     def harvest_months

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -79,6 +79,7 @@ class Member < ApplicationRecord
   scope :interesting, -> { confirmed.located.recently_signed_in.has_plantings }
   scope :has_plantings, -> { joins(:plantings).group("members.id") }
   scope :wants_reminders, -> { where(send_planting_reminder: true) }
+  scope :wants_harvest_reminders, -> { where(send_harvest_reminder: true) }
 
   # Include default devise modules. Others available are:
   # :token_authenticatable, :confirmable,

--- a/app/views/devise/registrations/_edit_email.html.haml
+++ b/app/views/devise/registrations/_edit_email.html.haml
@@ -31,6 +31,12 @@
   .form-group
     .col-md-offset-2.col-md-8.checkbox
       %label
+        = f.check_box :send_harvest_reminder
+        Receive regular reminders of upcoming harvests.
+
+  .form-group
+    .col-md-offset-2.col-md-8.checkbox
+      %label
         = f.check_box :newsletter
         Subscribe to the #{ENV['GROWSTUFF_SITE_NAME']} newsletter
       .help-block

--- a/app/views/notifier_mailer/harvest_reminder.html.haml
+++ b/app/views/notifier_mailer/harvest_reminder.html.haml
@@ -1,0 +1,33 @@
+%p Hello #{@member.login_name},
+
+%h2= t('notifier_mailer.harvest_reminder.heading')
+
+%p= t('notifier_mailer.harvest_reminder.intro')
+
+%ul
+  - @plantings.each do |planting|
+    %li
+      = render 'planting', planting: planting
+      (Predicted harvest date: #{planting.first_harvest_predicted_at.to_date})
+
+%p
+  Harvested anything lately?
+  = link_to "Track your harvests here.", new_harvest_url, class: 'btn'
+
+%p
+  Track and predict your entire garden, and keep your garden records up to date at
+  = link_to member_gardens_url(@member), class: 'btn' do
+    your garden overview
+  and on
+  = link_to member_url(@member) do
+    your profile page
+
+%h4
+  See you soon on #{@sitename}!
+
+= render partial: 'signature'
+
+%hr/
+%p
+  Don't want to get these emails any more?
+  = link_to t('notifier_mailer.harvest_reminder.unsubscribe'), unsubscribe_member_url(message: @signed_message)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -456,3 +456,9 @@ en:
       all: Not authorized to %{action} %{subject}.
     read:
       notification: You must be signed in to view notifications.
+  notifier_mailer:
+    harvest_reminder:
+      subject: "Upcoming harvests in your garden - %{sitename}"
+      heading: "Upcoming harvests in your garden"
+      intro: "Based on our predictions, the following plantings in your garden are likely to be ready for harvest within the next week:"
+      unsubscribe: "Unsubscribe from harvest reminders"

--- a/db/migrate/20260429132911_add_send_harvest_reminder_to_members.rb
+++ b/db/migrate/20260429132911_add_send_harvest_reminder_to_members.rb
@@ -1,0 +1,5 @@
+class AddSendHarvestReminderToMembers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :members, :send_harvest_reminder, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_12_01_045000) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_29_132911) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -786,6 +786,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_12_01_045000) do
     t.string "facebook_handle"
     t.string "bluesky_handle"
     t.string "other_url"
+    t.boolean "send_harvest_reminder", default: true, null: false
     t.index ["confirmation_token"], name: "index_members_on_confirmation_token", unique: true
     t.index ["discarded_at"], name: "index_members_on_discarded_at"
     t.index ["email"], name: "index_members_on_email", unique: true

--- a/lib/tasks/growstuff.rake
+++ b/lib/tasks/growstuff.rake
@@ -48,8 +48,23 @@ namespace :growstuff do
     # Heroku scheduler only lets us run things daily, so this checks
     # Send on Monday
     if Time.zone.today.wday == 1
-      Member.confirmed.wants_reminders.each do |m|
-        Notifier.planting_reminder(m).deliver_now! unless m.plantings.active.empty?
+      Member.confirmed.wants_reminders.find_each do |m|
+        NotifierMailer.planting_reminder(m).deliver_later unless m.plantings.active.empty?
+      end
+    end
+  end
+
+  desc "Send harvest reminder email"
+  # usage: rake growstuff:send_harvest_reminders
+
+  task send_harvest_reminders: :environment do
+    # Heroku scheduler only lets us run things daily, so this checks
+    # Send on Wednesday
+    if Time.zone.today.wday == 3
+      Member.confirmed.wants_harvest_reminders.find_each do |m|
+        if m.plantings.active.any?(&:harvest_in_next_week?)
+          NotifierMailer.harvest_reminder(m).deliver_later
+        end
       end
     end
   end

--- a/spec/mailers/harvest_reminder_mailer_spec.rb
+++ b/spec/mailers/harvest_reminder_mailer_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe NotifierMailer, type: :mailer do
+  let(:member) { create(:member) }
+  let(:mail)   { NotifierMailer.harvest_reminder(member) }
+
+  it "has a greeting" do
+    expect(mail.body.encoded).to match "Hello"
+  end
+
+  context "when member has upcoming harvests" do
+    let(:crop) { create(:crop, median_days_to_first_harvest: 20) }
+    let!(:planting) { create(:planting, owner: member, crop: crop, planted_at: 15.days.ago) }
+    let(:plantings) { [planting] }
+
+    it "lists the upcoming harvest" do
+      expect(mail.body.encoded).to match "Upcoming harvests in your garden"
+      expect(mail.body.encoded).to match planting.crop.name
+      expect(mail.body.encoded).to match (Time.zone.today + 5.days).to_date.to_s
+    end
+
+    it "has an unsubscribe link" do
+      expect(mail.body.encoded).to match "Unsubscribe from harvest reminders"
+    end
+  end
+end

--- a/spec/models/harvest_prediction_spec.rb
+++ b/spec/models/harvest_prediction_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe "Harvest prediction logic" do
+  let(:crop) { create(:crop, median_days_to_first_harvest: 20) }
+  let(:planting) { create(:planting, crop: crop) }
+
+  describe "#harvest_in_next_week?" do
+    it "is true if predicted harvest is in 5 days" do
+      planting.planted_at = 15.days.ago
+      expect(planting.harvest_in_next_week?).to be true
+    end
+
+    it "is true if predicted harvest is today" do
+      planting.planted_at = 20.days.ago
+      expect(planting.harvest_in_next_week?).to be true
+    end
+
+    it "is true if predicted harvest is in 7 days" do
+      planting.planted_at = 13.days.ago
+      expect(planting.harvest_in_next_week?).to be true
+    end
+
+    it "is false if predicted harvest is in 8 days" do
+      planting.planted_at = 12.days.ago
+      expect(planting.harvest_in_next_week?).to be false
+    end
+
+    it "is false if predicted harvest was yesterday" do
+      planting.planted_at = 21.days.ago
+      expect(planting.harvest_in_next_week?).to be false
+    end
+
+    it "is false if there are already harvests" do
+      planting.planted_at = 15.days.ago
+      create(:harvest, planting: planting, owner: planting.owner, crop: planting.crop, harvested_at: 1.day.ago)
+      expect(planting.harvest_in_next_week?).to be false
+    end
+  end
+end


### PR DESCRIPTION
This PR implements a new notification system to remind members of upcoming harvests in their garden.

### Key Changes:
- **Member Preference**: Added a `send_harvest_reminder` boolean column to the `members` table (default: true).
- **Settings UI**: Added a checkbox in the Email settings page for members to opt-out of harvest reminders.
- **Harvest Prediction**: Added `harvest_in_next_week?` to `PredictHarvest` concern, which identifies plantings predicted to be ready for harvest within the next 7 days that haven't been harvested yet.
- **Mailer**: Added `harvest_reminder` to `NotifierMailer` with localized HAML templates.
- **Scheduled Task**: Added `growstuff:send_harvest_reminders` Rake task, configured to run logic on Wednesdays (Heroku Scheduler pattern).
- **Bug Fix & Scalability**: Updated reminder tasks to use `deliver_later` and fixed a typo where `Notifier` was used instead of `NotifierMailer` in an existing task.

### Testing:
- Added `spec/models/harvest_prediction_spec.rb` to verify prediction logic.
- Added `spec/mailers/harvest_reminder_mailer_spec.rb` to verify email generation.
- Verified preference saving and Rake task logic via Rails runner.
- Performed frontend verification of the settings checkbox.

---
*PR created automatically by Jules for task [16703221337897327633](https://jules.google.com/task/16703221337897327633) started by @CloCkWeRX*