### PR TITLE
Extend session to 90 days and ensure persistence across browser restarts

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -107,7 +107,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :rememberable
   # The time the user will be remembered without asking for credentials again.
-  # config.remember_for = 2.weeks
+  config.remember_for = 90.days
 
   # If true, extends the user's remember period when remembered via cookie.
   # config.extend_remember_period = false
@@ -128,7 +128,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  config.timeout_in = 30.days
+  config.timeout_in = 90.days
 
   # If true, expires auth token on session timeout.
   # config.expire_auth_token_on_timeout = false

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -2,7 +2,7 @@
 
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_growstuff_session'
+Rails.application.config.session_store :cookie_store, key: '_growstuff_session', expire_after: 90.days
 
 # Use the database for sessions instead of the cookie-based default,
 # which shouldn't be used to store highly confidential information


### PR DESCRIPTION
This change extends the login session duration to 90 days and ensures that users remain logged in even after closing their browser or tabs. This was achieved by configuring the Rails session store with a 90-day expiration (making the cookie persistent) and updating Devise's timeout and rememberable settings to match.

---
*PR created automatically by Jules for task [15822131657557420620](https://jules.google.com/task/15822131657557420620) started by @CloCkWeRX*