### PR TITLE
Bump oauth from 0.5.10 to 0.5.11

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -446,7 +446,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.4-x86_64-linux-gnu)
       racc (~> 1.4)
-    oauth (0.5.10)
+    oauth (0.5.11)
     oj (3.17.6)
       bigdecimal (>= 3.0)
       ostruct (>= 0.2)


### PR DESCRIPTION
https://github.com/ruby-oauth/oauth/compare/v0.5.10...v0.5.11

Vendors some bin commands, minor version deps constraints changed.