### PR TITLE
Bump oauth to 1.1.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'bundler', '>= 2.4.22'
 gem 'coffee-rails'
 gem 'haml'
 gem 'sassc-rails'
-gem 'oauth', '1.1.6'
+gem 'oauth', '1.1.6' # Explicitly pinned, as the maintainer does huge (400 files, 45k lines) changes in point releases - required manual plus agentic security review.
 
 # API data
 gem 'jsonapi-resources'

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'bundler', '>= 2.4.22'
 gem 'coffee-rails'
 gem 'haml'
 gem 'sassc-rails'
-gem 'oauth', '1.1.5'
+gem 'oauth', '1.1.6'
 
 # API data
 gem 'jsonapi-resources'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -451,13 +451,13 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.4-x86_64-linux-gnu)
       racc (~> 1.4)
-    oauth (1.1.5)
-      auth-sanitizer (~> 0.1, >= 0.1.3)
+    oauth (1.1.6)
+      auth-sanitizer (~> 0.2, >= 0.2.1)
       base64 (~> 0.1)
       cgi
       oauth-tty (~> 1.0, >= 1.0.8)
-      snaky_hash (~> 2.0, >= 2.0.4)
-      version_gem (~> 1.1, >= 1.1.9)
+      snaky_hash (~> 2.0, >= 2.0.5)
+      version_gem (~> 1.1, >= 1.1.11)
     oauth-tty (1.0.13)
       anonymous_loader (~> 0.1, >= 0.1.3)
       auth-sanitizer (~> 0.2, >= 0.2.3)
@@ -839,7 +839,7 @@ DEPENDENCIES
   material_icons
   memcachier
   msgpack
-  oauth (= 1.1.5)
+  oauth (= 1.1.6)
   oj
   omniauth (~> 1.3)
   omniauth-flickr (>= 0.0.15)


### PR DESCRIPTION
https://github.com/ruby-oauth/oauth/compare/v1.1.5...v1.1.6

 12 commits 226 files changed
 
 *facepalm*
 
 
 More ocean boiling:
 

Changelog claim | Found in code? | Assessment
-- | -- | --
Retemplate workflows/appraisals/development tooling | Yes | Accurate
Document OAuth::Consumer options | Yes | Accurate
Correct OAuth 1.0a example | Yes | Accurate
auth-sanitizer >= 0.2.1 | Yes | Accurate
snaky_hash >= 2.0.5 | Yes | Accurate
Bound token redirects | Yes | Accurate
Explicit redirect resolution | Yes | Accurate
Reject cross-origin redirects by default | Yes | Accurate
Require explicit opt-in for cross-origin redirects | Yes | Accurate

> The changelog does not, however, convey the full security implications of the enormous development-environment change. In particular, it doesn't call out the new download-and-execute path for tsdl.
> That omission is not necessarily malicious—the changelog describes the template migration at a high level—but from a supply-chain-review perspective it is material.