### PR TITLE
Fix Docker build by copying .ruby-version before bundle install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ ENV RAILS_ENV=production \
 WORKDIR /app
 
 # Install gems
-COPY Gemfile Gemfile.lock ./
+COPY Gemfile Gemfile.lock .ruby-version ./
 RUN bundle config set --local deployment 'true' && \
     bundle config set --local without 'development test' && \
     bundle install --jobs 4 --retry 3


### PR DESCRIPTION
This PR fixes a failing Docker build where `bundle install` would error out because it couldn't find the `.ruby-version` file. The `Gemfile` contains `ruby File.read('.ruby-version')`, so the file must be present in the build context before `bundle install` is executed.

I've updated the `Dockerfile` to include `.ruby-version` in the initial `COPY` command.

Verified the fix by:
1. Manually running `bundle install` in the sandbox with and without the file (after adjusting the Ruby version to match the sandbox environment).
2. Running a subset of the test suite (`spec/models/member_spec.rb`) to ensure the application remains functional.
3. Reviewing the `Dockerfile` to ensure the file is copied to the correct location.

---
*PR created automatically by Jules for task [8858247702805966576](https://jules.google.com/task/8858247702805966576) started by @CloCkWeRX*