### PR TITLE
Associate post with crop from crop show page

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -21,6 +21,10 @@ class PostsController < ApplicationController
   def new
     @post = Post.new
     @forum = Forum.find_by(id: params[:forum_id])
+    if params[:crop_id]
+      @crop = Crop.friendly.find(params[:crop_id])
+      @post.body = "[#{@crop.name}](crop)"
+    end
     respond_with(@post)
   end
 

--- a/app/views/crops/_actions.html.haml
+++ b/app/views/crops/_actions.html.haml
@@ -5,5 +5,8 @@
     = render 'plantings/modal', planting: Planting.new(crop: crop, owner: current_member)
     = render 'harvests/modal', harvest: Harvest.new(crop: @crop,  owner: current_member)
     = render 'seeds/modal', seed: Seed.new(crop: @crop,  owner: current_member)
+    = link_to new_post_path(crop_id: crop.slug), class: 'btn', id: 'post-button' do
+      = post_icon
+      Post
     - if active_plantings.any?
       = render 'plantings/failed_modal', crop: crop, active_plantings: active_plantings

--- a/app/views/crops/_posts.html.haml
+++ b/app/views/crops/_posts.html.haml
@@ -6,7 +6,7 @@
     Nobody has posted about #{crop.name.pluralize} yet.
   %p
     - if can? :create, Post
-      = link_to "Post something", new_post_path, class: 'btn btn-default'
+      = link_to "Post something", new_post_path(crop_id: crop.slug), class: 'btn btn-default'
     - else
       = render partial: "shared/signin_signup",
               locals: { to: "post your tips and experiences growing #{crop.name.pluralize}" }

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -10,6 +10,20 @@ describe PostsController do
     { author_id: member.id, subject: "blah", body: "blah blah" }
   end
 
+  describe '#new' do
+    let(:crop) { create(:crop, name: 'Bush Bean') }
+
+    it 'pre-populates the body when crop_id is present' do
+      get :new, params: { crop_id: crop.slug }
+      expect(assigns(:post).body).to eq("[#{crop.name}](crop)")
+    end
+
+    it 'does not pre-populate the body when crop_id is absent' do
+      get :new
+      expect(assigns(:post).body).to be_nil
+    end
+  end
+
   describe '#index' do
     before do
       create_list(:post, 100)


### PR DESCRIPTION
This change allows users to associate a new post with a crop when initiating the post from the crop's detail page. It adds a "Post" button to the crop actions and updates the "Post something" link to pass the crop's slug. The PostsController then pre-populates the post body with the appropriate markdown link `[crop name](crop)`, which the application uses to create the underlying association.

---
*PR created automatically by Jules for task [5945795316503813050](https://jules.google.com/task/5945795316503813050) started by @CloCkWeRX*