### PR TITLE
Bump oauth from 0.5.14 to 0.6.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'bundler', '>= 2.4.22'
 gem 'coffee-rails'
 gem 'haml'
 gem 'sassc-rails'
+gem 'oauth', '~> 0.6.0'
 
 # API data
 gem 'jsonapi-resources'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -446,7 +446,9 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.4-x86_64-linux-gnu)
       racc (~> 1.4)
-    oauth (0.5.14)
+    oauth (0.6.2)
+      snaky_hash (~> 2.0)
+      version_gem (~> 1.1)
     oj (3.17.6)
       bigdecimal (>= 3.0)
       ostruct (>= 0.2)
@@ -696,6 +698,9 @@ GEM
     simple_po_parser (1.1.6)
     sitemap_generator (7.1.1)
       builder (~> 3.0)
+    snaky_hash (2.0.7)
+      hashie (>= 0.1.0, < 6)
+      version_gem (~> 1.1, >= 1.1.14)
     sprockets (3.7.5)
       base64
       concurrent-ruby (~> 1.0)
@@ -731,6 +736,7 @@ GEM
       activemodel (>= 3.0.0)
       public_suffix
     vcr (6.4.0)
+    version_gem (1.1.15)
     warden (1.2.9)
       rack (>= 2.0.9)
     webrat (0.7.3)
@@ -820,6 +826,7 @@ DEPENDENCIES
   material_icons
   memcachier
   msgpack
+  oauth (~> 0.6.0)
   oj
   omniauth (~> 1.3)
   omniauth-flickr (>= 0.0.15)


### PR DESCRIPTION
https://github.com/ruby-oauth/oauth/compare/v0.5.14...v0.6.2

131 files :(

Claude review:

> Supply chain: two new runtime deps were added, snaky_hash and version_gem. I checked — both are maintained by the same person who maintains oauth itself (Peter Boling), are gem-signed, and snaky_hash alone has ~75M downloads and is also used by the oauth2 gem. Nothing typosquat-like or newly-orphaned about them.
>  So: no suspicious commits, no weakened checks, no backdoors — this range is what it presents as, a rubocop/Ruby-modernization release plus two minor correctness fixes.