### PR TITLE
Render garden creation flash prompt as HTML

### DIFF
--- a/app/views/shared/_flash_messages.html.haml
+++ b/app/views/shared/_flash_messages.html.haml
@@ -3,4 +3,4 @@
     %button.close{ type: "button", "data-bs-dismiss" => "alert" }
       %span{ "aria-hidden" => true } &times;
       %span.sr-only Close
-    = content
+    = sanitize(content)


### PR DESCRIPTION
The flash message prompted after garden creation contained HTML links that were being escaped when rendered. This was because the `html_safe` status of the string was being lost when stored in the flash (which uses session serialization). 

By changing the flash message rendering in `app/views/shared/_flash_messages.html.haml` to use `sanitize(content)`, we ensure that safe HTML tags are rendered correctly while still protecting against malicious content.

Verification was performed using a request spec that simulated garden creation and checked the response body for unescaped HTML in the flash message.

---
*PR created automatically by Jules for task [4215533735226531418](https://jules.google.com/task/4215533735226531418) started by @CloCkWeRX*