### PR TITLE
Bump oauth to 1.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'bundler', '>= 2.4.22'
 gem 'coffee-rails'
 gem 'haml'
 gem 'sassc-rails'
-gem 'oauth', '1.1.0'
+gem 'oauth', '1.1.1'
 
 # API data
 gem 'jsonapi-resources'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -450,10 +450,10 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.4-x86_64-linux-gnu)
       racc (~> 1.4)
-    oauth (1.1.0)
-      oauth-tty (~> 1.0, >= 1.0.1)
+    oauth (1.1.1)
+      oauth-tty (~> 1.0, >= 1.0.6)
       snaky_hash (~> 2.0)
-      version_gem (~> 1.1)
+      version_gem (~> 1.1, >= 1.1.9)
     oauth-tty (1.0.13)
       anonymous_loader (~> 0.1, >= 0.1.3)
       auth-sanitizer (~> 0.2, >= 0.2.3)
@@ -835,7 +835,7 @@ DEPENDENCIES
   material_icons
   memcachier
   msgpack
-  oauth (= 1.1.0)
+  oauth (= 1.1.1)
   oj
   omniauth (~> 1.3)
   omniauth-flickr (>= 0.0.15)


### PR DESCRIPTION
https://github.com/ruby-oauth/oauth/compare/v1.1.0...v1.1.1

>  Showing 343 changed files with 36,715 additions and 4,595 deletions.

I did some manual review, docs added, a bunch of binaries (good lord, why).


ChatGPT boiled an ocean for:


Area | Assessment
-- | --
Obvious malware in require "oauth" path | Not found
Hard-coded exfiltration endpoint | Not found
Shell execution in normal runtime | Not found
Credential harvesting in OAuth implementation | Not found
Obfuscated Ruby | Not found
Suspicious new network code | Not found
OAuth escaping change | Legitimate-looking
oauth-tty dependency floor | Suspicious / deserves investigation
version_gem dependency floor | Suspicious but currently benign-looking
Gem signing/private-key code | High-interest build-time attack surface
Huge unrelated diff | Supply-chain red flag, but not proof
Changelog claims | Ignored


And the deps:



Dependency | Supply-chain concern | Code-level finding
-- | -- | --
oauth-tty 1.0.6 | 🔴 High interest | Huge 237-file / 43-commit update after 3 years; new release infrastructure; no malicious runtime code found so far
version_gem 1.1.9 | 🟠 Moderate interest | Huge 157-file / 48-commit update; runtime code essentially unchanged; gemspec/release machinery substantially changed
snaky_hash | 🟢 No version floor change | Not newly introduced by 1.1.1
base64 | 🟢 Standard library gem | Not relevant to the suspicious update


