### PR TITLE
Fix crash during CSV export of harvests and seeds

### DIFF
--- a/app/controllers/crops_controller.rb
+++ b/app/controllers/crops_controller.rb
@@ -13,7 +13,7 @@ class CropsController < ApplicationController
     @crops = Crop.search('*', boost_by: %i(plantings_count harvests_count),
                               limit:    100,
                               page:     params[:page],
-                              load:     false)
+                              load:     (request.format.csv? ? { include: %i(scientific_names parent creator) } : false))
     @num_requested_crops = requested_crops.size if current_member
     @filename = filename
     respond_with @crops

--- a/app/controllers/harvests_controller.rb
+++ b/app/controllers/harvests_controller.rb
@@ -23,7 +23,7 @@ class HarvestsController < DataController
     @harvests = Harvest.search('*', where:,
                                     limit:    100,
                                     page:     params[:page],
-                                    load:     false,
+                                    load:     (request.format.csv? ? { include: %i(crop owner plant_part) } : false),
                                     boost_by: [:created_at])
 
     @filename = csv_filename

--- a/app/controllers/seeds_controller.rb
+++ b/app/controllers/seeds_controller.rb
@@ -30,7 +30,7 @@ class SeedsController < DataController
       page:     params[:page],
       limit:    30,
       boost_by: [:created_at],
-      load:     false
+      load:     (request.format.csv? ? { include: %i(crop owner) } : false)
     )
 
     respond_with(@seeds)

--- a/app/views/crops/index.csv.shaper
+++ b/app/views/crops/index.csv.shaper
@@ -58,7 +58,7 @@ csv.headers *all_headers
     end
 
     csv.cell :plantings_count, c.plantings_count || 0
-    csv.cell :seeds_count, c.seeds.size[]
+    csv.cell :seeds_count, c.seeds.size
     csv.cell :harvests_count, c.harvests.size
 
   # Sunniness


### PR DESCRIPTION
The CSV export for harvests, seeds, and crops was crashing because it used Searchkick with `load: false`, which returns hash-like objects instead of ActiveRecord instances. The export templates (shapshers) were attempting to access model associations and use Rails URL helpers with these objects, causing `ActionView::Template::Error` and `No route matches` errors.

Changes:
- Modified `HarvestsController`, `SeedsController`, and `CropsController` to use `load: true` (with appropriate preloading) only when CSV format is requested.
- Fixed a typo (`c.seeds.size[]`) in `app/views/crops/index.csv.shaper`.
- Ensured consistent behavior across data export controllers.

This approach prevents the crash while maintaining high performance for standard HTML/JSON search requests.

---
*PR created automatically by Jules for task [4991917409830119333](https://jules.google.com/task/4991917409830119333) started by @CloCkWeRX*