### PR TITLE
Pin Node.js and Yarn engine versions in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "mdbootstrap": "^4.20.0"
   },
   "engines": {
-    "node": ">=6.0.0",
-    "yarn": ">=0.25.2"
+    "node": "24.13.0",
+    "yarn": "1.22.22"
   },
   "devDependencies": {
     "@coffeelint/cli": "^3.0.0",


### PR DESCRIPTION
This PR pins the Node.js and Yarn engine versions in `package.json` to `24.13.0` and `1.22.22` respectively. This suppresses Heroku build warnings about using default, unpinned versions and ensures a stable and predictable build process.

---
*PR created automatically by Jules for task [571353181399297160](https://jules.google.com/task/571353181399297160) started by @CloCkWeRX*