### PR TITLE
Bump oauth to 1.1.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'bundler', '>= 2.4.22'
 gem 'coffee-rails'
 gem 'haml'
 gem 'sassc-rails'
-gem 'oauth', '1.1.2'
+gem 'oauth', '1.1.3'
 
 # API data
 gem 'jsonapi-resources'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -450,7 +450,8 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.4-x86_64-linux-gnu)
       racc (~> 1.4)
-    oauth (1.1.2)
+    oauth (1.1.3)
+      base64 (~> 0.1)
       oauth-tty (~> 1.0, >= 1.0.6)
       snaky_hash (~> 2.0)
       version_gem (~> 1.1, >= 1.1.9)
@@ -835,7 +836,7 @@ DEPENDENCIES
   material_icons
   memcachier
   msgpack
-  oauth (= 1.1.2)
+  oauth (= 1.1.3)
   oj
   omniauth (~> 1.3)
   omniauth-flickr (>= 0.0.15)


### PR DESCRIPTION
https://github.com/ruby-oauth/oauth/compare/v1.1.2...v1.1.3

Many doc updates that are trivial.
Weirdly changes the sha1sum of prior releases. Maybe given gem.coop vs rubygems, but not clear.