### PR TITLE
Bump oauth to 1.1.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'bundler', '>= 2.4.22'
 gem 'coffee-rails'
 gem 'haml'
 gem 'sassc-rails'
-gem 'oauth', '1.1.3'
+gem 'oauth', '1.1.4'
 
 # API data
 gem 'jsonapi-resources'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -199,6 +199,7 @@ GEM
       image_processing (~> 1.1)
       marcel (~> 1.0.0)
       ssrf_filter (~> 1.0)
+    cgi (0.5.2)
     chartkick (5.2.1)
     childprocess (5.1.0)
       logger (~> 1.5)
@@ -450,10 +451,12 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.4-x86_64-linux-gnu)
       racc (~> 1.4)
-    oauth (1.1.3)
+    oauth (1.1.4)
+      auth-sanitizer (~> 0.1, >= 0.1.2)
       base64 (~> 0.1)
-      oauth-tty (~> 1.0, >= 1.0.6)
-      snaky_hash (~> 2.0)
+      cgi
+      oauth-tty (~> 1.0, >= 1.0.7)
+      snaky_hash (~> 2.0, >= 2.0.4)
       version_gem (~> 1.1, >= 1.1.9)
     oauth-tty (1.0.13)
       anonymous_loader (~> 0.1, >= 0.1.3)
@@ -836,7 +839,7 @@ DEPENDENCIES
   material_icons
   memcachier
   msgpack
-  oauth (= 1.1.3)
+  oauth (= 1.1.4)
   oj
   omniauth (~> 1.3)
   omniauth-flickr (>= 0.0.15)


### PR DESCRIPTION
https://github.com/ruby-oauth/oauth/compare/v1.1.3...v1.1.4

Auth sanitizer changes, among others.

Agentic review
> So, yes: the code-based review and the changelog agree. There isn't an obvious discrepancy where the changelog claims a benign change while the code contains a major undocumented functional change.