### PR TITLE
Bump oauth to 1.1.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'bundler', '>= 2.4.22'
 gem 'coffee-rails'
 gem 'haml'
 gem 'sassc-rails'
-gem 'oauth', '1.1.4'
+gem 'oauth', '1.1.5'
 
 # API data
 gem 'jsonapi-resources'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -451,11 +451,11 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.4-x86_64-linux-gnu)
       racc (~> 1.4)
-    oauth (1.1.4)
-      auth-sanitizer (~> 0.1, >= 0.1.2)
+    oauth (1.1.5)
+      auth-sanitizer (~> 0.1, >= 0.1.3)
       base64 (~> 0.1)
       cgi
-      oauth-tty (~> 1.0, >= 1.0.7)
+      oauth-tty (~> 1.0, >= 1.0.8)
       snaky_hash (~> 2.0, >= 2.0.4)
       version_gem (~> 1.1, >= 1.1.9)
     oauth-tty (1.0.13)
@@ -839,7 +839,7 @@ DEPENDENCIES
   material_icons
   memcachier
   msgpack
-  oauth (= 1.1.4)
+  oauth (= 1.1.5)
   oj
   omniauth (~> 1.3)
   omniauth-flickr (>= 0.0.15)


### PR DESCRIPTION
https://github.com/ruby-oauth/oauth/compare/v1.1.4...v1.1.5

Mostly an internal version of auth sanitizer to fix namespace pollution