### PR TITLE
Update oauth gem from 0.5.8 to 0.5.9

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -446,7 +446,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.4-x86_64-linux-gnu)
       racc (~> 1.4)
-    oauth (0.5.8)
+    oauth (0.5.9)
     oj (3.17.6)
       bigdecimal (>= 3.0)
       ostruct (>= 0.2)


### PR DESCRIPTION
https://github.com/ruby-oauth/oauth/compare/v0.5.8...v0.5.9

Should be safe, but... Its a lot!

