### PR TITLE
Allow collaborators to remove themselves from gardens

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -123,6 +123,7 @@ class Ability
     can :create,  GardenCollaborator, garden: { owner_id: member.id }
     can :update,  GardenCollaborator, garden: { owner_id: member.id }
     can :destroy, GardenCollaborator, garden: { owner_id: member.id }
+    can :destroy, GardenCollaborator, member_id: member.id
 
     can :create,  Activity
     can :update,  Activity, owner_id: member.id

--- a/app/views/gardens/show.html.haml
+++ b/app/views/gardens/show.html.haml
@@ -102,6 +102,8 @@
           %strong Collaborators:
           - if can?(:create, GardenCollaborator.new(garden: @garden))
             = link_to "Manage", garden_garden_collaborators_path(@garden)
+          - elsif current_member.present? && (collab = @garden.garden_collaborators.find_by(member: current_member))
+            = link_to "Leave garden", garden_garden_collaborator_path(@garden, collab), method: :delete, class: 'text-danger', data: { confirm: 'Are you sure you want to leave this garden?' }
           - if @garden.garden_collaborators.any?
             %ul
               - @garden.garden_collaborators.each do |collabator|

--- a/spec/models/garden_collaborator_ability_spec.rb
+++ b/spec/models/garden_collaborator_ability_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'cancan/matchers'
+
+describe Ability do
+  let(:member) { create(:member) }
+  let(:ability) { described_class.new(member) }
+
+  context 'garden collaborators' do
+    let(:garden) { create(:garden) }
+    let(:garden_collaborator) { create(:garden_collaborator, garden: garden, member: member) }
+    let(:other_member) { create(:member) }
+    let(:other_garden_collaborator) { create(:garden_collaborator, garden: garden, member: other_member) }
+
+    it 'can remove themselves as a collaborator' do
+      expect(ability).to be_able_to(:destroy, garden_collaborator)
+    end
+
+    it 'cannot remove others as a collaborator if not garden owner' do
+      expect(ability).not_to be_able_to(:destroy, other_garden_collaborator)
+    end
+
+    context 'as garden owner' do
+      let(:garden) { create(:garden, owner: member) }
+
+      it 'can remove others as a collaborator' do
+        expect(ability).to be_able_to(:destroy, other_garden_collaborator)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This change updates the authorization logic to allow garden collaborators to remove themselves from a garden they are collaborating on. It also adds a 'Leave garden' link to the garden show page for collaborators and a test suite to verify the new permissions. Previously, only garden owners could remove collaborators.

---
*PR created automatically by Jules for task [12960238170304052502](https://jules.google.com/task/12960238170304052502) started by @CloCkWeRX*