### PR TITLE
Bump oauth to 1.0.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'bundler', '>= 2.4.22'
 gem 'coffee-rails'
 gem 'haml'
 gem 'sassc-rails'
-gem 'oauth', '~> 0.6.0'
+gem 'oauth', '~> 1.0.1'
 
 # API data
 gem 'jsonapi-resources'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -446,7 +446,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.4-x86_64-linux-gnu)
       racc (~> 1.4)
-    oauth (0.6.2)
+    oauth (1.0.1)
       snaky_hash (~> 2.0)
       version_gem (~> 1.1)
     oj (3.17.6)
@@ -826,7 +826,7 @@ DEPENDENCIES
   material_icons
   memcachier
   msgpack
-  oauth (~> 0.6.0)
+  oauth (~> 1.0.1)
   oj
   omniauth (~> 1.3)
   omniauth-flickr (>= 0.0.15)


### PR DESCRIPTION
https://github.com/ruby-oauth/oauth/compare/v0.6.2...v1.0.1

Syntax tweaks and one change to push responsibilty to a gem