### PR TITLE
Bump oauth to 1.1.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'bundler', '>= 2.4.22'
 gem 'coffee-rails'
 gem 'haml'
 gem 'sassc-rails'
-gem 'oauth', '1.1.1'
+gem 'oauth', '1.1.2'
 
 # API data
 gem 'jsonapi-resources'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -450,7 +450,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.4-x86_64-linux-gnu)
       racc (~> 1.4)
-    oauth (1.1.1)
+    oauth (1.1.2)
       oauth-tty (~> 1.0, >= 1.0.6)
       snaky_hash (~> 2.0)
       version_gem (~> 1.1, >= 1.1.9)
@@ -835,7 +835,7 @@ DEPENDENCIES
   material_icons
   memcachier
   msgpack
-  oauth (= 1.1.1)
+  oauth (= 1.1.2)
   oj
   omniauth (~> 1.3)
   omniauth-flickr (>= 0.0.15)


### PR DESCRIPTION
https://github.com/ruby-oauth/oauth/compare/v1.1.1...v1.1.2

Docstring updates, but also changes prior release checksums